### PR TITLE
Upgrade dependencies, rqlite/go-sqlite3 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.2 (unreleased)
+### Implementation changes and bug fixes
+- [PR #880](https://github.com/rqlite/rqlite/pull/880): Increase maximum in-memory database size to 2GiB, via upgraded dependencies.
+
 ## 6.4.1 (August 31st 2021)
 ### Implementation changes and bug fixes
 - [PR #879](https://github.com/rqlite/rqlite/pull/879): Set timeout when fetching node API address.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ No.
 Since the Raft log is the authoritative store for all data, and it is stored on disk by each node, an in-memory database can be fully recreated on start-up from the information stored in the Raft log. Using an in-memory database does not put your data at risk.
 
 ## Limitations
+ * In-memory databases are currently limited to 2GiB (2147483648 bytes) in size. Future releases may support larger databases.
+
  * Only SQL statements that are [__deterministic__](https://www.sqlite.org/deterministic.html) are safe to use with rqlite, because statements are committed to the Raft log before they are sent to each node. In other words, rqlite performs _statement-based replication_. For example, the following statement could result in a different SQLite database under each node:
 ```
 INSERT INTO foo (n) VALUES(random());

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ No.
 Since the Raft log is the authoritative store for all data, and it is stored on disk by each node, an in-memory database can be fully recreated on start-up from the information stored in the Raft log. Using an in-memory database does not put your data at risk.
 
 ## Limitations
- * In-memory databases are currently limited to 2GiB (2147483648 bytes) in size. Future releases may support larger databases.
+ * In-memory databases are currently limited to 2GiB (2147483648 bytes) in size. Future releases may support larger in-memory databases.
 
  * Only SQL statements that are [__deterministic__](https://www.sqlite.org/deterministic.html) are safe to use with rqlite, because statements are committed to the Raft log before they are sent to each node. In other words, rqlite performs _statement-based replication_. For example, the following statement could result in a different SQLite database under each node:
 ```

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1435,7 +1435,7 @@ func Test_1GiBInMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get size: %s", err.Error())
 	}
-	if sz <= 1073741824 {
+	if sz <= 1024*1024*1024 {
 		t.Fatalf("failed to create a database greater than 1 GiB in size: %d", sz)
 	}
 }

--- a/db/testdata/text.go
+++ b/db/testdata/text.go
@@ -1,0 +1,3 @@
+package text
+
+const Lorum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ultricies turpis nisi, quis egestas enim scelerisque sit amet. Maecenas id massa tempus, pellentesque metus sit amet, faucibus ex. Fusce velit lacus, eleifend sit amet semper vitae, varius nec odio. Vestibulum dignissim massa sem, quis elementum nibh sodales ac. Mauris eget pretium diam. Praesent non diam mauris. Suspendisse finibus non purus non condimentum. In hac habitasse platea dictumst. Quisque vitae nibh justo. Aliquam tempus eget diam at commodo. Aenean nec sem leo. Cras bibendum, quam eu elementum laoreet, turpis orci bibendum arcu, id euismod justo dolor a augue"

--- a/go.mod
+++ b/go.mod
@@ -22,10 +22,10 @@ require (
 	github.com/mkideal/cli v0.2.7
 	github.com/mkideal/log v1.0.0 // indirect
 	github.com/mkideal/pkg v0.1.3
-	github.com/rqlite/go-sqlite3 v1.21.0
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+	github.com/rqlite/go-sqlite3 v1.22.0
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/rqlite/go-sqlite3 v1.20.4 h1:w16wwylR8qTJ+NWXLbXc8C7SNbljuRwOscBKZMz9
 github.com/rqlite/go-sqlite3 v1.20.4/go.mod h1:ml55MVv28UP7V8zrxILd2EsrI6Wfsz76YSskpg08Ut4=
 github.com/rqlite/go-sqlite3 v1.21.0 h1:YTeeVH5olioCnR8WzdL1qcmM8lN5xfYZ++E2YGI3tAc=
 github.com/rqlite/go-sqlite3 v1.21.0/go.mod h1:ml55MVv28UP7V8zrxILd2EsrI6Wfsz76YSskpg08Ut4=
+github.com/rqlite/go-sqlite3 v1.22.0 h1:twqvKzylJXG62Qe0rcqdy5ClGhc0YRc2vvA3nEXwmes=
+github.com/rqlite/go-sqlite3 v1.22.0/go.mod h1:ml55MVv28UP7V8zrxILd2EsrI6Wfsz76YSskpg08Ut4=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -278,6 +280,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -340,6 +344,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828 h1:htWEtQEuEVJ4tU/Ngx7Cd/4Q7e3A5Up1owgyBtVsTwk=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=


### PR DESCRIPTION
Support in-memory databases up to 2GiB in size. See https://sqlite.org/forum/forumpost/b1ba232667130afa?t=h.