### PR TITLE
CLI checks for HTTP 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.2.1 (unreleased)
 - [PR #367](https://github.com/rqlite/rqlite/pull/367): Remove superflous leading space at CLI prompt.
+- [PR #368](https://github.com/rqlite/rqlite/pull/368): CLI displays clear error message when not authorized.
 
 ## 4.2.0 (October 19th 2017)
 - [PR #354](https://github.com/rqlite/rqlite/pull/354): Vendor Raft.

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -133,6 +133,10 @@ func sendRequest(ctx *cli.Context, urlStr string, line string, argv *argT, ret i
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("unauthorized")
+		}
+
 		// Check for redirect.
 		if resp.StatusCode == http.StatusMovedPermanently {
 			nRedirect++
@@ -189,6 +193,10 @@ func cliJSON(ctx *cli.Context, cmd, line, url string, argv *argT) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("unauthorized")
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
The CLI doesn't yet support passing authentication credentials, but this change means the user will know what is happening.