### PR TITLE
Include any query params with 301 redirect URL

### DIFF
--- a/doc/DATA_API.md
+++ b/doc/DATA_API.md
@@ -125,12 +125,12 @@ $ curl -v -G 'localhost:4003/db/query?pretty&timings' --data-urlencode 'q=SELECT
 > 
 < HTTP/1.1 301 Moved Permanently
 < Content-Type: application/json; charset=utf-8
-< Location: http://localhost:4001/db/query
+< Location: http://localhost:4001/db/query?pretty&timings&q=SELECT%20%2A%20FROM%20foo
 < X-Rqlite-Version: 4
-< Date: Mon, 24 Jul 2017 10:16:24 GMT
-< Content-Length: 65
+< Date: Mon, 07 Aug 2017 21:10:59 GMT
+< Content-Length: 116
 < 
-<a href="http://localhost:4001/db/query">Moved Permanently</a>.
+<a href="http://localhost:4001/db/query?pretty&amp;timings&amp;q=SELECT%20%2A%20FROM%20foo">Moved Permanently</a>.
 
 * Connection #0 to host localhost left intact
 ```

--- a/http/service.go
+++ b/http/service.go
@@ -682,7 +682,11 @@ func (s *Service) FormRedirect(r *http.Request, host string) string {
 	if s.credentialStore != nil {
 		protocol = "https"
 	}
-	return fmt.Sprintf("%s://%s%s", protocol, host, r.URL.Path)
+	rq := r.URL.RawQuery
+	if rq != "" {
+		rq = fmt.Sprintf("?%s", rq)
+	}
+	return fmt.Sprintf("%s://%s%s%s", protocol, host, r.URL.Path, rq)
 }
 
 // CheckRequestPerm returns true if authentication is enabled and the user contained

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -366,6 +366,32 @@ func Test_RegisterStatus(t *testing.T) {
 	}
 }
 
+func Test_FormRedirect(t *testing.T) {
+	m := &MockStore{}
+	s := New("127.0.0.1:0", m, nil)
+	req := mustNewHTTPRequest("http://foo:4001")
+
+	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001" {
+		t.Fatal("failed to form redirect for simple URL")
+	}
+	if rd := s.FormRedirect(req, "bar:4002"); rd != "http://bar:4002" {
+		t.Fatal("failed to form redirect for simple URL with new host")
+	}
+}
+
+func Test_FormRedirectParam(t *testing.T) {
+	m := &MockStore{}
+	s := New("127.0.0.1:0", m, nil)
+	req := mustNewHTTPRequest("http://foo:4001/db/query?x=y")
+
+	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001/db/query?x=y" {
+		t.Fatal("failed to form redirect for URL")
+	}
+	if rd := s.FormRedirect(req, "bar:4003"); rd != "http://bar:4003/db/query?x=y" {
+		t.Fatal("failed to form redirect for URL with new host")
+	}
+}
+
 type MockStore struct {
 	executeFn func(queries []string, tx bool) ([]*sql.Result, error)
 	queryFn   func(queries []string, tx, leader, verify bool) ([]*sql.Rows, error)
@@ -427,4 +453,12 @@ type mockStatuser struct {
 
 func (m *mockStatuser) Stats() (interface{}, error) {
 	return nil, nil
+}
+
+func mustNewHTTPRequest(url string) *http.Request {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		panic("failed to create HTTP request for testing")
+	}
+	return req
 }


### PR DESCRIPTION
With this change, any URL set as `Location` in the HTTP headers includes the full request path *including* the query params.