### PR TITLE
Set timeout when fetching node API address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.1 (unreleased)
+### Implementation changes and bug fixes
+- [PR #879](https://github.com/rqlite/rqlite/pull/879): Set timeout when fetching node API address.
+
 ## 6.4.0 (August 31st 2021)
 ### New features
 - [PR #878](https://github.com/rqlite/rqlite/pull/878): CLI supports setting read consistency level.

--- a/cluster/service_mux_test.go
+++ b/cluster/service_mux_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/rqlite/rqlite/tcp"
 	"github.com/rqlite/rqlite/testdata/x509"
@@ -28,7 +29,7 @@ func Test_NewServiceSetGetNodeAPIAddrMuxed(t *testing.T) {
 
 	c := NewClient(mustNewDialer(1, false, false))
 
-	addr, err := c.GetNodeAPIAddr(s.Addr())
+	addr, err := c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}
@@ -62,7 +63,7 @@ func Test_NewServiceSetGetNodeAPIAddrMuxedTLS(t *testing.T) {
 
 	c := NewClient(mustNewDialer(1, true, true))
 
-	addr, err := c.GetNodeAPIAddr(s.Addr())
+	addr, err := c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -65,7 +65,7 @@ func Test_NewServiceSetGetNodeAPIAddr(t *testing.T) {
 
 	// Test by connecting to itself.
 	c := NewClient(ml)
-	addr, err := c.GetNodeAPIAddr(s.Addr())
+	addr, err := c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}
@@ -76,7 +76,7 @@ func Test_NewServiceSetGetNodeAPIAddr(t *testing.T) {
 	s.EnableHTTPS(true)
 
 	// Test fetch via network.
-	addr, err = c.GetNodeAPIAddr(s.Addr())
+	addr, err = c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}
@@ -118,7 +118,7 @@ func Test_NewServiceSetGetNodeAPIAddrLocal(t *testing.T) {
 	if err := c.SetLocal(s.Addr(), s); err != nil {
 		t.Fatalf("failed to set cluster client local parameters: %s", err)
 	}
-	addr, err := c.GetNodeAPIAddr(s.Addr())
+	addr, err := c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address locally: %s", err)
 	}
@@ -139,7 +139,7 @@ func Test_NewServiceSetGetNodeAPIAddrLocal(t *testing.T) {
 	if err := c.SetLocal(net.JoinHostPort("localhost", port), s); err != nil {
 		t.Fatalf("failed to set cluster client local parameters: %s", err)
 	}
-	addr, err = c.GetNodeAPIAddr(s.Addr())
+	addr, err = c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address locally: %s", err)
 	}
@@ -169,7 +169,7 @@ func Test_NewServiceSetGetNodeAPIAddrTLS(t *testing.T) {
 
 	// Test by connecting to itself.
 	c := NewClient(ml)
-	addr, err := c.GetNodeAPIAddr(s.Addr())
+	addr, err := c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}
@@ -179,7 +179,7 @@ func Test_NewServiceSetGetNodeAPIAddrTLS(t *testing.T) {
 	}
 
 	s.EnableHTTPS(true)
-	addr, err = c.GetNodeAPIAddr(s.Addr())
+	addr, err = c.GetNodeAPIAddr(s.Addr(), 5*time.Second)
 	if err != nil {
 		t.Fatalf("failed to get node API address: %s", err)
 	}

--- a/http/service.go
+++ b/http/service.go
@@ -72,7 +72,7 @@ type Store interface {
 // Cluster is the interface node API services must provide
 type Cluster interface {
 	// GetNodeAPIAddr returns the HTTP API URL for the node at the given Raft address.
-	GetNodeAPIAddr(nodeAddr string) (string, error)
+	GetNodeAPIAddr(nodeAddr string, timeout time.Duration) (string, error)
 
 	// Execute performs an Execute Request on a remote node.
 	Execute(er *command.ExecuteRequest, nodeAddr string, timeout time.Duration) ([]*command.ExecuteResult, error)
@@ -142,7 +142,7 @@ const (
 	numAuthOK           = "authOK"
 	numAuthFail         = "authFail"
 
-	// Default timeout for request forwarding
+	// Default timeout for cluster communications.
 	defaulTimeout = 30 * time.Second
 
 	// PermAll means all actions permitted.
@@ -981,7 +981,7 @@ func (s *Service) LeaderAPIAddr() string {
 		return ""
 	}
 
-	apiAddr, err := s.cluster.GetNodeAPIAddr(nodeAddr)
+	apiAddr, err := s.cluster.GetNodeAPIAddr(nodeAddr, defaulTimeout)
 
 	if err != nil {
 		return ""
@@ -1016,7 +1016,7 @@ func (s *Service) checkNodes(nodes []*store.Server, timeout time.Duration) (map[
 			defer mu.Unlock()
 
 			start := time.Now()
-			apiAddr, err := s.cluster.GetNodeAPIAddr(raftAddr)
+			apiAddr, err := s.cluster.GetNodeAPIAddr(raftAddr, defaulTimeout)
 			if err != nil {
 				resp[id].error = err.Error()
 				return

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -943,7 +943,7 @@ type mockClusterService struct {
 	queryFn   func(qr *command.QueryRequest, addr string, t time.Duration) ([]*command.QueryRows, error)
 }
 
-func (m *mockClusterService) GetNodeAPIAddr(a string) (string, error) {
+func (m *mockClusterService) GetNodeAPIAddr(a string, t time.Duration) (string, error) {
 	return m.apiAddr, nil
 }
 


### PR DESCRIPTION
Deal with intermittent timeout errors during performance measurement on public clouds.

This should be user-configurable in a future release to address https://github.com/rqlite/rqlite/issues/801.