### PR TITLE
Simplify rqlite implementation

### DIFF
--- a/cmd/rqlite/execute.go
+++ b/cmd/rqlite/execute.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -40,6 +41,10 @@ func executeWithClient(ctx *cli.Context, client *http.Client, argv *argT, timer 
 
 	nRedirect := 0
 	for {
+		if _, err := requestData.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+
 		req, err := http.NewRequest("POST", urlStr, requestData)
 		if err != nil {
 			return err


### PR DESCRIPTION
This results in significant duplicated code, but is easier to follow. The previous code was buggy when it came to redirection handling. Longer term tool needs to be rebuilt to use a proper Go SQL-compliant package (yet to be written).