### PR TITLE
Remove 'redirect' from HTTP status

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -532,9 +532,8 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httpStatus := map[string]interface{}{
-		"addr":     s.Addr().String(),
-		"auth":     prettyEnabled(s.credentialStore != nil),
-		"redirect": s.LeaderAPIAddr(),
+		"addr": s.Addr().String(),
+		"auth": prettyEnabled(s.credentialStore != nil),
 	}
 
 	nodeStatus := map[string]interface{}{

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -353,6 +353,7 @@ class TestSingleNode(unittest.TestCase):
       t+=1
 
 class TestIdempotentJoin(unittest.TestCase):
+    '''Test that a node performing two join requests works fine'''
   def tearDown(self):
     deprovision_node(self.n0)
     deprovision_node(self.n1)

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -353,12 +353,12 @@ class TestSingleNode(unittest.TestCase):
       t+=1
 
 class TestIdempotentJoin(unittest.TestCase):
-    '''Test that a node performing two join requests works fine'''
   def tearDown(self):
     deprovision_node(self.n0)
     deprovision_node(self.n1)
 
   def test(self):
+    '''Test that a node performing two join requests works fine'''
     self.n0 = Node(RQLITED_PATH, '0')
     self.n0.start()
     self.n0.wait_for_leader()


### PR DESCRIPTION
Getting the redirect information requires accessing other nodes, which could block if those nodes are not up.