### PR TITLE
Add features list to status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This release uses a new Raft consensus version, with the move to Hashicorp Raft 
 
 ### New features
 - [PR #595](https://github.com/rqlite/rqlite/pull/595): rqlite CLI prints Welcome message on startup.
+- [PR #608](https://github.com/rqlite/rqlite/pull/608): Add features list to status output.
 
 ### Implementation changes and bug fixes
 - [PR #597](https://github.com/rqlite/rqlite/pull/597): Don't ignore any Join error, instead return it.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -43,6 +43,7 @@ var (
 	commit    = "unknown"
 	branch    = "unknown"
 	buildtime = "unknown"
+	features  = []string{}
 )
 
 const (


### PR DESCRIPTION
This will make it easier for client libraries to check for features in a given server, in a standard way.