### PR TITLE
Enable history for rqlite client

### DIFF
--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -47,22 +47,21 @@ func main() {
 		}
 		timer := false
 		prefix := fmt.Sprintf("%s:%d>", argv.Host, argv.Port)
-		history := []string{}
+		term, err := prompt.NewTerminal()
+		if err != nil {
+			ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
+			return nil
+		}
+		term.Close()
 	FOR_READ:
 		for {
-			term, err := prompt.NewTerminal()
-			if err != nil {
-				ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
-				return nil
-			}
-			term.History = history
+			term.Reopen()
 			line, err := term.Basic(prefix, false)
-			history = term.History
 			term.Close()
-
 			if err != nil {
 				return err
 			}
+
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -47,9 +47,14 @@ func main() {
 		}
 		timer := false
 		prefix := fmt.Sprintf("%s:%d>", argv.Host, argv.Port)
+		term, err := prompt.NewTerminal()
+		if err != nil {
+			ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
+			return nil
+		}
 	FOR_READ:
 		for {
-			line, err := prompt.Basic(prefix, false)
+			line, err := term.Basic(prefix, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -47,14 +47,19 @@ func main() {
 		}
 		timer := false
 		prefix := fmt.Sprintf("%s:%d>", argv.Host, argv.Port)
-		term, err := prompt.NewTerminal()
-		if err != nil {
-			ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
-			return nil
-		}
+		history := []string{}
 	FOR_READ:
 		for {
+			term, err := prompt.NewTerminal()
+			if err != nil {
+				ctx.String("%s %v\n", ctx.Color().Red("ERR!"), err)
+				return nil
+			}
+			term.History = history
 			line, err := term.Basic(prefix, false)
+			history = term.History
+			term.Close()
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently, we initiate a new terminal every iteration by calling the wrapper to the `prompt.NewTerminal()` using `prompt.Basic()` but by creating a separate terminal instance using `prompt.NewTerminal()` we can reduce the multiple instances of terminal getting spawned and also use the history slice implemented by the library by pressing the up/down arrow key.