### PR TITLE
Start unit-test of join-via-follower

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -269,9 +269,14 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fmt.Println(">>>here1")
+
 	if err := s.store.Join(remoteAddr); err != nil {
+		fmt.Println(">>>here 2")
 		if err == store.ErrNotLeader {
+			fmt.Println(">>>>> here 2.5")
 			leader := s.store.Peer(s.store.Leader())
+			fmt.Println(">>>>> here 3", leader)
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return


### PR DESCRIPTION
Fails (I think) because there is no cluster service part of this test
setup. Therefore the follower is never informed of the leader's address,
and therefore can't redirect to it.
