### PR TITLE
Create GZIP writer for every compression request

### DIFF
--- a/command/marshal.go
+++ b/command/marshal.go
@@ -97,10 +97,10 @@ func (m *RequestMarshaler) Marshal(r Requester) ([]byte, bool, error) {
 		var buf bytes.Buffer
 		gzw.Reset(&buf)
 		if _, err := gzw.Write(b); err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("gzip Write: %s", err)
 		}
 		if err := gzw.Close(); err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("gzip Close: %s", err)
 		}
 
 		// Is compression better?

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -263,6 +263,25 @@ func (n *Node) postQuery(stmt string) (string, error) {
 	return string(body), nil
 }
 
+// PostExecuteStmt performs a HTTP execute request
+func PostExecuteStmt(apiAddr, stmt string) (string, error) {
+	j, err := json.Marshal([]string{stmt})
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.Post("http://"+apiAddr+"/db/execute", "application/json", strings.NewReader(string(j)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
 // Cluster represents a cluster of nodes.
 type Cluster []*Node
 

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -152,9 +152,9 @@ func Test_SingleNodeConcurrentRequests(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			_, err = node.Execute(`INSERT INTO foo(name) VALUES("fiona")`)
+			resp, err := PostExecuteStmt(node.APIAddr, `INSERT INTO foo(name) VALUES("fiona")`)
 			if err != nil {
-				t.Fatalf("failed to insert record: %s", err.Error())
+				t.Fatalf("failed to insert record: %s %s", err.Error(), resp)
 			}
 		}()
 	}


### PR DESCRIPTION
The GZIP writer was being shared -- incorrectly -- by multiple HTTP requests (both queries and executes). But it's not thread safe. Bad, bad, bad.

https://github.com/rqlite/rqlite/issues/781