### PR TITLE
Do not use resolved address in join request

### DIFF
--- a/cluster/join.go
+++ b/cluster/join.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -55,12 +54,6 @@ func join(joinAddr, id, addr string, voter bool, meta map[string]string, tlsConf
 		return "", fmt.Errorf("node ID not set")
 	}
 
-	// Join using IP address, as that is what Hashicorp Raft works in.
-	resv, err := net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
-		return "", err
-	}
-
 	// Check for protocol scheme, and insert default if necessary.
 	fullAddr := httpd.NormalizeAddr(fmt.Sprintf("%s/join", joinAddr))
 
@@ -76,7 +69,7 @@ func join(joinAddr, id, addr string, voter bool, meta map[string]string, tlsConf
 	for {
 		b, err := json.Marshal(map[string]interface{}{
 			"id":    id,
-			"addr":  resv.String(),
+			"addr":  addr,
 			"voter": voter,
 			"meta":  meta,
 		})


### PR DESCRIPTION
It's not clear why this code was put in place in the first place, but it may not be necessary.