### PR TITLE
Don't do any join operations if not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.12.1 (unreleased)
+- [PR #291](https://github.com/rqlite/rqlite/pull/291): Don't access Discovery Service if node already part of cluster.
+
 ## 3.12.0 (March 1st 2017)
 - [PR #286](https://github.com/rqlite/rqlite/pull/286): Tweak help output.
 - [PR #283](https://github.com/rqlite/rqlite/pull/283): Main code should log to stderr.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -206,7 +206,7 @@ func main() {
 			log.Fatalf("unable to determine join addresses: %s", err.Error())
 		}
 	} else {
-		log.Println("node is already member of cluster, skipping determining join addresses")
+		log.Println("node is already member of cluster, skip determining join addresses")
 	}
 
 	// Now, open it.
@@ -235,7 +235,7 @@ func main() {
 		}
 
 	} else {
-		log.Println("no join addresses available")
+		log.Println("no join addresses set")
 	}
 
 	// Publish to the cluster the mapping between this Raft address and API address.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -172,23 +172,23 @@ func main() {
 	}
 	dbConf := store.NewDBConfig(dsn, !onDisk)
 
-	store := store.New(&store.StoreConfig{
+	str := store.New(&store.StoreConfig{
 		DBConf: dbConf,
 		Dir:    dataPath,
 		Tn:     raftTn,
 	})
 
 	// Set optional parameters on store.
-	store.SnapshotThreshold = raftSnapThreshold
-	store.HeartbeatTimeout, err = time.ParseDuration(raftHeartbeatTimeout)
+	str.SnapshotThreshold = raftSnapThreshold
+	str.HeartbeatTimeout, err = time.ParseDuration(raftHeartbeatTimeout)
 	if err != nil {
 		log.Fatalf("failed to parse Raft heartbeat timeout %s: %s", raftHeartbeatTimeout, err.Error())
 	}
-	store.ApplyTimeout, err = time.ParseDuration(raftApplyTimeout)
+	str.ApplyTimeout, err = time.ParseDuration(raftApplyTimeout)
 	if err != nil {
 		log.Fatalf("failed to parse Raft apply timeout %s: %s", raftApplyTimeout, err.Error())
 	}
-	store.OpenTimeout, err = time.ParseDuration(raftOpenTimeout)
+	str.OpenTimeout, err = time.ParseDuration(raftOpenTimeout)
 	if err != nil {
 		log.Fatalf("failed to parse Raft open timeout %s: %s", raftOpenTimeout, err.Error())
 	}
@@ -200,13 +200,13 @@ func main() {
 	}
 
 	// Now, open it.
-	if err := store.Open(len(joins) == 0); err != nil {
+	if err := str.Open(len(joins) == 0); err != nil {
 		log.Fatalf("failed to open store: %s", err.Error())
 	}
 
 	// Create and configure cluster service.
 	tn := mux.Listen(muxMetaHeader)
-	cs := cluster.NewService(tn, store)
+	cs := cluster.NewService(tn, str)
 	if err := cs.Open(); err != nil {
 		log.Fatalf("failed to open cluster service: %s", err.Error())
 	}
@@ -214,7 +214,7 @@ func main() {
 	// Execute any requested join operation.
 	if len(joins) > 0 {
 		log.Println("join addresses are:", joins)
-		if store.JoinRequired() {
+		if str.JoinRequired() {
 			advAddr := raftAddr
 			if raftAdv != "" {
 				advAddr = raftAdv
@@ -255,9 +255,9 @@ func main() {
 		if err := credentialStore.Load(f); err != nil {
 			log.Fatalf("failed to load authentication file: %s", err.Error())
 		}
-		s = httpd.New(httpAddr, store, credentialStore)
+		s = httpd.New(httpAddr, str, credentialStore)
 	} else {
-		s = httpd.New(httpAddr, store, nil)
+		s = httpd.New(httpAddr, str, nil)
 	}
 
 	s.CertFile = x509Cert
@@ -277,7 +277,7 @@ func main() {
 	terminate := make(chan os.Signal, 1)
 	signal.Notify(terminate, os.Interrupt)
 	<-terminate
-	if err := store.Close(true); err != nil {
+	if err := str.Close(true); err != nil {
 		log.Printf("failed to close store: %s", err.Error())
 	}
 	stopProfile()

--- a/store/peers.go
+++ b/store/peers.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	jsonPeerPath = "peers.json"
+)
+
+// NumPeers returns the number of peers indicated by the config files
+// within raftDir.
+//
+// This code makes assumptions about how the Raft module works.
+func NumPeers(raftDir string) (int, error) {
+	// Read the file
+	buf, err := ioutil.ReadFile(filepath.Join(raftDir, jsonPeerPath))
+	if err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+
+	// Check for no peers
+	if len(buf) == 0 {
+		return 0, nil
+	}
+
+	// Decode the peers
+	var peerSet []string
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	if err := dec.Decode(&peerSet); err != nil {
+		return 0, err
+	}
+
+	return len(peerSet), nil
+}
+
+// JoinAllowed returns whether the config files within raftDir indicate
+// that the node can join a cluster.
+func JoinAllowed(raftDir string) (bool, error) {
+	n, err := NumPeers(raftDir)
+	if err != nil {
+		return false, err
+	}
+	return n <= 1, nil
+}

--- a/store/peers_test.go
+++ b/store/peers_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"os"
+	"sort"
+	"testing"
+	"time"
+)
+
+func Test_NumPeersEnableSingle(t *testing.T) {
+	s0 := mustNewStore(true)
+	defer os.RemoveAll(s0.Path())
+	if err := s0.Open(true); err != nil {
+		t.Fatalf("failed to open node for num peers test: %s", err.Error())
+	}
+	s0.WaitForLeader(5 * time.Second)
+	s0.Close(true)
+
+	j, err := JoinAllowed(s0.Path())
+	if err != nil {
+		t.Fatalf("failed to check join status of %s: %s", s0.Path(), err.Error())
+	}
+	if !j {
+		t.Fatalf("config files at %s indicate joining is not allowed", s0.Path())
+	}
+}
+
+func Test_NumPeersDisableSingle(t *testing.T) {
+	s0 := mustNewStore(true)
+	defer os.RemoveAll(s0.Path())
+	if err := s0.Open(false); err != nil {
+		t.Fatalf("failed to open node for num peers test: %s", err.Error())
+	}
+	s0.Close(true)
+
+	j, err := JoinAllowed(s0.Path())
+	if err != nil {
+		t.Fatalf("failed to check join status of %s: %s", s0.Path(), err.Error())
+	}
+	if !j {
+		t.Fatalf("config files at %s indicate joining is not allowed", s0.Path())
+	}
+}
+
+func Test_NumPeersJoin(t *testing.T) {
+	s0 := mustNewStore(true)
+	defer os.RemoveAll(s0.Path())
+	if err := s0.Open(true); err != nil {
+		t.Fatalf("failed to open node for num peers test: %s", err.Error())
+	}
+	s0.WaitForLeader(5 * time.Second)
+
+	s1 := mustNewStore(true)
+	defer os.RemoveAll(s1.Path())
+	if err := s1.Open(false); err != nil {
+		t.Fatalf("failed to open node for num peers test: %s", err.Error())
+	}
+
+	// Get sorted list of cluster nodes.
+	storeNodes := []string{s0.Addr().String(), s1.Addr().String()}
+	sort.StringSlice(storeNodes).Sort()
+
+	// Join the second node to the first.
+	if err := s0.Join(s1.Addr().String()); err != nil {
+		t.Fatalf("failed to join to node at %s: %s", s0.Addr().String(), err.Error())
+	}
+	s1.WaitForLeader(5 * time.Second)
+	s1.Close(true)
+	s0.Close(true)
+
+	// Check that peers are set as expected.
+	m, _ := NumPeers(s0.Path())
+	if m != 2 {
+		t.Fatalf("got wrong value for number of peers, exp %d, got %d", 2, m)
+	}
+
+	j, err := JoinAllowed(s0.Path())
+	if err != nil {
+		t.Fatalf("failed to check join status of %s: %s", s0.Path(), err.Error())
+	}
+	if j {
+		t.Fatalf("config files at %s indicate joining is allowed", s0.Path())
+	}
+
+	k, err := JoinAllowed(s1.Path())
+	if err != nil {
+		t.Fatalf("failed to check join status of %s: %s", s1.Path(), err.Error())
+	}
+	if k {
+		t.Fatalf("config files at %s indicate joining is allowed", s1.Path())
+	}
+}


### PR DESCRIPTION
The main rqlite code needs this logic to check if the Discovery Service
should even be accessed. This code makes assumptions about how the Raft
module works, which is subject to change. The new unit tests should
capture that.