### PR TITLE
Server -http-ca-cert and -node-ca-cert options

### DIFF
--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -16,7 +16,7 @@ func Test_SingleJoinOK(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	j, err := Join([]string{ts.URL}, "127.0.0.1:9090", true)
+	j, err := Join([]string{ts.URL}, "127.0.0.1:9090", nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -31,7 +31,7 @@ func Test_SingleJoinFail(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := Join([]string{ts.URL}, "127.0.0.1:9090", true)
+	_, err := Join([]string{ts.URL}, "127.0.0.1:9090", nil)
 	if err == nil {
 		t.Fatalf("expected error when joining bad node")
 	}
@@ -45,7 +45,7 @@ func Test_DoubleJoinOK(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "127.0.0.1:9090", true)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "127.0.0.1:9090", nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -63,7 +63,7 @@ func Test_DoubleJoinOKSecondNode(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "127.0.0.1:9090", true)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "127.0.0.1:9090", nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -83,7 +83,7 @@ func Test_DoubleJoinOKSecondNodeRedirect(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts2.URL}, "127.0.0.1:9090", true)
+	j, err := Join([]string{ts2.URL}, "127.0.0.1:9090", nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -177,7 +177,7 @@ func TestTLSMux(t *testing.T) {
 	key := x509.KeyFile()
 	defer os.Remove(key)
 
-	mux, err := NewTLSMux(tcpListener, nil, cert, key)
+	mux, err := NewTLSMux(tcpListener, nil, cert, key, "")
 	if err != nil {
 		t.Fatalf("failed to create mux: %s", err.Error())
 	}
@@ -206,7 +206,7 @@ func TestTLSMux_Fail(t *testing.T) {
 	key := x509.KeyFile()
 	defer os.Remove(key)
 
-	_, err := NewTLSMux(tcpListener, nil, "xxxx", "yyyy")
+	_, err := NewTLSMux(tcpListener, nil, "xxxx", "yyyy", "")
 	if err == nil {
 		t.Fatalf("created mux unexpectedly with bad resources")
 	}


### PR DESCRIPTION
The -http-ca-cert and -node-ca-cert options allow the user to specify
trusted X.509 root CA certificates as an alternative to the
-http-no-verify and -node-no-verify options. This behavior is analogous
to the rqlite client -ca-cert option from https://github.com/rqlite/rqlite/pull/550.

This backports https://github.com/rqlite/rqlite/pull/561 to the [4.3.0-patch](https://github.com/rqlite/rqlite/tree/4.3.0-patch) branch.