### PR TITLE
join endpoint returns HTTP 301 if necessary

### DIFF
--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -317,8 +317,6 @@ func join(joinAddr string, skipVerify bool, raftAddr, raftAdv string) error {
 			return fmt.Errorf("failed to join, node returned: %s: (%s)", resp.Status, string(b))
 		}
 	}
-
-	return nil
 }
 
 func publishAPIAddr(c *cluster.Service, raftAddr, apiAddr string, t time.Duration) error {

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -304,17 +304,15 @@ func join(joinAddr string, skipVerify bool, raftAddr, raftAdv string) error {
 		}
 
 		switch resp.StatusCode {
-		case 200:
+		case http.StatusOK:
 			return nil
-		case 301:
-			if resp.StatusCode == 301 {
-				fullAddr = resp.Header.Get("location")
-				if fullAddr == "" {
-					return fmt.Errorf("failed to join, invalid redirect received")
-				}
-				log.Println("join request redirecting to", fullAddr)
-				continue
+		case http.StatusMovedPermanently:
+			fullAddr = resp.Header.Get("location")
+			if fullAddr == "" {
+				return fmt.Errorf("failed to join, invalid redirect received")
 			}
+			log.Println("join request redirecting to", fullAddr)
+			continue
 		default:
 			return fmt.Errorf("failed to join, node returned: %s: (%s)", resp.Status, string(b))
 		}

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -160,7 +160,7 @@ func (c Cluster) WaitForNewLeader(old *Node) (*Node, error) {
 	}
 }
 
-// Followers returns the slide of nodes in the cluster that are followers.
+// Followers returns the slice of nodes in the cluster that are followers.
 func (c Cluster) Followers() ([]*Node, error) {
 	n, err := c[0].WaitForLeader()
 	if err != nil {

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -75,13 +75,7 @@ func (n *Node) Query(stmt string) (string, error) {
 
 // Join instructs this node to join the leader.
 func (n *Node) Join(leader *Node) error {
-	b, err := json.Marshal(map[string]string{"addr": n.RaftAddr})
-	if err != nil {
-		return err
-	}
-
-	// Attempt to join leader
-	resp, err := http.Post("http://"+leader.APIAddr+"/join", "application-type/json", bytes.NewReader(b))
+	resp, err := DoJoinRequest(leader.APIAddr, n.RaftAddr)
 	if err != nil {
 		return err
 	}
@@ -225,6 +219,21 @@ func Remove(n *Node, addr string) error {
 	}
 	defer resp.Body.Close()
 	return nil
+}
+
+// DoJoinRequest sends a join request to nodeAddr, for raftAddr.
+func DoJoinRequest(nodeAddr, raftAddr string) (*http.Response, error) {
+	b, err := json.Marshal(map[string]string{"addr": raftAddr})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post("http://"+nodeAddr+"/join", "application-type/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func mustNewNode(enableSingle bool) *Node {


### PR DESCRIPTION
With this change, if a node receives a join request,, and the receiving node is not the master, it will redirect the requesting node to the master. This allows new nodes to join the cluster through any existing node.