### PR TITLE
Support controlling FK constraints at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0 (September 5th 2016)
+- [PR #185](https://github.com/rqlite/rqlite/pull/185): Enable foreign key constraints by default.
+
 ## 3.4.1 (September 1st 2016)
 - [PR #175](https://github.com/rqlite/rqlite/pull/175): Simplify error handling of Update Peers API.
 - [PR #170](https://github.com/rqlite/rqlite/pull/170): Log any failure to call `Serve()` on HTTP service.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -77,6 +77,7 @@ var pprofEnabled bool
 var dsn string
 var onDisk bool
 var noVerifySelect bool
+var noFKCheck bool
 var raftSnapThreshold uint64
 var raftHeartbeatTimeout string
 var showVersion bool
@@ -99,6 +100,7 @@ func init() {
 	flag.StringVar(&dsn, "dsn", "", `SQLite DSN parameters. E.g. "cache=shared&mode=memory"`)
 	flag.BoolVar(&onDisk, "ondisk", false, "Use an on-disk SQLite database")
 	flag.BoolVar(&noVerifySelect, "nosel", false, "Don't verify that all queries begin with SELECT")
+	flag.BoolVar(&noFKCheck, "nofk", false, "Don't enforce foreign key constraints")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.StringVar(&raftHeartbeatTimeout, "rafttimeout", "1s", "Raft heartbeat timeout")
 	flag.Uint64Var(&raftSnapThreshold, "raftsnap", 8192, "Number of outstanding log entries to trigger snapshot")
@@ -186,6 +188,8 @@ func main() {
 		log.Fatalf("failed to determine absolute data path: %s", err.Error())
 	}
 	dbConf := store.NewDBConfig(dsn, !onDisk)
+	dbConf.NoFK = noFKCheck
+
 	store := store.New(dbConf, dataPath, raftTn)
 	if err := store.Open(joinAddr == ""); err != nil {
 		log.Fatalf("failed to open store: %s", err.Error())

--- a/db/db.go
+++ b/db/db.go
@@ -13,6 +13,11 @@ import (
 
 const bkDelay = 250
 
+const (
+	fkChecksEnabled  = "PRAGMA foreign_keys=ON"
+	fkChecksDisabled = "PRAGMA foreign_keys=OFF"
+)
+
 // DBVersion is the SQLite version.
 var DBVersion string
 
@@ -121,6 +126,19 @@ func open(dbPath string) (*DB, error) {
 		sqlite3conn: dbc.(*sqlite3.SQLiteConn),
 		path:        dbPath,
 	}, nil
+}
+
+// EnableFKConstraints allows control of foreign key constraint checks.
+func (db *DB) EnableFKConstraints(e bool) error {
+	var q string
+	if e {
+		q = fkChecksEnabled
+	} else {
+		q = fkChecksDisabled
+	}
+
+	_, err := db.sqlite3conn.Exec(q, nil)
+	return err
 }
 
 // Execute executes queries that modify the database.


### PR DESCRIPTION
This was possible previously, but would need to be set every time on startup via the API. This change allows it to set at startup AND enables foreign constraint checking by default.