### PR TITLE
Remove support for specifying SQLite DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.3 (unreleased)
+- [PR #841](https://github.com/rqlite/rqlite/pull/841): Remove support for specifying SQLite DSN.
+
 ## 6.0.2 (July 31st 2021)
 This release addresses a significant issue related to SQLite connection handling and multithreading. All users should upgrade to this version.
 

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -61,7 +61,6 @@ var discoURL string
 var discoID string
 var expvar bool
 var pprofEnabled bool
-var dsn string
 var onDisk bool
 var raftLogLevel string
 var raftNonVoter bool
@@ -109,7 +108,6 @@ func init() {
 	flag.StringVar(&discoID, "disco-id", "", "Set Discovery ID. If not set, Discovery Service not used")
 	flag.BoolVar(&expvar, "expvar", true, "Serve expvar data on HTTP server")
 	flag.BoolVar(&pprofEnabled, "pprof", true, "Serve pprof data on HTTP server")
-	flag.StringVar(&dsn, "dsn", "", `SQLite DSN parameters. E.g. "cache=shared&mode=memory"`)
 	flag.BoolVar(&onDisk, "on-disk", false, "Use an on-disk SQLite database")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&raftNonVoter, "raft-non-voter", false, "Configure as non-voting node")
@@ -197,7 +195,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to determine absolute data path: %s", err.Error())
 	}
-	dbConf := store.NewDBConfig(dsn, !onDisk)
+	dbConf := store.NewDBConfig(!onDisk)
 
 	str := store.New(raftTn, &store.StoreConfig{
 		DBConf: dbConf,

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -120,7 +120,7 @@ func Test_LoadInMemory(t *testing.T) {
 		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
 	}
 
-	inmem, err := LoadInMemoryWithDSN(path, "")
+	inmem, err := LoadInMemory(path)
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}
@@ -135,7 +135,7 @@ func Test_LoadInMemory(t *testing.T) {
 	}
 }
 
-func Test_DeserializeInMemoryWithDSN(t *testing.T) {
+func Test_DeserializeInMemory(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
 	defer os.Remove(path)
@@ -174,7 +174,7 @@ func Test_DeserializeInMemoryWithDSN(t *testing.T) {
 		t.Fatalf("failed to read database on disk: %s", err.Error())
 	}
 
-	newDB, err := DeserializeInMemoryWithDSN(b, "")
+	newDB, err := DeserializeInMemory(b)
 	if err != nil {
 		t.Fatalf("failed to deserialize database: %s", err.Error())
 	}
@@ -1170,7 +1170,7 @@ func Test_DumpMemory(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(path)
 
-	inmem, err := LoadInMemoryWithDSN(path, "")
+	inmem, err := LoadInMemory(path)
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}

--- a/store/db_config.go
+++ b/store/db_config.go
@@ -2,11 +2,10 @@ package store
 
 // DBConfig represents the configuration of the underlying SQLite database.
 type DBConfig struct {
-	DSN    string // Any custom DSN
-	Memory bool   // Whether the database is in-memory only.
+	Memory bool // Whether the database is in-memory only.
 }
 
 // NewDBConfig returns a new DB config instance.
-func NewDBConfig(dsn string, memory bool) *DBConfig {
-	return &DBConfig{DSN: dsn, Memory: memory}
+func NewDBConfig(memory bool) *DBConfig {
+	return &DBConfig{Memory: memory}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -464,7 +464,6 @@ func (s *Store) Stats() (map[string]interface{}, error) {
 		return nil, err
 	}
 	dbStatus := map[string]interface{}{
-		"dsn":             s.dbConf.DSN,
 		"fk_constraints":  enabledFromBool(fkEnabled),
 		"version":         sql.DBVersion,
 		"db_size":         dbSz,
@@ -755,9 +754,9 @@ func (s *Store) Noop(id string) error {
 // database will be initialized with the contents of b.
 func (s *Store) createInMemory(b []byte) (db *sql.DB, err error) {
 	if b == nil {
-		db, err = sql.OpenInMemoryWithDSN(s.dbConf.DSN)
+		db, err = sql.OpenInMemory()
 	} else {
-		db, err = sql.DeserializeInMemoryWithDSN(b, s.dbConf.DSN)
+		db, err = sql.DeserializeInMemory(b)
 	}
 	return
 }
@@ -774,7 +773,7 @@ func (s *Store) createOnDisk(b []byte) (*sql.DB, error) {
 			return nil, err
 		}
 	}
-	return sql.OpenWithDSN(s.dbPath, s.dbConf.DSN)
+	return sql.Open(s.dbPath)
 }
 
 // setLogInfo records some key indexs about the log.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1157,7 +1157,7 @@ func Test_State(t *testing.T) {
 }
 
 func mustNewStoreAtPath(path string, inmem bool) *Store {
-	cfg := NewDBConfig("", inmem)
+	cfg := NewDBConfig(inmem)
 	s := New(mustMockLister("localhost:0"), &StoreConfig{
 		DBConf: cfg,
 		Dir:    path,

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -478,7 +478,7 @@ func mustNodeEncryptedOnDisk(dir string, enableSingle, httpEncrypt bool, mux *tc
 		HTTPKeyPath:  httpKeyPath,
 	}
 
-	dbConf := store.NewDBConfig("", !onDisk)
+	dbConf := store.NewDBConfig(!onDisk)
 
 	raftTn := mux.Listen(cluster.MuxRaftHeader)
 	id := nodeID


### PR DESCRIPTION
This is a breaking change. However this feature hasn't been tested and allows end-users to break the system too easily. Low-level control over the SQLite database is better done with PRAGMA commands where possible.