### PR TITLE
add an API for using custom raft.PeerStore/log.Logger

### DIFF
--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -167,7 +167,11 @@ func main() {
 	}
 	dbConf := store.NewDBConfig(dsn, !onDisk)
 
-	store := store.New(dbConf, dataPath, raftTn)
+	store := store.New(&store.StoreConfig{
+		DBConf: dbConf,
+		Dir:    dataPath,
+		Tn:     raftTn,
+	})
 	if err := store.Open(joinAddr == ""); err != nil {
 		log.Fatalf("failed to open store: %s", err.Error())
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -696,7 +696,11 @@ func mustNewStore(inmem bool) *Store {
 	defer os.RemoveAll(path)
 
 	cfg := NewDBConfig("", inmem)
-	s := New(cfg, path, mustMockTransport("localhost:0"))
+	s := New(&StoreConfig{
+		DBConf: cfg,
+		Dir:    path,
+		Tn:     mustMockTransport("localhost:0"),
+	})
 	if s == nil {
 		panic("failed to create new store")
 	}

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -242,7 +242,11 @@ func mustNewNode(enableSingle bool) *Node {
 	}
 
 	dbConf := store.NewDBConfig("", false)
-	node.Store = store.New(dbConf, node.Dir, mustMockTransport("localhost:0"))
+	node.Store = store.New(&store.StoreConfig{
+		DBConf: dbConf,
+		Dir:    node.Dir,
+		Tn:     mustMockTransport("localhost:0"),
+	})
 	if err := node.Store.Open(enableSingle); err != nil {
 		node.Deprovision()
 		panic(fmt.Sprintf("failed to open store: %s", err.Error()))


### PR DESCRIPTION
This is useful in case the server needs to store other metadata (e.g. auth
data) along side the peer list.

The logging bit is handy in case something has its own logging framework
that it wants to use.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>