### PR TITLE
Server -http-ca-cert and -node-ca-cert options

### DIFF
--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -18,7 +18,7 @@ func Test_SingleJoinOK(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, true)
+	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -39,7 +39,7 @@ func Test_SingleJoinMetaOK(t *testing.T) {
 	defer ts.Close()
 
 	md := map[string]string{"foo": "bar"}
-	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", md, true)
+	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", md, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -56,7 +56,7 @@ func Test_SingleJoinFail(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, true)
+	_, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, nil)
 	if err == nil {
 		t.Fatalf("expected error when joining bad node")
 	}
@@ -72,7 +72,7 @@ func Test_DoubleJoinOK(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, true)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -92,7 +92,7 @@ func Test_DoubleJoinOKSecondNode(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, true)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -114,7 +114,7 @@ func Test_DoubleJoinOKSecondNodeRedirect(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts2.URL}, "id0", "127.0.0.1:9090", nil, true)
+	j, err := Join([]string{ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}

--- a/http/service.go
+++ b/http/service.go
@@ -5,6 +5,7 @@ package http
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"expvar"
@@ -169,6 +170,7 @@ type Service struct {
 	statusMu sync.RWMutex
 	statuses map[string]Statuser
 
+	CACertFile string // Path to root X.509 certificate.
 	CertFile string // Path to SSL certificate.
 	KeyFile  string // Path to SSL private key.
 
@@ -212,7 +214,7 @@ func (s *Service) Start() error {
 			return err
 		}
 	} else {
-		config, err := createTLSConfig(s.CertFile, s.KeyFile)
+		config, err := createTLSConfig(s.CertFile, s.KeyFile, s.CACertFile)
 		if err != nil {
 			return err
 		}
@@ -773,13 +775,24 @@ func writeResponse(w http.ResponseWriter, r *http.Request, j *Response) {
 }
 
 // createTLSConfig returns a TLS config from the given cert and key.
-func createTLSConfig(certFile, keyFile string) (*tls.Config, error) {
+func createTLSConfig(certFile, keyFile, caCertFile string) (*tls.Config, error) {
 	var err error
 	config := &tls.Config{}
 	config.Certificates = make([]tls.Certificate, 1)
 	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, err
+	}
+	if caCertFile != "" {
+		asn1Data, err := ioutil.ReadFile(caCertFile)
+		if err != nil {
+			return nil, err
+		}
+		config.RootCAs = x509.NewCertPool()
+		ok := config.RootCAs.AppendCertsFromPEM([]byte(asn1Data))
+		if !ok {
+			return nil, fmt.Errorf("failed to parse root certificate(s) in %q", caCertFile)
+		}
 	}
 	return config, nil
 }

--- a/tcp/transport_test.go
+++ b/tcp/transport_test.go
@@ -52,7 +52,7 @@ func Test_NewTLSTransport(t *testing.T) {
 	k := x509.KeyFile()
 	defer os.Remove(k)
 
-	if NewTLSTransport(c, k, true) == nil {
+	if NewTLSTransport(c, k, "", true) == nil {
 		t.Fatal("failed to create new TLS Transport")
 	}
 }
@@ -65,7 +65,7 @@ func Test_TLSTransportOpenClose(t *testing.T) {
 	k := x509.KeyFile()
 	defer os.Remove(k)
 
-	tn := NewTLSTransport(c, k, true)
+	tn := NewTLSTransport(c, k, "", true)
 	if err := tn.Open("localhost:0"); err != nil {
 		t.Fatalf("failed to open TLS transport: %s", err.Error())
 	}


### PR DESCRIPTION
The -http-ca-cert and -node-ca-cert options allow the user to specify
trusted X.509 root CA certificates as an alternative to the
-http-no-verify and -node-no-verify options. This behavior is analogous
to the rqlite client -ca-cert option from https://github.com/rqlite/rqlite/pull/550.

A [backport to v4 series is available](https://github.com/zmedico/rqlite/compare/4.3.0-patch...zmedico:server-ca-cert-option-4.3.0).