### PR TITLE
Rename Store Leader() to LeaderAddr()

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -39,8 +39,8 @@ type Transport interface {
 
 // Store represents a store of information, managed via consensus.
 type Store interface {
-	// Leader returns the leader of the consensus system.
-	Leader() string
+	// Leader returns the address of the leader of the consensus system.
+	LeaderAddr() string
 
 	// UpdateAPIPeers updates the API peers on the store.
 	UpdateAPIPeers(peers map[string]string) error
@@ -102,10 +102,10 @@ func (s *Service) SetPeer(raftAddr, apiAddr string) error {
 	}
 
 	// Try talking to the leader over the network.
-	if leader := s.store.Leader(); leader == "" {
+	if leader := s.store.LeaderAddr(); leader == "" {
 		return fmt.Errorf("no leader available")
 	}
-	conn, err := s.tn.Dial(s.store.Leader(), connectionTimeout)
+	conn, err := s.tn.Dial(s.store.LeaderAddr(), connectionTimeout)
 	if err != nil {
 		return err
 	}

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -178,7 +178,7 @@ func newMockStore() *mockStore {
 	}
 }
 
-func (ms *mockStore) Leader() string {
+func (ms *mockStore) LeaderAddr() string {
 	return ms.leader
 }
 

--- a/http/service.go
+++ b/http/service.go
@@ -44,8 +44,8 @@ type Store interface {
 	// Remove removes the node, specified by addr, from the cluster.
 	Remove(addr string) error
 
-	// Leader returns the Raft leader of the cluster.
-	Leader() string
+	// Leader returns the Raft address of the leader of the cluster.
+	LeaderAddr() string
 
 	// Peer returns the API peer for the given address
 	Peer(addr string) string
@@ -302,7 +302,7 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.Join(remoteID, remoteAddr); err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.store.Peer(s.store.Leader())
+			leader := s.store.Peer(s.store.LeaderAddr())
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
@@ -356,7 +356,7 @@ func (s *Service) handleRemove(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.Remove(remoteAddr); err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.store.Peer(s.store.Leader())
+			leader := s.store.Peer(s.store.LeaderAddr())
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
@@ -437,7 +437,7 @@ func (s *Service) handleLoad(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.Execute(&store.ExecuteRequest{queries, timings, false})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.store.Peer(s.store.Leader())
+			leader := s.store.Peer(s.store.LeaderAddr())
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
@@ -487,7 +487,7 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	httpStatus := map[string]interface{}{
 		"addr":     s.Addr().String(),
 		"auth":     prettyEnabled(s.credentialStore != nil),
-		"redirect": s.store.Peer(s.store.Leader()),
+		"redirect": s.store.Peer(s.store.LeaderAddr()),
 	}
 
 	nodeStatus := map[string]interface{}{
@@ -584,7 +584,7 @@ func (s *Service) handleExecute(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.Execute(&store.ExecuteRequest{queries, timings, isTx})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.store.Peer(s.store.Leader())
+			leader := s.store.Peer(s.store.LeaderAddr())
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
@@ -646,7 +646,7 @@ func (s *Service) handleQuery(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.Query(&store.QueryRequest{queries, timings, isTx, lvl})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.store.Peer(s.store.Leader())
+			leader := s.store.Peer(s.store.LeaderAddr())
 			if leader == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -465,7 +465,7 @@ func (m *MockStore) Remove(addr string) error {
 	return nil
 }
 
-func (m *MockStore) Leader() string {
+func (m *MockStore) LeaderAddr() string {
 	return ""
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -318,9 +318,9 @@ func (s *Store) ID() string {
 	return s.raftID
 }
 
-// Leader returns the current leader. Returns a blank string if there is
-// no leader.
-func (s *Store) Leader() string {
+// LeaderAddr returns the Raft address of the current leader. Returns a
+// blank string if there is no leader.
+func (s *Store) LeaderAddr() string {
 	return string(s.raft.Leader())
 }
 
@@ -372,7 +372,7 @@ func (s *Store) WaitForLeader(timeout time.Duration) (string, error) {
 	for {
 		select {
 		case <-tck.C:
-			l := s.Leader()
+			l := s.LeaderAddr()
 			if l != "" {
 				return l, nil
 			}
@@ -434,7 +434,7 @@ func (s *Store) Stats() (map[string]interface{}, error) {
 		"node_id":            s.raftID,
 		"raft":               s.raft.Stats(),
 		"addr":               s.Addr().String(),
-		"leader":             s.Leader(),
+		"leader":             s.LeaderAddr(),
 		"apply_timeout":      s.ApplyTimeout.String(),
 		"heartbeat_timeout":  s.HeartbeatTimeout.String(),
 		"snapshot_threshold": s.SnapshotThreshold,


### PR DESCRIPTION
With the advent of Raft IDs, this distinction matters.