### PR TITLE
CLI should handle HTTP redirect explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.13.0 (unreleased)
 - [PR #296](https://github.com/rqlite/rqlite/pull/296): Log Go version at startup.
 - [PR #294](https://github.com/rqlite/rqlite/pull/294): Support multiple explicit join addresses.
+- [PR #297](https://github.com/rqlite/rqlite/pull/297): CLI should explicitly handle redirects due to Go1.8. Fixes [issue #295](https://github.com/rqlite/rqlite/issues/295).
 
 ## 3.12.1 (March 2nd 2017)
 - [PR #291](https://github.com/rqlite/rqlite/pull/291): Don't access Discovery Service if node already part of cluster.

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -90,6 +90,11 @@ func sendRequest(ctx *cli.Context, urlStr string, line string, argv *argT, ret i
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: argv.Insecure},
 	}}
 
+	// Explicitly handle redirects.
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
 	nRedirect := 0
 	for {
 		resp, err := client.Post(url, "application/json", strings.NewReader(data))


### PR DESCRIPTION
HTTP client behavior changed with Go 1.8. This change makes behavior that was implicit in Go 1.7 and earlier, explicit now.