### PR TITLE
fix bug for rqlite-cli query: results should be a slice instead of array

### DIFF
--- a/cmd/rqlite/query.go
+++ b/cmd/rqlite/query.go
@@ -9,11 +9,11 @@ import (
 
 // Rows represents query result
 type Rows struct {
-	Columns []string         `json:"columns"`
-	Types   []string         `json:"types"`
-	Values  [][2]interface{} `json:"values"`
-	Time    float64          `json:"time"`
-	Error   string           `json:"error,omitempty"`
+	Columns []string        `json:"columns"`
+	Types   []string        `json:"types"`
+	Values  [][]interface{} `json:"values"`
+	Time    float64         `json:"time"`
+	Error   string          `json:"error,omitempty"`
 }
 
 // RowCount implements textutil.Table interface


### PR DESCRIPTION
I'm sorry for this fatal bug.