### PR TITLE
Serialize on-disk databases by simply reading SQLite file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Implementation changes and bug fixes
 - [PR #882](https://github.com/rqlite/rqlite/pull/882): Some minor improvements related to on-disk SQLite use.
 - [PR #883](https://github.com/rqlite/rqlite/pull/883): Add missing returns after HTTP errors.
+- [PR #884](https://github.com/rqlite/rqlite/pull/884): Serialize on-disk databases by simply reading SQLite file.
 
 ## 6.4.2 (September 1st 2021)
 ### Implementation changes and bug fixes

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1492,7 +1492,9 @@ func Test_1GiBInMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to insert record %s", err.Error())
 	}
-	fmt.Println(r)
+	if exp, got := `[{"last_insert_id":1715018,"rows_affected":1}]`, asJSON(r); exp != got {
+		t.Fatalf("got incorrect response, exp: %s, got: %s", exp, got)
+	}
 
 	sz, err := db.Size()
 	if err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1286,10 +1286,73 @@ func Test_Copy(t *testing.T) {
 	}
 }
 
-func Test_Serialize(t *testing.T) {
+func Test_SerializeOnDisk(t *testing.T) {
 	db, path := mustCreateDatabase()
 	defer db.Close()
 	defer os.Remove(path)
+
+	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+
+	req := &command.Request{
+		Transaction: true,
+		Statements: []*command.Statement{
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(2, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(3, "fiona")`,
+			},
+			{
+				Sql: `INSERT INTO foo(id, name) VALUES(4, "fiona")`,
+			},
+		},
+	}
+	_, err = db.Execute(req, false)
+	if err != nil {
+		t.Fatalf("failed to insert records: %s", err.Error())
+	}
+
+	dstDB, err := ioutil.TempFile("", "rqlite-bak-")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err.Error())
+	}
+	dstDB.Close()
+	defer os.Remove(dstDB.Name())
+
+	// Get the bytes, and write to a temp file.
+	b, err := db.Serialize()
+	if err != nil {
+		t.Fatalf("failed to serialize database: %s", err.Error())
+	}
+	err = ioutil.WriteFile(dstDB.Name(), b, 0644)
+	if err != nil {
+		t.Fatalf("failed to write serialized database to file: %s", err.Error())
+	}
+
+	newDB, err := Open(dstDB.Name(), false)
+	if err != nil {
+		t.Fatalf("failed to open on-disk serialized database: %s", err.Error())
+	}
+	defer newDB.Close()
+	defer os.Remove(dstDB.Name())
+	ro, err := newDB.QueryStringStmt(`SELECT * FROM foo`)
+	if err != nil {
+		t.Fatalf("failed to query table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"fiona"],[3,"fiona"],[4,"fiona"]]}]`, asJSON(ro); exp != got {
+		t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+	}
+}
+
+func Test_SerializeInMemory(t *testing.T) {
+	db := mustCreateInMemoryDatabase()
+	defer db.Close()
 
 	_, err := db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -826,10 +826,10 @@ func (s *Store) Noop(id string) error {
 	return nil
 }
 
-// createInMemory returns an in-memory database. If b is non-nil, then the
-// database will be initialized with the contents of b.
+// createInMemory returns an in-memory database. If b is non-nil and non-empty,
+// then the database will be initialized with the contents of b.
 func (s *Store) createInMemory(b []byte) (db *sql.DB, err error) {
-	if b == nil {
+	if b == nil || len(b) == 0 {
 		db, err = sql.OpenInMemory(s.dbConf.FKConstraints)
 	} else {
 		db, err = sql.DeserializeIntoMemory(b, s.dbConf.FKConstraints)


### PR DESCRIPTION
This is safe according to https://sqlite.org/howtocorrupt.html and avoids any sqlite3_serialize() limitations.