### PR TITLE
Start fixing Discovery Redirects

### DIFF
--- a/disco/client.go
+++ b/disco/client.go
@@ -74,7 +74,7 @@ func (c *Client) Register(id, addr string) (*Response, error) {
 			c.logger.Printf("discovery client successfully registered %s at %s", addr, url)
 			return r, nil
 		case http.StatusMovedPermanently:
-			url = c.registrationURL(resp.Header.Get("location"), id)
+			url = resp.Header.Get("location")
 			c.logger.Println("discovery client redirecting to", url)
 			continue
 		default:

--- a/disco/client_test.go
+++ b/disco/client_test.go
@@ -134,7 +134,7 @@ func Test_ClientRegisterRequestRedirectOK(t *testing.T) {
 	}))
 	defer ts1.Close()
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, ts1.URL + "/1234", http.StatusMovedPermanently)
+		http.Redirect(w, r, ts1.URL+"/1234", http.StatusMovedPermanently)
 	}))
 
 	c := New(ts2.URL)

--- a/disco/client_test.go
+++ b/disco/client_test.go
@@ -134,7 +134,7 @@ func Test_ClientRegisterRequestRedirectOK(t *testing.T) {
 	}))
 	defer ts1.Close()
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, ts1.URL, http.StatusMovedPermanently)
+		http.Redirect(w, r, ts1.URL + "/1234", http.StatusMovedPermanently)
 	}))
 
 	c := New(ts2.URL)


### PR DESCRIPTION
This testing has shown that the Lambda function should just return the registered addresses when an attempt is made to register an address already in use.