### PR TITLE
Control text conversion

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -50,8 +50,6 @@ type DB struct {
 	path        string              // Path to database file.
 	dsn         string              // DSN, if any.
 	memory      bool                // In-memory only.
-
-	TextDisable bool // Set to disable TEXT affinity []byte to string
 }
 
 // Result represents the outcome of an operation that changes rows.
@@ -280,7 +278,7 @@ func (db *DB) Execute(queries []string, tx, xTime bool) ([]*Result, error) {
 }
 
 // Query executes queries that return rows, but don't modify the database.
-func (db *DB) Query(queries []string, tx, xTime bool) ([]*Rows, error) {
+func (db *DB) Query(queries []string, tx, conv, xTime bool) ([]*Rows, error) {
 	stats.Add(numQueries, int64(len(queries)))
 	if tx {
 		stats.Add(numQTx, 1)
@@ -346,7 +344,7 @@ func (db *DB) Query(queries []string, tx, xTime bool) ([]*Rows, error) {
 				}
 
 				values := normalizeDriverValues(dest)
-				if !db.TextDisable {
+				if conv {
 					values = normalizeRowValues(dest, rows.Types)
 				}
 				rows.Values = append(rows.Values, values)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -82,6 +82,31 @@ func Test_LoadInMemory(t *testing.T) {
 	}
 }
 
+func Test_SimpleSingleStatementsNoTextConvert(t *testing.T) {
+    db, path := mustCreateDatabase()
+    db.TextDisable = true
+    defer db.Close()
+    defer os.Remove(path)
+
+    _, err := db.Execute([]string{"CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)"}, false, false)
+    if err != nil {
+        t.Fatalf("failed to create table: %s", err.Error())
+    }
+
+    _, err = db.Execute([]string{`INSERT INTO foo(name) VALUES("fiona")`}, false, false)
+    if err != nil {
+        t.Fatalf("failed to insert record: %s", err.Error())
+    }
+
+    r, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+    if err != nil {
+        t.Fatalf("failed to query table: %s", err.Error())
+    }
+    if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"ZmlvbmE="]]}]`, asJSON(r); exp != got {
+        t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+    }
+}
+
 func Test_SimpleSingleStatements(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -83,28 +83,28 @@ func Test_LoadInMemory(t *testing.T) {
 }
 
 func Test_SimpleSingleStatementsNoTextConvert(t *testing.T) {
-    db, path := mustCreateDatabase()
-    db.TextDisable = true
-    defer db.Close()
-    defer os.Remove(path)
+	db, path := mustCreateDatabase()
+	db.TextDisable = true
+	defer db.Close()
+	defer os.Remove(path)
 
-    _, err := db.Execute([]string{"CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)"}, false, false)
-    if err != nil {
-        t.Fatalf("failed to create table: %s", err.Error())
-    }
+	_, err := db.Execute([]string{"CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)"}, false, false)
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
 
-    _, err = db.Execute([]string{`INSERT INTO foo(name) VALUES("fiona")`}, false, false)
-    if err != nil {
-        t.Fatalf("failed to insert record: %s", err.Error())
-    }
+	_, err = db.Execute([]string{`INSERT INTO foo(name) VALUES("fiona")`}, false, false)
+	if err != nil {
+		t.Fatalf("failed to insert record: %s", err.Error())
+	}
 
-    r, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
-    if err != nil {
-        t.Fatalf("failed to query table: %s", err.Error())
-    }
-    if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"ZmlvbmE="]]}]`, asJSON(r); exp != got {
-        t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
-    }
+	r, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	if err != nil {
+		t.Fatalf("failed to query table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"ZmlvbmE="]]}]`, asJSON(r); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
 }
 
 func Test_SimpleSingleStatements(t *testing.T) {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -40,7 +40,7 @@ func Test_TableCreation(t *testing.T) {
 		t.Fatalf("failed to create table: %s", err.Error())
 	}
 
-	r, err := db.Query([]string{"SELECT * FROM foo"}, false, false)
+	r, err := db.Query([]string{"SELECT * FROM foo"}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query empty table: %s", err.Error())
 	}
@@ -59,7 +59,7 @@ func Test_LoadInMemory(t *testing.T) {
 		t.Fatalf("failed to create table: %s", err.Error())
 	}
 
-	r, err := db.Query([]string{"SELECT * FROM foo"}, false, false)
+	r, err := db.Query([]string{"SELECT * FROM foo"}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query empty table: %s", err.Error())
 	}
@@ -73,7 +73,7 @@ func Test_LoadInMemory(t *testing.T) {
 	}
 
 	// Ensure it has been loaded correctly into the database
-	r, err = inmem.Query([]string{"SELECT * FROM foo"}, false, false)
+	r, err = inmem.Query([]string{"SELECT * FROM foo"}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query empty table: %s", err.Error())
 	}
@@ -84,7 +84,6 @@ func Test_LoadInMemory(t *testing.T) {
 
 func Test_SimpleSingleStatementsNoTextConvert(t *testing.T) {
 	db, path := mustCreateDatabase()
-	db.TextDisable = true
 	defer db.Close()
 	defer os.Remove(path)
 
@@ -98,7 +97,7 @@ func Test_SimpleSingleStatementsNoTextConvert(t *testing.T) {
 		t.Fatalf("failed to insert record: %s", err.Error())
 	}
 
-	r, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	r, err := db.Query([]string{`SELECT * FROM foo`}, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -127,7 +126,7 @@ func Test_SimpleSingleStatements(t *testing.T) {
 		t.Fatalf("failed to insert record: %s", err.Error())
 	}
 
-	r, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	r, err := db.Query([]string{`SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -135,7 +134,7 @@ func Test_SimpleSingleStatements(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	r, err = db.Query([]string{`SELECT * FROM foo WHERE name="aoife"`}, false, false)
+	r, err = db.Query([]string{`SELECT * FROM foo WHERE name="aoife"`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -143,7 +142,7 @@ func Test_SimpleSingleStatements(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	r, err = db.Query([]string{`SELECT * FROM foo WHERE name="dana"`}, false, false)
+	r, err = db.Query([]string{`SELECT * FROM foo WHERE name="dana"`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -151,7 +150,7 @@ func Test_SimpleSingleStatements(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	r, err = db.Query([]string{`SELECT * FROM foo ORDER BY name`}, false, false)
+	r, err = db.Query([]string{`SELECT * FROM foo ORDER BY name`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -159,7 +158,7 @@ func Test_SimpleSingleStatements(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	r, err = db.Query([]string{`SELECT *,name FROM foo`}, false, false)
+	r, err = db.Query([]string{`SELECT *,name FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -183,7 +182,7 @@ func Test_SimpleSingleConcatStatements(t *testing.T) {
 		t.Fatalf("failed to insert record: %s", err.Error())
 	}
 
-	r, err := db.Query([]string{`SELECT id || "_bar", name FROM foo`}, false, false)
+	r, err := db.Query([]string{`SELECT id || "_bar", name FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -210,7 +209,7 @@ func Test_SimpleMultiStatements(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	ro, err := db.Query([]string{`SELECT * FROM foo`, `SELECT * FROM foo`}, false, false)
+	ro, err := db.Query([]string{`SELECT * FROM foo`, `SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query empty table: %s", err.Error())
 	}
@@ -298,7 +297,7 @@ func Test_SimpleFailingStatements_Query(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(path)
 
-	ro, err := db.Query([]string{`SELECT * FROM bar`}, false, false)
+	ro, err := db.Query([]string{`SELECT * FROM bar`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to attempt query of non-existent table: %s", err.Error())
 	}
@@ -306,14 +305,14 @@ func Test_SimpleFailingStatements_Query(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	ro, err = db.Query([]string{`SELECTxx * FROM foo`}, false, false)
+	ro, err = db.Query([]string{`SELECTxx * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to attempt nonsense query: %s", err.Error())
 	}
 	if exp, got := `[{"error":"near \"SELECTxx\": syntax error"}]`, asJSON(ro); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
-	r, err := db.Query([]string{`utter nonsense`}, false, false)
+	r, err := db.Query([]string{`utter nonsense`}, false, true, false)
 	if err != nil {
 		if exp, got := `[{"error":"near \"utter\": syntax error"}]`, asJSON(r); exp != got {
 			t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
@@ -433,7 +432,7 @@ func Test_PartialFail(t *testing.T) {
 	if exp, got := `[{"last_insert_id":1,"rows_affected":1},{"last_insert_id":2,"rows_affected":1},{"error":"UNIQUE constraint failed: foo.id"},{"last_insert_id":4,"rows_affected":1}]`, asJSON(r); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
-	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -465,7 +464,7 @@ func Test_SimpleTransaction(t *testing.T) {
 	if exp, got := `[{"last_insert_id":1,"rows_affected":1},{"last_insert_id":2,"rows_affected":1},{"last_insert_id":3,"rows_affected":1},{"last_insert_id":4,"rows_affected":1}]`, asJSON(r); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
-	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -497,7 +496,7 @@ func Test_PartialFailTransaction(t *testing.T) {
 	if exp, got := `[{"last_insert_id":1,"rows_affected":1},{"last_insert_id":2,"rows_affected":1},{"error":"UNIQUE constraint failed: foo.id"}]`, asJSON(r); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
-	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, false)
+	ro, err := db.Query([]string{`SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
@@ -545,7 +544,7 @@ func Test_Backup(t *testing.T) {
 	}
 	defer newDB.Close()
 	defer os.Remove(dstDB.Name())
-	ro, err := newDB.Query([]string{`SELECT * FROM foo`}, false, false)
+	ro, err := newDB.Query([]string{`SELECT * FROM foo`}, false, true, false)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -206,6 +206,36 @@ func Test_SingleNodeExecuteQueryTx(t *testing.T) {
 	}
 }
 
+func Test_SingleNodeExecuteQueryRaw(t *testing.T) {
+	s := mustNewStore(true)
+	defer os.RemoveAll(s.Path())
+
+	if err := s.Open(true); err != nil {
+		t.Fatalf("failed to open single-node store: %s", err.Error())
+	}
+	defer s.Close(true)
+	s.WaitForLeader(10 * time.Second)
+
+	queries := []string{
+		`CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)`,
+		`INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+	}
+	_, err := s.Execute(queries, false, true)
+	if err != nil {
+		t.Fatalf("failed to execute on single node: %s", err.Error())
+	}
+	r, err := s.QueryRaw([]string{`SELECT * FROM foo`}, false, false, None)
+	if err != nil {
+		t.Fatalf("failed to query single node: %s", err.Error())
+	}
+	if exp, got := `["id","name"]`, asJSON(r[0].Columns); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+	if exp, got := `[[1,"ZmlvbmE="]]`, asJSON(r[0].Values); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+}
+
 func Test_SingleNodeLoad(t *testing.T) {
 	s := mustNewStore(true)
 	defer os.RemoveAll(s.Path())


### PR DESCRIPTION
This change is a proposed solution to locking down behaviour of the `Store` package, to help with https://github.com/rqlite/rqlite/issues/241

This gives users of the `Store` package a new call, which doesn't perform any conversion of values which have TEXT affinity (see http://www.sqlite.org/datatype3.html) to strings. 

This functionality has not been exposed beyond the `Store` layer for now. It could be, and controlled via a HTTP URL param to rqlited clients.