### PR TITLE
Allow log level control for Raft module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 - [PR #613](https://github.com/rqlite/rqlite/pull/613): Support read-only, non-voting nodes. These provide read scalability for the system.
 - [PR #614](https://github.com/rqlite/rqlite/pull/614): Support specifying minimum leader freshness with _None_ consistency queries.
+- [PR #620](https://github.com/rqlite/rqlite/pull/620): Log level can be specified for Raft module.
 
 ## 5.0.0 (December 30th 2019)
 This release uses a new Raft consensus version, with the move to Hashicorp Raft v1. As a result **the Raft system in 5.0 is not compatible with the 4.0 series**. To upgrade from an earlier version to this release you should backup your 4.0 leader node, and restore the database dump into a new 5.0 cluster.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -66,6 +66,7 @@ var expvar bool
 var pprofEnabled bool
 var dsn string
 var onDisk bool
+var raftLogLevel string
 var raftNonVoter bool
 var raftSnapThreshold uint64
 var raftHeartbeatTimeout string
@@ -112,6 +113,7 @@ func init() {
 	flag.StringVar(&raftOpenTimeout, "raft-open-timeout", "120s", "Time for initial Raft logs to be applied. Use 0s duration to skip wait")
 	flag.Uint64Var(&raftSnapThreshold, "raft-snap", 8192, "Number of outstanding log entries that trigger snapshot")
 	flag.BoolVar(&raftShutdownOnRemove, "raft-remove-shutdown", false, "Shutdown Raft if node removed")
+	flag.StringVar(&raftLogLevel, "raft-log-level", "INFO", "Minimum log level for Raft module")
 	flag.StringVar(&cpuProfile, "cpu-profile", "", "Path to file for CPU profiling information")
 	flag.StringVar(&memProfile, "mem-profile", "", "Path to file for memory profiling information")
 	flag.Usage = func() {
@@ -177,6 +179,7 @@ func main() {
 	})
 
 	// Set optional parameters on store.
+	str.RaftLogLevel = raftLogLevel
 	str.ShutdownOnRemove = raftShutdownOnRemove
 	str.SnapshotThreshold = raftSnapThreshold
 	str.HeartbeatTimeout, err = time.ParseDuration(raftHeartbeatTimeout)

--- a/store/store.go
+++ b/store/store.go
@@ -150,6 +150,7 @@ type Store struct {
 	HeartbeatTimeout  time.Duration
 	ElectionTimeout   time.Duration
 	ApplyTimeout      time.Duration
+	RaftLogLevel      string
 }
 
 // StoreConfig represents the configuration of the underlying Store.
@@ -766,6 +767,7 @@ func (s *Store) remove(id string) error {
 func (s *Store) raftConfig() *raft.Config {
 	config := raft.DefaultConfig()
 	config.ShutdownOnRemove = s.ShutdownOnRemove
+	config.LogLevel = s.RaftLogLevel
 	if s.SnapshotThreshold != 0 {
 		config.SnapshotThreshold = s.SnapshotThreshold
 	}


### PR DESCRIPTION
Default log level is INFO.