### PR TITLE
Explicitly don't follow redirects

### DIFF
--- a/cluster/join.go
+++ b/cluster/join.go
@@ -5,13 +5,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	httpd "github.com/rqlite/rqlite/http"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"time"
+
+	httpd "github.com/rqlite/rqlite/http"
 )
 
 const numAttempts int = 3
@@ -55,6 +56,9 @@ func join(joinAddr string, advAddr string, skipVerify bool) (string, error) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
 	}
 	client := &http.Client{Transport: tr}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 
 	for {
 		b, err := json.Marshal(map[string]string{"addr": resv.String()})

--- a/disco/client.go
+++ b/disco/client.go
@@ -46,6 +46,10 @@ func (c *Client) Register(id, addr string) (*Response, error) {
 	}
 
 	url := c.registrationURL(c.url, id)
+	client := &http.Client{}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 
 	for {
 		b, err := json.Marshal(m)
@@ -54,7 +58,7 @@ func (c *Client) Register(id, addr string) (*Response, error) {
 		}
 
 		c.logger.Printf("discovery client attempting registration of %s at %s", addr, url)
-		resp, err := http.Post(url, "application-type/json", bytes.NewReader(b))
+		resp, err := client.Post(url, "application-type/json", bytes.NewReader(b))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Without this, rqlite would behave differently when compiled by Go 1.7 and earlier.

See the Go 1.8 release notes, 
