### PR TITLE
Support true concurrent queries via vfs=memdb

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -93,25 +93,14 @@ type Rows struct {
 
 // Open opens a file-based database, creating it if it does not exist.
 func Open(dbPath string) (*DB, error) {
-	rwOpts := strings.Join(
-		[]string{
-			"mode=rw",
-		}, "&")
-
-	rwDB, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?%s", dbPath, rwOpts))
+	rwDB, err := sql.Open("sqlite3", fmt.Sprintf("file:%s", dbPath))
 	if err != nil {
 		return nil, err
 	}
 
 	// XXX NOT SURE IF WAL WILL WORK. SIMPLY COPYING THE DATABASE FILE
 	// WONT GET THE ENTIRE DATABASE. CAN WAL COMPACT BE FORCED?
-
-	roOpts := strings.Join(
-		[]string{
-			"mode=ro",
-		}, "&")
-
-	roDB, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?%s", dbPath, roOpts))
+	roDB, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", dbPath))
 	if err != nil {
 		return nil, err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -273,17 +273,6 @@ func (db *DB) Stats() (map[string]interface{}, error) {
 	return stats, nil
 }
 
-// EnableFKConstraints allows control of foreign key constraint checks.
-func (db *DB) EnableFKConstraints(e bool) error {
-	q := fkChecksEnabled
-	if !e {
-		q = fkChecksDisabled
-	}
-
-	_, err := db.ExecuteStringStmt(q)
-	return err
-}
-
 // Size returns the size of the database in bytes. "Size" is defined as
 // page_count * schema.page_size.
 func (db *DB) Size() (int64, error) {

--- a/db/db.go
+++ b/db/db.go
@@ -254,7 +254,6 @@ func (db *DB) Stats() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(">>>", db.rwDSN)
 	stats := map[string]interface{}{
 		"version":         DBVersion,
 		"db_size":         dbSz,

--- a/db/db.go
+++ b/db/db.go
@@ -784,5 +784,5 @@ func randomInMemoryDB() string {
 		randomChar := chars[random]
 		output.WriteString(string(randomChar))
 	}
-	return fmt.Sprintf("file:%s?mode=memory", output.String())
+	return fmt.Sprintf("file:/%s?vfs=memdb", output.String())
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -102,7 +102,7 @@ func Test_SQLiteMasterTable(t *testing.T) {
 	}
 }
 
-func Test_LoadInMemory(t *testing.T) {
+func Test_LoadIntoMemory(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
 	defer os.Remove(path)
@@ -120,7 +120,7 @@ func Test_LoadInMemory(t *testing.T) {
 		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
 	}
 
-	inmem, err := LoadInMemory(path)
+	inmem, err := LoadIntoMemory(path)
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}
@@ -135,7 +135,7 @@ func Test_LoadInMemory(t *testing.T) {
 	}
 }
 
-func Test_DeserializeInMemory(t *testing.T) {
+func Test_DeserializeIntoMemory(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
 	defer os.Remove(path)
@@ -174,7 +174,7 @@ func Test_DeserializeInMemory(t *testing.T) {
 		t.Fatalf("failed to read database on disk: %s", err.Error())
 	}
 
-	newDB, err := DeserializeInMemory(b)
+	newDB, err := DeserializeIntoMemory(b)
 	if err != nil {
 		t.Fatalf("failed to deserialize database: %s", err.Error())
 	}
@@ -709,89 +709,6 @@ func Test_CommonTableExpressions(t *testing.T) {
 	}
 }
 
-func Test_ForeignKeyConstraints(t *testing.T) {
-	db, path := mustCreateDatabase()
-	defer db.Close()
-	defer os.Remove(path)
-
-	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, ref INTEGER REFERENCES foo(id))")
-	if err != nil {
-		t.Fatalf("failed to create table: %s", err.Error())
-	}
-
-	// Explicitly disable constraints.
-	if err := db.EnableFKConstraints(false); err != nil {
-		t.Fatalf("failed to enable foreign key constraints: %s", err.Error())
-	}
-
-	// Check constraints
-	fk, err := db.FKConstraints()
-	if err != nil {
-		t.Fatalf("failed to check FK constraints: %s", err.Error())
-	}
-	if fk != false {
-		t.Fatal("FK constraints are not disabled")
-	}
-
-	r, err := db.ExecuteStringStmt(`INSERT INTO foo(id, ref) VALUES(1, 2)`)
-	if err != nil {
-		t.Fatalf("failed to execute FK test statement: %s", err.Error())
-	}
-	if exp, got := `[{"last_insert_id":1,"rows_affected":1}]`, asJSON(r); exp != got {
-		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
-	}
-
-	// Explicitly enable constraints.
-	if err := db.EnableFKConstraints(true); err != nil {
-		t.Fatalf("failed to enable foreign key constraints: %s", err.Error())
-	}
-
-	// Check constraints
-	fk, err = db.FKConstraints()
-	if err != nil {
-		t.Fatalf("failed to check FK constraints: %s", err.Error())
-	}
-	if fk != true {
-		t.Fatal("FK constraints are not enabled")
-	}
-
-	r, err = db.ExecuteStringStmt(`INSERT INTO foo(id, ref) VALUES(1, 3)`)
-	if err != nil {
-		t.Fatalf("failed to execute FK test statement: %s", err.Error())
-	}
-	if exp, got := `[{"error":"UNIQUE constraint failed: foo.id"}]`, asJSON(r); exp != got {
-		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
-	}
-}
-
-func Test_JournalMode(t *testing.T) {
-	db, path := mustCreateDatabase()
-	defer db.Close()
-	defer os.Remove(path)
-
-	m, err := db.JournalMode()
-	if err != nil {
-		t.Fatalf("failed to check journal mode: %s", err.Error())
-	}
-	if exp, got := "delete", m; exp != got {
-		t.Fatalf("got wrong mode for journal, expected %s, got %s", exp, got)
-	}
-
-	_, err = db.ExecuteStringStmt(`PRAGMA journal_mode=off`)
-	if err != nil {
-		t.Fatalf(`failed to execute 'PRAGMA journal_mode' statement: %s`, err.Error())
-	}
-
-	m, err = db.JournalMode()
-	if err != nil {
-		t.Fatalf("failed to check journal mode: %s", err.Error())
-	}
-	if exp, got := "off", m; exp != got {
-		t.Fatalf("got wrong mode for journal, expected %s, got %s", exp, got)
-	}
-
-}
-
 func Test_UniqueConstraints(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
@@ -1170,7 +1087,7 @@ func Test_DumpMemory(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(path)
 
-	inmem, err := LoadInMemory(path)
+	inmem, err := LoadIntoMemory(path)
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -593,7 +593,7 @@ func Test_WriteOnQueryOnDiskDatabase(t *testing.T) {
 
 	_, err = db.QueryStringStmt(`INSERT INTO foo(id, name) VALUES(2, "fiona")`)
 	if err == nil {
-		t.Fatalf("no error attempting to write to read-only database")
+		t.Fatalf("no error attempting to write using read-only database connection")
 	}
 
 	ro, err := db.QueryStringStmt(`SELECT COUNT(*) FROM foo`)
@@ -627,7 +627,7 @@ func Test_WriteOnQueryInMemDatabase(t *testing.T) {
 
 	_, err = db.QueryStringStmt(`INSERT INTO foo(id, name) VALUES(2, "fiona")`)
 	if err == nil {
-		t.Fatalf("no error attempting to write to read-only database")
+		t.Fatalf("no error attempting to write using read-only database connection")
 	}
 
 	ro, err := db.QueryStringStmt(`SELECT COUNT(*) FROM foo`)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -682,8 +682,8 @@ func Test_ConcurrentQueriesInMemory(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < 32; i++ {
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 			ro, err := db.QueryStringStmt(`SELECT COUNT(*) FROM foo`)
 			if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -639,7 +639,8 @@ func (s *Store) Query(qr *command.QueryRequest) ([]*sql.Rows, error) {
 		return nil, ErrStaleRead
 	}
 
-	return s.db.Query(qr.Request, qr.Timings)
+	rows, err := s.db.Query(qr.Request, qr.Timings)
+	return rows, err
 }
 
 // Join joins a node, identified by id and located at addr, to this store.

--- a/store/store.go
+++ b/store/store.go
@@ -450,25 +450,14 @@ func (s *Store) WaitForAppliedIndex(idx uint64, timeout time.Duration) error {
 
 // Stats returns stats for the store.
 func (s *Store) Stats() (map[string]interface{}, error) {
-	fkEnabled, err := s.db.FKConstraints()
-	if err != nil {
-		return nil, err
-	}
-
 	dbSz, err := s.db.Size()
 	if err != nil {
 		return nil, err
 	}
-	jm, err := s.db.JournalMode()
-	if err != nil {
-		return nil, err
-	}
 	dbStatus := map[string]interface{}{
-		"fk_constraints":  enabledFromBool(fkEnabled),
 		"version":         sql.DBVersion,
 		"db_size":         dbSz,
 		"conn_pool_stats": s.db.ConnectionPoolStats(),
-		"journal_mode":    jm,
 	}
 	if s.dbConf.Memory {
 		dbStatus["path"] = ":memory:"
@@ -756,7 +745,7 @@ func (s *Store) createInMemory(b []byte) (db *sql.DB, err error) {
 	if b == nil {
 		db, err = sql.OpenInMemory()
 	} else {
-		db, err = sql.DeserializeInMemory(b)
+		db, err = sql.DeserializeIntoMemory(b)
 	}
 	return
 }

--- a/store/store.go
+++ b/store/store.go
@@ -450,24 +450,9 @@ func (s *Store) WaitForAppliedIndex(idx uint64, timeout time.Duration) error {
 
 // Stats returns stats for the store.
 func (s *Store) Stats() (map[string]interface{}, error) {
-	dbSz, err := s.db.Size()
+	dbStatus, err := s.db.Stats()
 	if err != nil {
 		return nil, err
-	}
-	dbStatus := map[string]interface{}{
-		"version":         sql.DBVersion,
-		"db_size":         dbSz,
-		"conn_pool_stats": s.db.ConnectionPoolStats(),
-	}
-	if s.dbConf.Memory {
-		dbStatus["path"] = ":memory:"
-	} else {
-		dbStatus["path"] = s.dbPath
-		if s.onDiskCreated {
-			if dbStatus["size"], err = s.db.FileSize(); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	nodes, err := s.Nodes()

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -12,6 +12,28 @@ import (
 	"time"
 )
 
+func Test_SingleNodeBasicEndpoint(t *testing.T) {
+	node := mustNewLeaderNode()
+	defer node.Deprovision()
+
+	// Ensure accessing endpoints in basic manner works
+	_, err := node.Status()
+	if err != nil {
+		t.Fatalf(`failed to retrieve status for in-memory: %s`, err)
+	}
+
+	dir := mustTempDir()
+	mux := mustNewOpenMux("")
+	node = mustNodeEncryptedOnDisk(dir, true, false, mux, "", false)
+	if _, err := node.WaitForLeader(); err != nil {
+		t.Fatalf("node never became leader")
+	}
+	_, err = node.Status()
+	if err != nil {
+		t.Fatalf(`failed to retrieve status for on-disk: %s`, err)
+	}
+}
+
 func Test_SingleNode(t *testing.T) {
 	node := mustNewLeaderNode()
 	defer node.Deprovision()

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -262,14 +262,19 @@ func Test_SingleNodeSQLInjection(t *testing.T) {
 			execute:  true,
 		},
 		{
-			stmt:     `SELECT * FROM foo WHERE name="baz"`,
+			stmt:     `CREATE TABLE bar (id integer not null primary key, name text)`,
+			expected: `{"results":[{}]}`,
+			execute:  true,
+		},
+		{
+			stmt:     `SELECT * FROM foo`,
 			expected: `{"results":[{"columns":["id","name"],"types":["integer","text"]}]}`,
 			execute:  false,
 		},
 		{
-			stmt:     fmt.Sprintf(`SELECT * FROM foo WHERE name=%s`, `"baz";DROP TABLE FOO`),
-			expected: `{"results":[{}]}`,
-			execute:  false,
+			stmt:     fmt.Sprintf(`INSERT INTO foo(name) VALUES(%s)`, `"alice");DROP TABLE foo;INSERT INTO bar(name) VALUES("bob"`),
+			expected: `{"results":[{"last_insert_id":1,"rows_affected":1}]}`,
+			execute:  true,
 		},
 		{
 			stmt:     `SELECT * FROM foo`,


### PR DESCRIPTION
Implement the design proposal from @rittneje in https://github.com/mattn/go-sqlite3/issues/959#issuecomment-890371852

This provides correct, true concurrent reads of an in-memory database.