### PR TITLE
[RFC] Implementation of transactions

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -486,6 +486,10 @@ func (db *DB) Backup(path string) error {
 	return nil
 }
 
+func (db *DB) Begin() (*sql.Tx, error) {
+	return db.db.Begin()
+}
+
 // normalizeRowValues performs some normalization of values in the returned rows.
 // Text values come over (from sqlite-go) as []byte instead of strings
 // for some reason, so we have explicitly convert (but only when type

--- a/db/db.go
+++ b/db/db.go
@@ -82,12 +82,18 @@ func OpenWithDSN(dbPath, dsn string) (*DB, error) {
 
 // OpenInMemory opens an in-memory database.
 func OpenInMemory() (*DB, error) {
-	return open(fqdsn(":memory:", ""))
+	return OpenInMemoryWithDSN("")
 }
 
 // OpenInMemoryWithDSN opens an in-memory database with a specific DSN.
 func OpenInMemoryWithDSN(dsn string) (*DB, error) {
-	return open(fqdsn(":memory:", dsn))
+	db, err := open(fqdsn(":memory:", dsn))
+	if err != nil {
+		return nil, err
+	}
+
+	db.memory = true
+	return db, nil
 }
 
 // LoadInMemoryWithDSN loads an in-memory database with that at the path,

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -67,7 +67,7 @@ func Test_LoadInMemory(t *testing.T) {
 		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
 	}
 
-	inmem, err := LoadInMemoryWithDSN(path, "")
+	inmem, err := LoadInMemoryWithDSN(path, "mode=memory&cache=shared")
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -265,12 +265,18 @@ CREATE TRIGGER new_foobar instead of insert on foobar begin insert into foo (nam
 	}
 
 	// Check that the VIEW and TRIGGER are OK by using both.
-	r, err := s.Execute([]string{`INSERT INTO foobar VALUES('jason', 16)`}, false, true)
+	_, err = s.Execute([]string{`INSERT INTO foobar VALUES('jason', 16)`}, false, true)
 	if err != nil {
 		t.Fatalf("failed to insert into view on single node: %s", err.Error())
 	}
-	if exp, got := int64(3), r[0].LastInsertID; exp != got {
-		t.Fatalf("unexpected results for query\nexp: %d\ngot: %d", exp, got)
+
+	rows, err := s.Query([]string{`SELECT * FROM foo WHERE name='jason'`}, false, false, None)
+	if err != nil {
+		t.Fatalf("failed to query foo: %s", err.Error())
+	}
+
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[4,"jason"]]}]`, asJSON(rows); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -216,10 +216,8 @@ func Test_SingleNodeLoad(t *testing.T) {
 	s.WaitForLeader(10 * time.Second)
 
 	dump := `PRAGMA foreign_keys=OFF;
-BEGIN TRANSACTION;
 CREATE TABLE foo (id integer not null primary key, name text);
 INSERT INTO "foo" VALUES(1,'fiona');
-COMMIT;
 `
 	_, err := s.Execute([]string{dump}, false, false)
 	if err != nil {
@@ -250,7 +248,6 @@ func Test_SingleNodeSingleCommandTrigger(t *testing.T) {
 	s.WaitForLeader(10 * time.Second)
 
 	dump := `PRAGMA foreign_keys=OFF;
-BEGIN TRANSACTION;
 CREATE TABLE foo (id integer primary key asc, name text);
 INSERT INTO "foo" VALUES(1,'bob');
 INSERT INTO "foo" VALUES(2,'alice');
@@ -261,7 +258,6 @@ INSERT INTO "bar" VALUES(2,46);
 INSERT INTO "bar" VALUES(3,8);
 CREATE VIEW foobar as select name as Person, Age as age from foo inner join bar on foo.id == bar.nameid;
 CREATE TRIGGER new_foobar instead of insert on foobar begin insert into foo (name) values (new.Person); insert into bar (nameid, age) values ((select id from foo where name == new.Person), new.Age); end;
-COMMIT;
 `
 	_, err := s.Execute([]string{dump}, false, false)
 	if err != nil {
@@ -289,8 +285,6 @@ func Test_SingleNodeLoadNoStatements(t *testing.T) {
 	s.WaitForLeader(10 * time.Second)
 
 	dump := `PRAGMA foreign_keys=OFF;
-BEGIN TRANSACTION;
-COMMIT;
 `
 	_, err := s.Execute([]string{dump}, false, false)
 	if err != nil {
@@ -681,7 +675,12 @@ func mustNewStore(inmem bool) *Store {
 	path := mustTempDir()
 	defer os.RemoveAll(path)
 
-	cfg := NewDBConfig("", inmem)
+	dsn := ""
+	if inmem {
+		dsn = "mode=memory&cache=shared"
+	}
+
+	cfg := NewDBConfig(dsn, inmem)
 	s := New(&StoreConfig{
 		DBConf: cfg,
 		Dir:    path,

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -48,7 +48,7 @@ func Test_SingleNode(t *testing.T) {
 		},
 		{
 			stmt:     `DROP TABLE foo`,
-			expected: `{"results":[{"last_insert_id":1,"rows_affected":1}]}`,
+			expected: `{"results":[{}]}`,
 			execute:  true,
 		},
 	}


### PR DESCRIPTION
This is an implementation of transactions as described in #266. There are a couple caveats:

* Two tests don't pass right now, although I believe this is a bug in the sqlite3 driver; I'm working on it.
* We're doing a little bit of voodoo with in memory databases. This doesn't seem very nice; I think we should probably just put all the DBs on disk, so easier to figure out what's going on. The DBs probably aren't ever going to be very big since we're coordinating everything over raft, so I think this would be an acceptable compromise.

Anyway, play around with it and let me know if you have any thoughts.