### PR TITLE
Add Backup method to the CLI

### DIFF
--- a/cmd/rqlite/backup.go
+++ b/cmd/rqlite/backup.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/mkideal/cli"
+)
+
+type backupResponse struct {
+	BackupFile []byte
+}
+
+func backup(ctx *cli.Context, filename string, argv *argT) error {
+	queryStr := url.Values{}
+	u := url.URL{
+		Scheme:   argv.Protocol,
+		Host:     fmt.Sprintf("%s:%d", argv.Host, argv.Port),
+		Path:     fmt.Sprintf("%sdb/backup", argv.Prefix),
+		RawQuery: queryStr.Encode(),
+	}
+	response, err := sendRequest(ctx, "GET", u.String(), "", argv)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filename, *response, 0644)
+	if err != nil {
+		return err
+	}
+
+	ctx.String("backup file written successfully\n")
+	return nil
+}

--- a/cmd/rqlite/execute.go
+++ b/cmd/rqlite/execute.go
@@ -32,8 +32,12 @@ func execute(ctx *cli.Context, cmd, line string, timer bool, argv *argT) error {
 		Path:     fmt.Sprintf("%sdb/execute", argv.Prefix),
 		RawQuery: queryStr.Encode(),
 	}
+	response, err := sendRequest(ctx, "POST", u.String(), line, argv)
+	if err != nil {
+		return err
+	}
 	ret := &executeResponse{}
-	if err := sendRequest(ctx, u.String(), line, argv, ret); err != nil {
+	if err := parseResponse(response, &ret); err != nil {
 		return err
 	}
 	if ret.Error != "" {

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -32,6 +33,7 @@ const cliHelp = `.help				Show this message
 .expvar				Show expvar (Go runtime) information for connected node
 .tables				List names of tables
 .timer on|off			Turn SQL timer on or off
+.backup <file>			Create a backup file for the database
 `
 
 func main() {
@@ -75,6 +77,12 @@ func main() {
 				err = status(ctx, cmd, line, argv)
 			case ".EXPVAR":
 				err = expvar(ctx, cmd, line, argv)
+			case ".BACKUP":
+				if index == -1 || index == len(line)-1 {
+					err = fmt.Errorf("Please specify an output file for the backup")
+					break
+				}
+				err = backup(ctx, line[index+1:], argv)
 			case ".HELP":
 				err = help(ctx, cmd, line, argv)
 			case ".QUIT", "QUIT", "EXIT":
@@ -124,8 +132,13 @@ func expvar(ctx *cli.Context, cmd, line string, argv *argT) error {
 	return cliJSON(ctx, cmd, line, url, argv)
 }
 
-func sendRequest(ctx *cli.Context, urlStr string, line string, argv *argT, ret interface{}) error {
-	data := makeJSONBody(line)
+func sendRequest(ctx *cli.Context, method string, urlStr string, line string, argv *argT) (*[]byte, error) {
+	var requestData io.Reader
+	if line != "" {
+		requestData = strings.NewReader(makeJSONBody(line))
+	} else {
+		requestData = nil
+	}
 	url := urlStr
 
 	client := http.Client{Transport: &http.Transport{
@@ -139,46 +152,48 @@ func sendRequest(ctx *cli.Context, urlStr string, line string, argv *argT, ret i
 
 	nRedirect := 0
 	for {
-		req, err := http.NewRequest("POST", url, strings.NewReader(data))
+		req, err := http.NewRequest(method, url, requestData)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if argv.Credentials != "" {
 			creds := strings.Split(argv.Credentials, ":")
 			if len(creds) != 2 {
-				return fmt.Errorf("invalid Basic Auth credentials format")
+				return nil, fmt.Errorf("invalid Basic Auth credentials format")
 			}
 			req.SetBasicAuth(creds[0], creds[1])
 		}
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusUnauthorized {
-			return fmt.Errorf("unauthorized")
+			return nil, fmt.Errorf("unauthorized")
 		}
 
 		// Check for redirect.
 		if resp.StatusCode == http.StatusMovedPermanently {
 			nRedirect++
 			if nRedirect > maxRedirect {
-				return fmt.Errorf("maximum leader redirect limit exceeded")
+				return nil, fmt.Errorf("maximum leader redirect limit exceeded")
 			}
 			url = resp.Header["Location"][0]
 			continue
 		}
-
-		body, err := ioutil.ReadAll(resp.Body)
+		response, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return err
+			return nil, err
 		}
-
-		return json.Unmarshal(body, ret)
+		return &response, nil
 	}
+}
+
+func parseResponse(response *[]byte, ret interface{}) error {
+	return json.Unmarshal(*response, ret)
 }
 
 // cliJSON fetches JSON from a URL, and displays it at the CLI.

--- a/cmd/rqlite/query.go
+++ b/cmd/rqlite/query.go
@@ -91,8 +91,12 @@ func query(ctx *cli.Context, cmd, line string, timer bool, argv *argT) error {
 		Path:     fmt.Sprintf("%sdb/query", argv.Prefix),
 		RawQuery: queryStr.Encode(),
 	}
+	response, err := sendRequest(ctx, "POST", u.String(), line, argv)
+	if err != nil {
+		return err
+	}
 	ret := &queryResponse{}
-	if err := sendRequest(ctx, u.String(), line, argv, ret); err != nil {
+	if err := parseResponse(response, &ret); err != nil {
 		return err
 	}
 	if ret.Error != "" {


### PR DESCRIPTION
Add a CLI command to call the HTTP API and save the backup file. The API responds with the raw file,
so it cannot be unmarshalled into a struct.

Make sendResponse returns the raw response body and provide a function to parse the raw response
into a struct.

Closes #432