### PR TITLE
Don't use temp file when restoring to in-memory SQLite

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -467,6 +467,15 @@ func (db *DB) Serialize() ([]byte, error) {
 	return b, nil
 }
 
+// Deserialize forces a disconnect from the current database and then re-open
+// as an in-memory database based on the contents of the byte slice.
+func (db *DB) Deserialize(b []byte) error {
+	if err := db.sqlite3conn.Deserialize(b, ""); err != nil {
+		return fmt.Errorf("failed to deserialize database: %s", err.Error())
+	}
+	return nil
+}
+
 // Dump writes a consistent snapshot of the database in SQL text format.
 func (db *DB) Dump(w io.Writer) error {
 	if _, err := w.Write([]byte("PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\n")); err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -158,8 +158,7 @@ func Test_DeserializeInMemoryWithDSN(t *testing.T) {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 
-	// Write a some records to the new database, to ensure
-	// it's fully functional.
+	// Write a lot of records to the new database, to ensure it's fully functional.
 	req = &command.Request{
 		Statements: []*command.Statement{
 			{
@@ -167,7 +166,7 @@ func Test_DeserializeInMemoryWithDSN(t *testing.T) {
 			},
 		},
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 5000; i++ {
 		_, err = newDB.Execute(req, false)
 		if err != nil {
 			t.Fatalf("failed to insert records: %s", err.Error())
@@ -177,7 +176,7 @@ func Test_DeserializeInMemoryWithDSN(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())
 	}
-	if exp, got := `[{"columns":["COUNT(*)"],"types":[""],"values":[[1004]]}]`, asJSON(ro); exp != got {
+	if exp, got := `[{"columns":["COUNT(*)"],"types":[""],"values":[[5004]]}]`, asJSON(ro); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -105,6 +105,83 @@ func Test_LoadInMemory(t *testing.T) {
 	}
 }
 
+func Test_DeserializeInMemoryWithDSN(t *testing.T) {
+	db, path := mustCreateDatabase()
+	defer db.Close()
+	defer os.Remove(path)
+
+	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+
+	req := &command.Request{
+		Transaction: true,
+		Statements: []*command.Statement{
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(2, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(3, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(4, "fiona")`,
+			},
+		},
+	}
+	_, err = db.Execute(req, false)
+	if err != nil {
+		t.Fatalf("failed to insert records: %s", err.Error())
+	}
+
+	// Get byte representation of database on disk which, according to SQLite docs
+	// is the same as a serialized version.
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read database on disk: %s", err.Error())
+	}
+
+	newDB, err := DeserializeInMemoryWithDSN(b, "")
+	if err != nil {
+		t.Fatalf("failed to deserialize database: %s", err.Error())
+	}
+	defer newDB.Close()
+
+	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
+	if err != nil {
+		t.Fatalf("failed to query table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"fiona"],[3,"fiona"],[4,"fiona"]]}]`, asJSON(ro); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+
+	// Write a some records to the new database, to ensure
+	// it's fully functional.
+	req = &command.Request{
+		Statements: []*command.Statement{
+			{
+				Sql: `INSERT INTO foo(name) VALUES("fiona")`,
+			},
+		},
+	}
+	for i := 0; i < 1000; i++ {
+		_, err = newDB.Execute(req, false)
+		if err != nil {
+			t.Fatalf("failed to insert records: %s", err.Error())
+		}
+	}
+	ro, err = newDB.QueryStringStmt(`SELECT COUNT(*) FROM foo`)
+	if err != nil {
+		t.Fatalf("failed to query table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["COUNT(*)"],"types":[""],"values":[[1004]]}]`, asJSON(ro); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+}
+
 func Test_EmptyStatements(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
@@ -1066,62 +1143,6 @@ func Test_Serialize(t *testing.T) {
 	}
 	defer newDB.Close()
 	defer os.Remove(dstDB.Name())
-	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
-	if err != nil {
-		t.Fatalf("failed to query table: %s", err.Error())
-	}
-	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"fiona"],[3,"fiona"],[4,"fiona"]]}]`, asJSON(ro); exp != got {
-		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
-	}
-}
-
-func Test_Deserialize(t *testing.T) {
-	db, path := mustCreateDatabase()
-	defer db.Close()
-	defer os.Remove(path)
-
-	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
-	if err != nil {
-		t.Fatalf("failed to create table: %s", err.Error())
-	}
-
-	req := &command.Request{
-		Transaction: true,
-		Statements: []*command.Statement{
-			{
-				Sql: `INSERT INTO foo(id, name) VALUES(1, "fiona")`,
-			},
-			{
-				Sql: `INSERT INTO foo(id, name) VALUES(2, "fiona")`,
-			},
-			{
-				Sql: `INSERT INTO foo(id, name) VALUES(3, "fiona")`,
-			},
-			{
-				Sql: `INSERT INTO foo(id, name) VALUES(4, "fiona")`,
-			},
-		},
-	}
-	_, err = db.Execute(req, false)
-	if err != nil {
-		t.Fatalf("failed to insert records: %s", err.Error())
-	}
-
-	// Get byte representation of database on disk.
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read database on disk: %s", err.Error())
-	}
-
-	newDB, path2 := mustCreateDatabase()
-	defer newDB.Close()
-	defer os.Remove(path2)
-
-	// Load empty database with bytes from disk.
-	if err := newDB.Deserialize(b); err != nil {
-		t.Fatalf("failed to deserialize database: %s", err.Error())
-	}
-
 	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1012,10 +1012,66 @@ func Test_Serialize(t *testing.T) {
 
 	newDB, err := Open(dstDB.Name())
 	if err != nil {
-		t.Fatalf("failed to open backup database: %s", err.Error())
+		t.Fatalf("failed to open on-disk serialized database: %s", err.Error())
 	}
 	defer newDB.Close()
 	defer os.Remove(dstDB.Name())
+	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
+	if err != nil {
+		t.Fatalf("failed to query table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"fiona"],[3,"fiona"],[4,"fiona"]]}]`, asJSON(ro); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+}
+
+func Test_Deserialize(t *testing.T) {
+	db, path := mustCreateDatabase()
+	defer db.Close()
+	defer os.Remove(path)
+
+	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+
+	req := &command.Request{
+		Transaction: true,
+		Statements: []*command.Statement{
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(2, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(3, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(4, "fiona")`,
+			},
+		},
+	}
+	_, err = db.Execute(req, false)
+	if err != nil {
+		t.Fatalf("failed to insert records: %s", err.Error())
+	}
+
+	// Get byte representation of database on disk.
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read database on disk: %s", err.Error())
+	}
+
+	newDB, path2 := mustCreateDatabase()
+	defer newDB.Close()
+	defer os.Remove(path2)
+
+	// Load empty database with bytes from disk.
+	if err := newDB.Deserialize(b); err != nil {
+		t.Fatalf("failed to deserialize database: %s", err.Error())
+	}
+
 	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
 	if err != nil {
 		t.Fatalf("failed to query table: %s", err.Error())

--- a/store/store.go
+++ b/store/store.go
@@ -1050,12 +1050,9 @@ func (s *Store) Restore(rc io.ReadCloser) error {
 		}
 	} else {
 		// In memory, so directly deserialize into the database.
-		db, err = sql.OpenInMemoryWithDSN(s.dbConf.DSN)
+		db, err = sql.DeserializeInMemoryWithDSN(database, s.dbConf.DSN)
 		if err != nil {
-			return fmt.Errorf("open in memory with DSN: %s", err)
-		}
-		if err := db.Deserialize(database); err != nil {
-			return fmt.Errorf("failed to deserialize database: %s", err)
+			return fmt.Errorf("DeserializeInMemoryWithDSN with DSN: %s", err)
 		}
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1103,6 +1103,23 @@ func Test_SingleNodeSnapshotInMem(t *testing.T) {
 	if exp, got := `[[1,"fiona"]]`, asJSON(r[0].Values); exp != got {
 		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
 	}
+
+	// Write a record, ensuring it works and can be queried back i.e. that
+	// the system remains functional.
+	_, err = s.Execute(executeRequestFromString(`INSERT INTO foo(id, name) VALUES(2, "fiona")`, false, false))
+	if err != nil {
+		t.Fatalf("failed to execute on single node: %s", err.Error())
+	}
+	r, err = s.Query(queryRequestFromString("SELECT COUNT(*) FROM foo", false, false))
+	if err != nil {
+		t.Fatalf("failed to query single node: %s", err.Error())
+	}
+	if exp, got := `["COUNT(*)"]`, asJSON(r[0].Columns); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+	if exp, got := `[[2]]`, asJSON(r[0].Values); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
 }
 
 func Test_SingleNodeRestoreNoncompressed(t *testing.T) {

--- a/system_test/misc/test-pr739.sh
+++ b/system_test/misc/test-pr739.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+RQLITED=~/rqlite/src/github.com/rqlite/rqlite/cmd/rqlited/rqlited
+RQBENCH=~/rqlite/src/github.com/rqlite/rqlite/cmd/rqbench/rqbench
+DATA_DIR=`mktemp -d`
+
+$RQLITED -raft-snap 13 -raft-snap-int=1s $DATA_DIR &
+sleep 3
+$RQBENCH -b 10 -m 1 -n 500 -o 'CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)' 'INSERT INTO foo(name) VALUES("fiona")'
+
+killall rqlited
+sleep 3
+
+$RQLITED -raft-snap 50000 -raft-snap-int=500s $DATA_DIR & 
+sleep 3
+$RQBENCH -b 10 -m 1 -n 500 'INSERT INTO foo(name) VALUES("fiona")'
+wait


### PR DESCRIPTION
Saves a read and write, the size of the SQLite database, when restoring an in-memory database.