### PR TITLE
Add Basic Auth credentials support to the CLI

### DIFF
--- a/cmd/rqlite/README.md
+++ b/cmd/rqlite/README.md
@@ -31,6 +31,9 @@ Options:
 
   i,  --insecure[=false]
       do not verify rqlited HTTPS certificate
+
+  -u, --user
+      Basic Auth credentials (username:password)
 ```
 
 ## Example

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -17,11 +17,12 @@ const maxRedirect = 21
 
 type argT struct {
 	cli.Helper
-	Protocol string `cli:"s,scheme" usage:"protocol scheme (http or https)" dft:"http"`
-	Host     string `cli:"H,host" usage:"rqlited host address" dft:"127.0.0.1"`
-	Port     uint16 `cli:"p,port" usage:"rqlited host port" dft:"4001"`
-	Prefix   string `cli:"P,prefix" usage:"rqlited HTTP URL prefix" dft:"/"`
-	Insecure bool   `cli:"i,insecure" usage:"do not verify rqlited HTTPS certificate" dft:"false"`
+	Protocol    string `cli:"s,scheme" usage:"protocol scheme (http or https)" dft:"http"`
+	Host        string `cli:"H,host" usage:"rqlited host address" dft:"127.0.0.1"`
+	Port        uint16 `cli:"p,port" usage:"rqlited host port" dft:"4001"`
+	Prefix      string `cli:"P,prefix" usage:"rqlited HTTP URL prefix" dft:"/"`
+	Insecure    bool   `cli:"i,insecure" usage:"do not verify rqlited HTTPS certificate" dft:"false"`
+	Credentials string `cli:"u,user" usage:"Basic Auth credentials (username:password)"`
 }
 
 const cliHelp = `.help				Show this message
@@ -127,7 +128,20 @@ func sendRequest(ctx *cli.Context, urlStr string, line string, argv *argT, ret i
 
 	nRedirect := 0
 	for {
-		resp, err := client.Post(url, "application/json", strings.NewReader(data))
+		req, err := http.NewRequest("POST", url, strings.NewReader(data))
+		if err != nil {
+			return err
+		}
+
+		if argv.Credentials != "" {
+			creds := strings.Split(argv.Credentials, ":")
+			if len(creds) != 2 {
+				return fmt.Errorf("invalid Basic Auth credentials format")
+			}
+			req.SetBasicAuth(creds[0], creds[1])
+		}
+
+		resp, err := client.Do(req)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently the CLI doesn’t support Basic Auth credentials. This change adds a new option, `-u, —user` to accept an username and password in the form of `username:password`. Credentials are then used to set the Authorization header for all HTTP requests.

Resolves: #369