### PR TITLE
Added go-hclog support and formatted log messages to conform.

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -258,7 +258,7 @@ COMMIT;
 
 	f, err := ioutil.TempFile("", "rqlite-baktest-")
 	defer os.Remove(f.Name())
-	s.logger.Printf("backup file is %s", f.Name())
+	s.logger.Info("backup file is %s", f.Name())
 
 	if err := s.Backup(true, BackupSQL, f); err != nil {
 		t.Fatalf("Backup failed %s", err.Error())


### PR DESCRIPTION
hclog uses a weird format for their log messages, rather than doing a
string format on the back end it takes the args for the log message
and prints them as alternating key/values. This replaces the current
logging implementation with hclog (so that the logging interface can be
passed directly down to the underlying raft implementation) and does its
best to make log messages conform to hclogs format.

I'm not sure I really like hclog, but it would be nice to have the uniform
logging in the mean time until another solution comes along. At the very
least this allows me to pass in my own logging interface that does match
hclog's interface and use that instead.