### PR TITLE
Used resolved address when joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 3.2.0 (Unreleased)
+- [PR #137](https://github.com/rqlite/rqlite/pull/137): Use resolved version of joining node's address.
 - [PR #136](https://github.com/rqlite/rqlite/pull/136): Better errors on join failures.
 - [PR #133](https://github.com/rqlite/rqlite/pull/133): Add Peers to status output.
 - [PR #132](https://github.com/rqlite/rqlite/pull/132): Support removing a node from a cluster.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -261,7 +261,14 @@ func join(joinAddr string, skipVerify bool, raftAddr, raftAdv string) error {
 	if raftAdv != "" {
 		addr = raftAdv
 	}
-	b, err := json.Marshal(map[string]string{"addr": addr})
+
+	// Join using IP address, as that is what Hashicorp Raft works in.
+	resv, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(map[string]string{"addr": resv.String()})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It seems Hashicorp Raft only works in IP addresses, and joining with a hostname caused the remove logic to cause all nodes to leave when one node was instructed to leave.