### PR TITLE
 write backup directly to ResponseWriter instead of returning

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -57,8 +58,8 @@ type Store interface {
 	// Stats returns stats on the Store.
 	Stats() (map[string]interface{}, error)
 
-	// Backup returns a byte slice representing a backup of the node state.
-	Backup(leader bool, f store.BackupFormat) ([]byte, error)
+	// Backup wites backup of the node state to dst
+	Backup(leader bool, f store.BackupFormat, dst io.Writer) error
 }
 
 // CredentialStore is the interface credential stores must support.
@@ -407,17 +408,12 @@ func (s *Service) handleBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := s.store.Backup(!noLeader, bf)
+	err = s.store.Backup(!noLeader, bf, w)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	_, err = w.Write(b)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	s.lastBackup = time.Now()
 }
 

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -513,8 +514,8 @@ func (m *MockStore) Stats() (map[string]interface{}, error) {
 	return nil, nil
 }
 
-func (m *MockStore) Backup(leader bool, f store.BackupFormat) ([]byte, error) {
-	return nil, nil
+func (m *MockStore) Backup(leader bool, f store.BackupFormat, w io.Writer) error {
+	return nil
 }
 
 type mockCredentialStore struct {


### PR DESCRIPTION
returned data could be of any size and would take up additional space in
ram, instead write the data directly to the passed writer, which in this
case would be http.ResponseWriter

Later this writer could be gzipped buffer writer

There is a wipped commit, as I wanted some input on how to test the backedup file.  I tested manually and it was fine.

I would have to use the db package. But not sure if is a good idea