### PR TITLE
Add statement timings support to CLI

### DIFF
--- a/cmd/rqlite/execute.go
+++ b/cmd/rqlite/execute.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mkideal/cli"
 )
@@ -20,10 +21,19 @@ type executeResponse struct {
 	Time    float64   `json:"time,omitempty"`
 }
 
-func execute(ctx *cli.Context, cmd, line string, argv *argT) error {
-	urlStr := fmt.Sprintf("%s://%s:%d%sdb/execute", argv.Protocol, argv.Host, argv.Port, argv.Prefix)
+func execute(ctx *cli.Context, cmd, line string, timer bool, argv *argT) error {
+	queryStr := url.Values{}
+	if timer {
+		queryStr.Set("timings", "")
+	}
+	u := url.URL{
+		Scheme:   argv.Protocol,
+		Host:     fmt.Sprintf("%s:%d", argv.Host, argv.Port),
+		Path:     fmt.Sprintf("%sdb/query", argv.Prefix),
+		RawQuery: queryStr.Encode(),
+	}
 	ret := &executeResponse{}
-	if err := sendRequest(ctx, urlStr, line, argv, ret); err != nil {
+	if err := sendRequest(ctx, u.String(), line, argv, ret); err != nil {
 		return err
 	}
 	if ret.Error != "" {

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -31,6 +31,7 @@ const cliHelp = `.help				Show this message
 .status				Show status and diagnostic information for connected node
 .expvar				Show expvar (Go runtime) information for connected node
 .tables				List names of tables
+.timer on|off			Turn SQL timer on or off
 `
 
 func main() {
@@ -41,7 +42,7 @@ func main() {
 			ctx.WriteUsage()
 			return nil
 		}
-
+		timer := false
 		prefix := fmt.Sprintf("%s:%d>", argv.Host, argv.Port)
 	FOR_READ:
 		for {
@@ -63,11 +64,13 @@ func main() {
 			cmd = strings.ToUpper(cmd)
 			switch cmd {
 			case ".TABLES":
-				err = query(ctx, cmd, `SELECT name FROM sqlite_master WHERE type="table"`, argv)
+				err = query(ctx, cmd, `SELECT name FROM sqlite_master WHERE type="table"`, timer, argv)
 			case ".INDEXES":
-				err = query(ctx, cmd, `SELECT sql FROM sqlite_master WHERE type="index"`, argv)
+				err = query(ctx, cmd, `SELECT sql FROM sqlite_master WHERE type="index"`, timer, argv)
 			case ".SCHEMA":
-				err = query(ctx, cmd, "SELECT sql FROM sqlite_master", argv)
+				err = query(ctx, cmd, "SELECT sql FROM sqlite_master", timer, argv)
+			case ".TIMER":
+				err = toggleTimer(line[index+1:], &timer)
 			case ".STATUS":
 				err = status(ctx, cmd, line, argv)
 			case ".EXPVAR":
@@ -77,9 +80,9 @@ func main() {
 			case ".QUIT", "QUIT", "EXIT":
 				break FOR_READ
 			case "SELECT":
-				err = query(ctx, cmd, line, argv)
+				err = query(ctx, cmd, line, timer, argv)
 			default:
-				err = execute(ctx, cmd, line, argv)
+				err = execute(ctx, cmd, line, timer, argv)
 			}
 			if err != nil {
 				ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
@@ -88,6 +91,14 @@ func main() {
 		ctx.String("bye~\n")
 		return nil
 	})
+}
+
+func toggleTimer(op string, flag *bool) error {
+	if op != "on" && op != "off" {
+		return fmt.Errorf("invalid option '%s'. Use 'on' or 'off' (default)", op)
+	}
+	*flag = (op == "on")
+	return nil
 }
 
 func makeJSONBody(line string) string {


### PR DESCRIPTION
Currently the CLI doesn’t display the statement timings after executing an SQL query. This change adds a new `.timer on|off` command to enable/disable this feature. When enabled, the CLI will append the `timings` URL query parameter to all query/execute requests sent to the API. When a response is received, the execution time is shown below the result.

Resolves: #317