### PR TITLE
Set Location for HTTP redirect properly for secure nodes

### DIFF
--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -231,8 +231,13 @@ func main() {
 	if httpAdv != "" {
 		apiAdv = httpAdv
 	}
+	apiProto := "http"
+	if x509Cert != "" {
+		apiProto = "https"
+	}
 	meta := map[string]string{
-		"api_addr": apiAdv,
+		"api_addr":  apiAdv,
+		"api_proto": apiProto,
 	}
 
 	// Execute any requested join operation.

--- a/http/service.go
+++ b/http/service.go
@@ -738,9 +738,11 @@ func (s *Service) Addr() net.Addr {
 }
 
 // FormRedirect returns the value for the "Location" header for a 301 response.
+// This function assume that if this node is using HTTPS, then all other nodes
+// are using HTTP.
 func (s *Service) FormRedirect(r *http.Request, host string) string {
 	protocol := "http"
-	if s.credentialStore != nil {
+	if s.CertFile != "" {
 		protocol = "https"
 	}
 	rq := r.URL.RawQuery

--- a/http/service.go
+++ b/http/service.go
@@ -326,13 +326,14 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.Join(remoteID.(string), remoteAddr.(string), voter.(bool), m); err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.leaderAPIAddr()
-			if leader == "" {
+			leaderAPIAddr := s.leaderAPIAddr()
+			leaderProto := s.leaderAPIProto()
+			if leaderAPIAddr == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 
-			redirect := s.FormRedirect(r, leader)
+			redirect := s.FormRedirect(r, leaderProto, leaderAPIAddr)
 			http.Redirect(w, r, redirect, http.StatusMovedPermanently)
 			return
 		}
@@ -380,13 +381,14 @@ func (s *Service) handleRemove(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.store.Remove(remoteID); err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.leaderAPIAddr()
-			if leader == "" {
+			leaderAPIAddr := s.leaderAPIAddr()
+			leaderProto := s.leaderAPIProto()
+			if leaderAPIAddr == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 
-			redirect := s.FormRedirect(r, leader)
+			redirect := s.FormRedirect(r, leaderProto, leaderAPIAddr)
 			http.Redirect(w, r, redirect, http.StatusMovedPermanently)
 			return
 		}
@@ -460,13 +462,14 @@ func (s *Service) handleLoad(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.ExecuteOrAbort(&store.ExecuteRequest{queries, timings, false})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.leaderAPIAddr()
-			if leader == "" {
+			leaderAPIAddr := s.leaderAPIAddr()
+			leaderProto := s.leaderAPIProto()
+			if leaderAPIAddr == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 
-			redirect := s.FormRedirect(r, leader)
+			redirect := s.FormRedirect(r, leaderProto, leaderAPIAddr)
 			http.Redirect(w, r, redirect, http.StatusMovedPermanently)
 			return
 		}
@@ -607,13 +610,14 @@ func (s *Service) handleExecute(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.Execute(&store.ExecuteRequest{queries, timings, isTx})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.leaderAPIAddr()
-			if leader == "" {
+			leaderAPIAddr := s.leaderAPIAddr()
+			leaderProto := s.leaderAPIProto()
+			if leaderAPIAddr == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 
-			redirect := s.FormRedirect(r, leader)
+			redirect := s.FormRedirect(r, leaderProto, leaderAPIAddr)
 			http.Redirect(w, r, redirect, http.StatusMovedPermanently)
 			return
 		}
@@ -675,13 +679,14 @@ func (s *Service) handleQuery(w http.ResponseWriter, r *http.Request) {
 	results, err := s.store.Query(&store.QueryRequest{queries, timings, isTx, lvl, frsh})
 	if err != nil {
 		if err == store.ErrNotLeader {
-			leader := s.leaderAPIAddr()
-			if leader == "" {
+			leaderAPIAddr := s.leaderAPIAddr()
+			leaderProto := s.leaderAPIProto()
+			if leaderAPIAddr == "" {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 
-			redirect := s.FormRedirect(r, leader)
+			redirect := s.FormRedirect(r, leaderProto, leaderAPIAddr)
 			http.Redirect(w, r, redirect, http.StatusMovedPermanently)
 			return
 		}
@@ -740,11 +745,7 @@ func (s *Service) Addr() net.Addr {
 // FormRedirect returns the value for the "Location" header for a 301 response.
 // This function assume that if this node is using HTTPS, then all other nodes
 // are using HTTP.
-func (s *Service) FormRedirect(r *http.Request, host string) string {
-	protocol := "http"
-	if s.CertFile != "" {
-		protocol = "https"
-	}
+func (s *Service) FormRedirect(r *http.Request, protocol, host string) string {
 	rq := r.URL.RawQuery
 	if rq != "" {
 		rq = fmt.Sprintf("?%s", rq)
@@ -772,6 +773,19 @@ func (s *Service) leaderAPIAddr() string {
 		return ""
 	}
 	return s.store.Metadata(id, "api_addr")
+}
+
+func (s *Service) leaderAPIProto() string {
+	id, err := s.store.LeaderID()
+	if err != nil {
+		return "http"
+	}
+
+	p := s.store.Metadata(id, "api_proto")
+	if p == "" {
+		return "http"
+	}
+	return "https"
 }
 
 // addBuildVersion adds the build version to the HTTP response.

--- a/http/service.go
+++ b/http/service.go
@@ -743,8 +743,6 @@ func (s *Service) Addr() net.Addr {
 }
 
 // FormRedirect returns the value for the "Location" header for a 301 response.
-// This function assume that if this node is using HTTPS, then all other nodes
-// are using HTTP.
 func (s *Service) FormRedirect(r *http.Request, protocol, host string) string {
 	rq := r.URL.RawQuery
 	if rq != "" {

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -446,7 +446,7 @@ func Test_RegisterStatus(t *testing.T) {
 func Test_FormRedirect(t *testing.T) {
 	m := &MockStore{}
 	s := New("127.0.0.1:0", m, nil)
-	req := mustNewHTTPRequest("http://foo:4001")
+	req := mustNewHTTPRequest("http://qux:4001")
 
 	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001" {
 		t.Fatal("failed to form redirect for simple URL")
@@ -459,13 +459,27 @@ func Test_FormRedirect(t *testing.T) {
 func Test_FormRedirectParam(t *testing.T) {
 	m := &MockStore{}
 	s := New("127.0.0.1:0", m, nil)
-	req := mustNewHTTPRequest("http://foo:4001/db/query?x=y")
+	req := mustNewHTTPRequest("http://qux:4001/db/query?x=y")
 
 	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001/db/query?x=y" {
 		t.Fatal("failed to form redirect for URL")
 	}
 	if rd := s.FormRedirect(req, "bar:4003"); rd != "http://bar:4003/db/query?x=y" {
 		t.Fatal("failed to form redirect for URL with new host")
+	}
+}
+
+func Test_FormRedirectHTTPS(t *testing.T) {
+	m := &MockStore{}
+	s := New("127.0.0.1:0", m, nil)
+	s.CertFile = "/some/dummy/path"
+	req := mustNewHTTPRequest("http://qux:4001")
+
+	if rd := s.FormRedirect(req, "foo:4001"); rd != "https://foo:4001" {
+		t.Fatal("failed to form redirect for simple URL")
+	}
+	if rd := s.FormRedirect(req, "bar:4002"); rd != "https://bar:4002" {
+		t.Fatal("failed to form redirect for simple URL with new host")
 	}
 }
 

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -448,10 +448,10 @@ func Test_FormRedirect(t *testing.T) {
 	s := New("127.0.0.1:0", m, nil)
 	req := mustNewHTTPRequest("http://qux:4001")
 
-	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001" {
+	if rd := s.FormRedirect(req, "http", "foo:4001"); rd != "http://foo:4001" {
 		t.Fatal("failed to form redirect for simple URL")
 	}
-	if rd := s.FormRedirect(req, "bar:4002"); rd != "http://bar:4002" {
+	if rd := s.FormRedirect(req, "http", "bar:4002"); rd != "http://bar:4002" {
 		t.Fatal("failed to form redirect for simple URL with new host")
 	}
 }
@@ -461,10 +461,10 @@ func Test_FormRedirectParam(t *testing.T) {
 	s := New("127.0.0.1:0", m, nil)
 	req := mustNewHTTPRequest("http://qux:4001/db/query?x=y")
 
-	if rd := s.FormRedirect(req, "foo:4001"); rd != "http://foo:4001/db/query?x=y" {
+	if rd := s.FormRedirect(req, "http", "foo:4001"); rd != "http://foo:4001/db/query?x=y" {
 		t.Fatal("failed to form redirect for URL")
 	}
-	if rd := s.FormRedirect(req, "bar:4003"); rd != "http://bar:4003/db/query?x=y" {
+	if rd := s.FormRedirect(req, "http", "bar:4003"); rd != "http://bar:4003/db/query?x=y" {
 		t.Fatal("failed to form redirect for URL with new host")
 	}
 }
@@ -472,13 +472,12 @@ func Test_FormRedirectParam(t *testing.T) {
 func Test_FormRedirectHTTPS(t *testing.T) {
 	m := &MockStore{}
 	s := New("127.0.0.1:0", m, nil)
-	s.CertFile = "/some/dummy/path"
 	req := mustNewHTTPRequest("http://qux:4001")
 
-	if rd := s.FormRedirect(req, "foo:4001"); rd != "https://foo:4001" {
+	if rd := s.FormRedirect(req, "https", "foo:4001"); rd != "https://foo:4001" {
 		t.Fatal("failed to form redirect for simple URL")
 	}
-	if rd := s.FormRedirect(req, "bar:4002"); rd != "https://bar:4002" {
+	if rd := s.FormRedirect(req, "https", "bar:4002"); rd != "https://bar:4002" {
 		t.Fatal("failed to form redirect for simple URL with new host")
 	}
 }

--- a/system_test/cluster_test.go
+++ b/system_test/cluster_test.go
@@ -43,6 +43,15 @@ func Test_MultiNodeCluster(t *testing.T) {
 		t.Fatalf("failed to find cluster leader: %s", err.Error())
 	}
 
+	// Get a follower and confirm redirects work properly.
+	followers, err := c.Followers()
+	if err != nil {
+		t.Fatalf("failed to get followers: %s", err.Error())
+	}
+	if len(followers) != 1 {
+		t.Fatalf("got incorrect number of followers: %d", len(followers))
+	}
+
 	node3 := mustNewNode(false)
 	defer node3.Deprovision()
 	if err := node3.Join(leader); err != nil {


### PR DESCRIPTION
This change adds the API protocol uses by each node to the node meta. This new information is then used by non-leader nodes when forming the value returned in the Location header of a HTTP response.