### PR TITLE
Fix #360, AppVeyor publishes artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,10 @@ build_script:
   - go get ./...
   - go build -i ./...
   - go test -v ./...
+
+after_build:
+  - 7z a rqlited-4.{build}-ci-win64.zip
+
+artifacts:
+  - path: rqlited-4.{build}-ci-win64.zip
+    name: rqlite 4.{build} for Windows (64bit)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ clone_folder: c:\gopath\src\github.com\rqlite\rqlite
 
 environment:
   GOPATH: c:\gopath
-  CIVERS: rqlited-4.%APPVEYOR_BUILD_VERSION%-ci-%APPVEYOR_BUILD_ID%-win64
 
 install:
   - set BUILD_ENV=gnu
@@ -20,8 +19,8 @@ build_script:
   - go test -v ./...
 
 after_build:
-  - 7z a %CIVERS%.zip %GOPATH%\bin\rq*.exe
+  - 7z a rqlited-$(build)-nightly-win64.zip %GOPATH%\bin\rq*.exe
 
 artifacts:
-  - path: %CIVERS%.zip
+  - path: rqlited-$(build)-nightly-win64.zip
     name: rqlite 4.{build} for Windows (64bit)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
   - go test -v ./...
 
 after_build:
-  - 7z a rqlited-4.{build}-ci-win64.zip
+  - 7z a rqlited-4.{build}-ci-win64.zip %GOPATH%\bin\rq*.exe
 
 artifacts:
   - path: rqlited-4.{build}-ci-win64.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_folder: c:\gopath\src\github.com\rqlite\rqlite
 
 environment:
   GOPATH: c:\gopath
+  CIVERS: rqlited-4.%APPVEYOR_BUILD_VERSION%-ci-%APPVEYOR_BUILD_ID%-win64
 
 install:
   - set BUILD_ENV=gnu
@@ -19,8 +20,8 @@ build_script:
   - go test -v ./...
 
 after_build:
-  - 7z a rqlited-4.{build}-ci-win64.zip %GOPATH%\bin\rq*.exe
+  - 7z a %CIVERS%.zip %GOPATH%\bin\rq*.exe
 
 artifacts:
-  - path: rqlited-4.{build}-ci-win64.zip
+  - path: %CIVERS%.zip
     name: rqlite 4.{build} for Windows (64bit)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ build_script:
   - go test -v ./...
 
 after_build:
-  - 7z a rqlited-$(build)-nightly-win64.zip %GOPATH%\bin\rq*.exe
+  - 7z a rqlited-nightly-win64.zip %GOPATH%\bin\rq*.exe
 
 artifacts:
-  - path: rqlited-$(build)-nightly-win64.zip
-    name: rqlite 4.{build} for Windows (64bit)
+  - path: rqlited-nightly-win64.zip
+    name: rqlite for Windows x64


### PR DESCRIPTION
On successful builds, this will package the rqlite binaries and host them using AppVeyor's artifact CDN.

After builds, this will become the permalink to the latest windows build from `master`:

```text
https://ci.appveyor.com/api/projects/rqlite/rqlite/artifacts/rqlited-nightly-win64.zip?branch=master
```

The branch selection ensures that users can't download potentially broken PR builds.