### PR TITLE
Start the HTTP server before doing any joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [PR #889](https://github.com/rqlite/rqlite/pull/889): Add OS-level information to `status/` output.
 - [PR #892](https://github.com/rqlite/rqlite/pull/892): More Snapshot metrics.
 - [PR #894](https://github.com/rqlite/rqlite/pull/894): Support controlling timeout on nodes/ endpoint.
+- [PR #895](https://github.com/rqlite/rqlite/pull/895): Start HTTP service before attempting any join operation.
 
 ## 6.4.3 (September 8th 2021)
 ### Implementation changes and bug fixes

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -161,7 +161,7 @@ class Node(object):
   def wait_for_leader(self, timeout=TIMEOUT):
     lr = None
     t = 0
-    while lr == None or lr is '':
+    while lr == None or lr['addr'] == '':
       if t > timeout:
         raise Exception('timeout')
       lr = self.status()['store']['leader']


### PR DESCRIPTION
There is no point waiting for join operations to complete before starting the HTTP server. In the event the join fails it just introduces delays due to join-retrys. The HTTP API service is meant to be robust in the face of a non-ready underlying Store anyway.