### PR TITLE
Add support for non-voting nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0 (unreleased)
+
+### New features
+- [PR #613](https://github.com/rqlite/rqlite/pull/613): Support read-only, non-voting nodes. These provide read scalability for the system.
+
 ## 5.0.0 (December 30th 2019)
 This release uses a new Raft consensus version, with the move to Hashicorp Raft v1. As a result **the Raft system in 5.0 is not compatible with the 4.0 series**. To upgrade from an earlier version to this release you should backup your 4.0 leader node, and restore the database dump into a new 5.0 cluster.
 

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -46,6 +46,9 @@ There is also a rqlite _Discovery Service_, allowing nodes to automatically conn
 ## Through the firewall
 On some networks, like AWS EC2 cloud, nodes may have an IP address that is not routable from outside the firewall. Instead these nodes are addressed using a different IP address. You can still form a rqlite cluster however -- check out [this tutorial](http://www.philipotoole.com/rqlite-v3-0-1-globally-replicating-sqlite/) for more details.
 
+## Read-only (non-voting) nodes
+rqlite supports _read only_ nodes. When started in this mode, a node will not partipate in the Raft consensus system, but will subcribe to the stream of committed log entries, which are broadcast by the leader. You can use this feature to add read scalability to the cluster if you need a high volume of reads. Pass `-raft-non-voter=true` to configure read-only mode.
+
 # Dealing with failure
 It is the nature of clustered systems that nodes can fail at anytime. Depending on the size of your cluster, it will tolerate various amounts of failure. With a 3-node cluster, it can tolerate the failure of a single node, including the leader.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ rqlite uses [Raft](https://raft.github.io/) to achieve consensus across all the 
 - [Discovery Service support](https://github.com/rqlite/rqlite/blob/master/DOC/DISCOVERY.md), allowing clusters to be dynamically created.
 - [Extensive security and encryption support](https://github.com/rqlite/rqlite/blob/master/DOC/SECURITY.md), including node-to-node encryption.
 - Choice of [read consistency levels](https://github.com/rqlite/rqlite/blob/master/DOC/CONSISTENCY.md).
+- Optional read-only (non-voting) nodes, which can add read scalability to the system.
 - A form of transaction support.
 - Hot backups.
 

--- a/cluster/join.go
+++ b/cluster/join.go
@@ -23,7 +23,7 @@ const attemptInterval time.Duration = 5 * time.Second
 // It walks through joinAddr in order, and sets the node ID and Raft address of
 // the joining node as id addr respectively. It returns the endpoint successfully
 // used to join the cluster.
-func Join(joinAddr []string, id, addr string, meta map[string]string, tlsConfig *tls.Config) (string, error) {
+func Join(joinAddr []string, id, addr string, voter bool, meta map[string]string, tlsConfig *tls.Config) (string, error) {
 	var err error
 	var j string
 	logger := log.New(os.Stderr, "[cluster-join] ", log.LstdFlags)
@@ -33,7 +33,7 @@ func Join(joinAddr []string, id, addr string, meta map[string]string, tlsConfig 
 
 	for i := 0; i < numAttempts; i++ {
 		for _, a := range joinAddr {
-			j, err = join(a, id, addr, meta, tlsConfig, logger)
+			j, err = join(a, id, addr, voter, meta, tlsConfig, logger)
 			if err == nil {
 				// Success!
 				return j, nil
@@ -46,7 +46,7 @@ func Join(joinAddr []string, id, addr string, meta map[string]string, tlsConfig 
 	return "", err
 }
 
-func join(joinAddr, id, addr string, meta map[string]string, tlsConfig *tls.Config, logger *log.Logger) (string, error) {
+func join(joinAddr, id, addr string, voter bool, meta map[string]string, tlsConfig *tls.Config, logger *log.Logger) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("node ID not set")
 	}
@@ -71,9 +71,10 @@ func join(joinAddr, id, addr string, meta map[string]string, tlsConfig *tls.Conf
 
 	for {
 		b, err := json.Marshal(map[string]interface{}{
-			"id":   id,
-			"addr": resv.String(),
-			"meta": meta,
+			"id":    id,
+			"addr":  resv.String(),
+			"voter": voter,
+			"meta":  meta,
 		})
 		if err != nil {
 			return "", err

--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -10,20 +10,43 @@ import (
 )
 
 func Test_SingleJoinOK(t *testing.T) {
+	var body map[string]interface{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			t.Fatalf("Client did not use POST")
 		}
 		w.WriteHeader(http.StatusOK)
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if err := json.Unmarshal(b, &body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 	}))
+
 	defer ts.Close()
 
-	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, nil)
+	j, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", false, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
 	if j != ts.URL+"/join" {
 		t.Fatalf("node joined using wrong endpoint, exp: %s, got: %s", j, ts.URL)
+	}
+
+	if got, exp := body["id"].(string), "id0"; got != exp {
+		t.Fatalf("wrong node ID supplied, exp %s, got %s", exp, got)
+	}
+	if got, exp := body["addr"].(string), "127.0.0.1:9090"; got != exp {
+		t.Fatalf("wrong address supplied, exp %s, got %s", exp, got)
+	}
+	if got, exp := body["voter"].(bool), false; got != exp {
+		t.Fatalf("wrong voter state supplied, exp %v, got %v", exp, got)
 	}
 }
 
@@ -51,7 +74,7 @@ func Test_SingleJoinMetaOK(t *testing.T) {
 
 	nodeAddr := "127.0.0.1:9090"
 	md := map[string]string{"foo": "bar"}
-	j, err := Join([]string{ts.URL}, "id0", nodeAddr, md, nil)
+	j, err := Join([]string{ts.URL}, "id0", nodeAddr, true, md, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -77,7 +100,7 @@ func Test_SingleJoinFail(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", nil, nil)
+	_, err := Join([]string{ts.URL}, "id0", "127.0.0.1:9090", true, nil, nil)
 	if err == nil {
 		t.Fatalf("expected error when joining bad node")
 	}
@@ -91,7 +114,7 @@ func Test_DoubleJoinOK(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", true, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -109,7 +132,7 @@ func Test_DoubleJoinOKSecondNode(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
+	j, err := Join([]string{ts1.URL, ts2.URL}, "id0", "127.0.0.1:9090", true, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}
@@ -129,7 +152,7 @@ func Test_DoubleJoinOKSecondNodeRedirect(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	j, err := Join([]string{ts2.URL}, "id0", "127.0.0.1:9090", nil, nil)
+	j, err := Join([]string{ts2.URL}, "id0", "127.0.0.1:9090", true, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to join a single node: %s", err.Error())
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -78,6 +78,7 @@ var expvar bool
 var pprofEnabled bool
 var dsn string
 var onDisk bool
+var raftNonVoter bool
 var raftSnapThreshold uint64
 var raftHeartbeatTimeout string
 var raftElectionTimeout string
@@ -116,6 +117,7 @@ func init() {
 	flag.StringVar(&dsn, "dsn", "", `SQLite DSN parameters. E.g. "cache=shared&mode=memory"`)
 	flag.BoolVar(&onDisk, "on-disk", false, "Use an on-disk SQLite database")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
+	flag.BoolVar(&raftNonVoter, "raft-non-voter", false, "Configure as non-voting node")
 	flag.StringVar(&raftHeartbeatTimeout, "raft-timeout", "1s", "Raft heartbeat timeout")
 	flag.StringVar(&raftElectionTimeout, "raft-election-timeout", "1s", "Raft election timeout")
 	flag.StringVar(&raftApplyTimeout, "raft-apply-timeout", "10s", "Raft apply timeout")
@@ -253,7 +255,7 @@ func main() {
 			}
 		}
 
-		if j, err := cluster.Join(joins, str.ID(), advAddr, meta, &tlsConfig); err != nil {
+		if j, err := cluster.Join(joins, str.ID(), advAddr, !raftNonVoter, meta, &tlsConfig); err != nil {
 			log.Fatalf("failed to join cluster at %s: %s", joins, err.Error())
 		} else {
 			log.Println("successfully joined cluster at", j)

--- a/http/service.go
+++ b/http/service.go
@@ -45,7 +45,7 @@ type Store interface {
 	Query(qr *store.QueryRequest) ([]*sql.Rows, error)
 
 	// Join joins the node with the given ID, reachable at addr, to this node.
-	Join(id, addr string, metadata map[string]string) error
+	Join(id, addr string, voter bool, metadata map[string]string) error
 
 	// Remove removes the node, specified by id, from the cluster.
 	Remove(id string) error
@@ -318,7 +318,12 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.Join(remoteID.(string), remoteAddr.(string), m); err != nil {
+	voter, ok := md["voter"]
+	if !ok {
+		voter = true
+	}
+
+	if err := s.store.Join(remoteID.(string), remoteAddr.(string), voter.(bool), m); err != nil {
 		if err == store.ErrNotLeader {
 			leader := s.leaderAPIAddr()
 			if leader == "" {

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -492,7 +492,7 @@ func (m *MockStore) Query(qr *store.QueryRequest) ([]*sql.Rows, error) {
 	return nil, nil
 }
 
-func (m *MockStore) Join(id, addr string, metadata map[string]string) error {
+func (m *MockStore) Join(id, addr string, voter bool, metadata map[string]string) error {
 	return nil
 }
 


### PR DESCRIPTION
A non-voting node doesn't participate in Raft consensus, but does subscribe to the committed log entries originating with the leader. This means a non-voting node keeps up-to-date with the state machine, without impacting write-latency. These non-voting nodes can provide read scalability for the cluster.