### PR TITLE
Support recovering clusters that have permanently lost quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.6.0 (unreleased)
+### New features
+- [PR #898](https://github.com/rqlite/rqlite/pull/898): Support recovering clusters that have permanently lost quorum. Fixes [issue #897](https://github.com/rqlite/rqlite/issues/897).
+
 ## 6.5.0 (September 12th 2021)
 ### New features
 - [PR #896](https://github.com/rqlite/rqlite/pull/896): Add `/readyz` endpoint for easy ready-to-respond checks.

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -109,6 +109,7 @@ With a 5-node cluster, the cluster can tolerate the failure of 2 nodes. However 
 
 # Recovering a cluster after an outage
 _This section borrows heavily from the Consul documentation._
+
 In the event that multiple rqlite nodes are lost, causing a loss of quorum and a complete outage, partial recovery is possible using data on the remaining nodes in the cluster. There may be data loss in this situation because multiple servers were lost, so information about what's committed could be incomplete. The recovery process implicitly commits all outstanding Raft log entries, so it's also possible to commit data -- and therefore change the SQLite database -- that was uncommitted before the failure.
 
 You must also follow the recovery process if a cluster simply restarts, but all nodes (or a quorum) come up with different IP addresses. This can happen in certain deployment configurations.

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -106,3 +106,35 @@ The situation is similar for a 3-node cluster, in the sense that it can only tol
 Quorum of a 5-node cluster is 3.
 
 With a 5-node cluster, the cluster can tolerate the failure of 2 nodes. However if 3 nodes fail, at least one of those nodes must be restarted before you can make any change. If you remove a single node from a fully-functional 5-node cluster, quorum will be unchanged since you now have a 4-node cluster.
+
+# Recovering a cluster after an outage
+_This section borrows heavily from the Consul documentation._
+In the event that multiple rqlite nodes are lost, causing a loss of quorum and a complete outage, partial recovery is possible using data on the remaining nodes in the cluster. There may be data loss in this situation because multiple servers were lost, so information about what's committed could be incomplete. The recovery process implicitly commits all outstanding Raft log entries, so it's also possible to commit data -- and therefore change the SQLite database -- that was uncommitted before the failure.
+
+You must also follow the recovery process if a cluster simply restarts, but all nodes (or a quorum) come up with different IP addresses. This can happen in certain deployment configurations.
+
+To begin, stop all remaining nodes. You can attempt a graceful node-removal, but it will not work in most cases. Do not worry if the leave exits with an error. The cluster is in an unhealthy state, so this is expected.
+
+The next step is to go to the _data_ directory of each rqlite node. Inside that directory, there will be a `raft/` sub-directory. You need to create a `peers.json` file within that directory, which will contain the desired configuration of your rqlite cluster. This file should be formatted as a JSON array containing the node ID, address:port, and suffrage information of each rqlite node in the cluster. An example is shown below:
+
+```json
+[
+  {
+    "id": "1",
+    "address": "10.1.0.1:8300",
+    "non_voter": false
+  },
+  {
+    "id": "2",
+    "address": "10.1.0.2:8300",
+    "non_voter": false
+  },
+  {
+    "id": "2",
+    "address": "10.1.0.3:8300",
+    "non_voter": false
+  }
+]
+```
+
+`id` specifies the node ID of the server. This can be found in the logs when the node starts up if it was auto-generated. `address` specifies the IP and port of the Raft address. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes. Simply create entries for all nodes. You must confirm that nodes you do not include here have indeed failed and will not later rejoin the cluster. Ensure that this file is the same across all remaining rqlite nodes. At this point, you can restart your rqlite cluster.

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -138,7 +138,7 @@ The next step is to go to the _data_ directory of each rqlite node. Inside that 
 ]
 ```
 
-`id` specifies the node ID of the server. This can be found in the logs when the node starts up if it was auto-generated. `address` specifies the IP and port of the Raft address. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes.
+`id` specifies the node ID of the server, which must not be changed from its previous value. The ID for a given node can be found in the logs when the node starts up if it was auto-generated. `address` specifies the desired Raft IP and port for the node, which does not need to be the same as previously. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes.
 
 Next simply create entries for all nodes. You must confirm that nodes you do not include here have indeed failed and will not later rejoin the cluster. Ensure that this file is the same across all remaining rqlite nodes. At this point, you can restart your rqlite cluster.
 

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -107,7 +107,7 @@ Quorum of a 5-node cluster is 3.
 
 With a 5-node cluster, the cluster can tolerate the failure of 2 nodes. However if 3 nodes fail, at least one of those nodes must be restarted before you can make any change. If you remove a single node from a fully-functional 5-node cluster, quorum will be unchanged since you now have a 4-node cluster.
 
-# Recovering a cluster after an outage
+# Recovering a cluster that has permanently lost quorum
 _This section borrows heavily from the Consul documentation._
 
 In the event that multiple rqlite nodes are lost, causing a loss of quorum and a complete outage, partial recovery is possible using data on the remaining nodes in the cluster. There may be data loss in this situation because multiple servers were lost, so information about what's committed could be incomplete. The recovery process implicitly commits all outstanding Raft log entries, so it's also possible to commit data -- and therefore change the SQLite database -- that was uncommitted before the failure.

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -141,3 +141,5 @@ The next step is to go to the _data_ directory of each rqlite node. Inside that 
 `id` specifies the node ID of the server. This can be found in the logs when the node starts up if it was auto-generated. `address` specifies the IP and port of the Raft address. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes.
 
 Next simply create entries for all nodes. You must confirm that nodes you do not include here have indeed failed and will not later rejoin the cluster. Ensure that this file is the same across all remaining rqlite nodes. At this point, you can restart your rqlite cluster.
+
+Once recovery is completed, the `peers.json` file is renamed to `peers.info`. `peers.info` will not trigger further recoveries, and simply acts as a record for future reference. It may be deleted at anytime.

--- a/DOC/CLUSTER_MGMT.md
+++ b/DOC/CLUSTER_MGMT.md
@@ -112,11 +112,11 @@ _This section borrows heavily from the Consul documentation._
 
 In the event that multiple rqlite nodes are lost, causing a loss of quorum and a complete outage, partial recovery is possible using data on the remaining nodes in the cluster. There may be data loss in this situation because multiple servers were lost, so information about what's committed could be incomplete. The recovery process implicitly commits all outstanding Raft log entries, so it's also possible to commit data -- and therefore change the SQLite database -- that was uncommitted before the failure.
 
-You must also follow the recovery process if a cluster simply restarts, but all nodes (or a quorum) come up with different IP addresses. This can happen in certain deployment configurations.
+**You must also follow the recovery process if a cluster simply restarts, but all nodes (or a quorum of nodes) come up with different IP addresses. This can happen in certain deployment configurations.**
 
-To begin, stop all remaining nodes. You can attempt a graceful node-removal, but it will not work in most cases. Do not worry if the leave exits with an error. The cluster is in an unhealthy state, so this is expected.
+To begin, stop all remaining nodes. You can attempt a graceful node-removal, but it will not work in most cases. Do not worry if the remove operation results in an error. The cluster is in an unhealthy state, so this is expected.
 
-The next step is to go to the _data_ directory of each rqlite node. Inside that directory, there will be a `raft/` sub-directory. You need to create a `peers.json` file within that directory, which will contain the desired configuration of your rqlite cluster. This file should be formatted as a JSON array containing the node ID, address:port, and suffrage information of each rqlite node in the cluster. An example is shown below:
+The next step is to go to the _data_ directory of each rqlite node. Inside that directory, there will be a `raft/` sub-directory. You need to create a `peers.json` file within that directory, which will contain the desired configuration of your rqlite cluster. This file should be formatted as a JSON array containing the node ID, `address:port`, and suffrage information of each rqlite node in the cluster. An example is shown below:
 
 ```json
 [
@@ -138,4 +138,6 @@ The next step is to go to the _data_ directory of each rqlite node. Inside that 
 ]
 ```
 
-`id` specifies the node ID of the server. This can be found in the logs when the node starts up if it was auto-generated. `address` specifies the IP and port of the Raft address. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes. Simply create entries for all nodes. You must confirm that nodes you do not include here have indeed failed and will not later rejoin the cluster. Ensure that this file is the same across all remaining rqlite nodes. At this point, you can restart your rqlite cluster.
+`id` specifies the node ID of the server. This can be found in the logs when the node starts up if it was auto-generated. `address` specifies the IP and port of the Raft address. `non_voter` controls whether the server is a read-only node. If omitted, it will default to false, which is typical for most rqlite nodes.
+
+Next simply create entries for all nodes. You must confirm that nodes you do not include here have indeed failed and will not later rejoin the cluster. Ensure that this file is the same across all remaining rqlite nodes. At this point, you can restart your rqlite cluster.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,7 @@ build_script:
   - go version
   - go get ./...
   - go build ./...
-  - cd store
-  - go test -run Test_SingleNodeRecoverNetworkChange
+  - go test ./...
 
 after_build:
   - 7z a rqlite-latest-win64.zip %GOPATH%\bin\rq*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ build_script:
   - go version
   - go get ./...
   - go build ./...
-  - go test ./...
+  - cd store
+  - go test -run Test_SingleNodeRecoverNetworkChange
 
 after_build:
   - 7z a rqlite-latest-win64.zip %GOPATH%\bin\rq*.exe

--- a/db/db.go
+++ b/db/db.go
@@ -208,14 +208,14 @@ func DeserializeIntoMemory(b []byte, fkEnabled bool) (retDB *DB, retErr error) {
 
 	// tmpDB will still be using memory in Go space, so tmpDB needs to be explicitly
 	// copied to a new database, which we create now.
-	db, err := OpenInMemory(fkEnabled)
+	retDB, err = OpenInMemory(fkEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("DeserializeIntoMemory: %s", err.Error())
 	}
 	defer func() {
 		// Don't leak a database if deserialization fails.
 		if retErr != nil {
-			db.Close()
+			retDB.Close()
 		}
 	}()
 
@@ -228,7 +228,7 @@ func DeserializeIntoMemory(b []byte, fkEnabled bool) (retDB *DB, retErr error) {
 		defer srcConn.Close()
 
 		// Now copy from tmp database to the database this function will return.
-		dbConn, err3 := db.rwDB.Conn(context.Background())
+		dbConn, err3 := retDB.rwDB.Conn(context.Background())
 		if err3 != nil {
 			return fmt.Errorf("DeserializeIntoMemory: %s", err.Error())
 		}
@@ -243,7 +243,7 @@ func DeserializeIntoMemory(b []byte, fkEnabled bool) (retDB *DB, retErr error) {
 		return nil, err
 	}
 
-	return db, nil
+	return retDB, nil
 }
 
 // Close closes the underlying database connection.

--- a/store/store.go
+++ b/store/store.go
@@ -276,7 +276,7 @@ func (s *Store) Open(enableBootstrap bool) error {
 
 	// Request to recover node?
 	if pathExists(s.peersPath) {
-		s.logger.Printf("%s exists, attempting node recovery", s.peersPath)
+		s.logger.Printf("attempting node recovery using %s", s.peersPath)
 		config, err := raft.ReadConfigJSON(s.peersPath)
 		if err != nil {
 			return fmt.Errorf("failed to read peers file: %s", err.Error())

--- a/store/store.go
+++ b/store/store.go
@@ -234,7 +234,7 @@ func (s *Store) Open(enableBootstrap bool) error {
 	}
 
 	s.logger.Printf("ensuring directory at %s exists", s.raftDir)
-	err := os.MkdirAll(s.raftDir, 0755)
+	err := os.MkdirAll(filepath.Dir(s.peersPath), 0755)
 	if err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -171,8 +171,9 @@ type Store struct {
 	numTrailingLogs uint64
 
 	// For whitebox testing
-	numNoops     int
-	numSnapshots int
+	numNoops       int
+	numSnapshotsMu sync.Mutex
+	numSnapshots   int
 }
 
 // IsNewNode returns whether a node using raftDir would be a brand new node.
@@ -1040,6 +1041,8 @@ func (s *Store) Database(leader bool) ([]byte, error) {
 // database as long as no transaction is in progress.
 func (s *Store) Snapshot() (raft.FSMSnapshot, error) {
 	defer func() {
+		s.numSnapshotsMu.Lock()
+		defer s.numSnapshotsMu.Unlock()
 		s.numSnapshots++
 	}()
 

--- a/store/store.go
+++ b/store/store.go
@@ -280,6 +280,8 @@ func (s *Store) Open(enableBootstrap bool) error {
 	// Request to recover node?
 	if pathExists(s.peersPath) {
 		s.logger.Printf("attempting node recovery using %s", s.peersPath)
+		b, err := os.ReadFile(s.peersPath)
+		fmt.Println(string(b))
 		config, err := raft.ReadConfigJSON(s.peersPath)
 		if err != nil {
 			return fmt.Errorf("failed to read peers file: %s", err.Error())

--- a/store/store.go
+++ b/store/store.go
@@ -280,8 +280,6 @@ func (s *Store) Open(enableBootstrap bool) error {
 	// Request to recover node?
 	if pathExists(s.peersPath) {
 		s.logger.Printf("attempting node recovery using %s", s.peersPath)
-		b, err := os.ReadFile(s.peersPath)
-		fmt.Println(string(b))
 		config, err := raft.ReadConfigJSON(s.peersPath)
 		if err != nil {
 			return fmt.Errorf("failed to read peers file: %s", err.Error())

--- a/store/store.go
+++ b/store/store.go
@@ -1279,6 +1279,7 @@ func RecoverNode(dataDir string, logger *log.Logger, logs raft.LogStore, stable 
 	if err != nil {
 		return fmt.Errorf("failed to list snapshots: %v", err)
 	}
+	logger.Printf("recovery detected %d snapshots", len(snapshots))
 
 	var b []byte
 	for _, snapshot := range snapshots {
@@ -1329,6 +1330,8 @@ func RecoverNode(dataDir string, logger *log.Logger, logs raft.LogStore, stable 
 	if err != nil {
 		return fmt.Errorf("failed to find last log: %v", err)
 	}
+	logger.Printf("recovery snapshot index is %d, last index is %d", snapshotIndex, lastLogIndex)
+
 	for index := snapshotIndex + 1; index <= lastLogIndex; index++ {
 		var entry raft.Log
 		if err = logs.GetLog(index, &entry); err != nil {
@@ -1354,6 +1357,7 @@ func RecoverNode(dataDir string, logger *log.Logger, logs raft.LogStore, stable 
 	if err = sink.Close(); err != nil {
 		return fmt.Errorf("failed to finalize snapshot: %v", err)
 	}
+	logger.Printf("recovery snapshot created successfully")
 
 	// Compact the log so that we don't get bad interference from any
 	// configuration change log entries that might be there.

--- a/store/store.go
+++ b/store/store.go
@@ -1263,7 +1263,7 @@ func (f *fsmSnapshot) Release() {}
 func RecoverNode(dataDir string, logger *log.Logger, logs raft.LogStore, stable raft.StableStore,
 	snaps raft.SnapshotStore, tn raft.Transport, conf raft.Configuration) error {
 	// Sanity check the Raft peer configuration.
-	if err := checkConfiguration(conf); err != nil {
+	if err := checkRaftConfiguration(conf); err != nil {
 		return err
 	}
 
@@ -1451,9 +1451,9 @@ func applyCommand(data []byte, db *sql.DB) (command.Command_Type, interface{}) {
 	}
 }
 
-// checkConfiguration tests a cluster membership configuration for common
+// checkRaftConfiguration tests a cluster membership configuration for common
 // errors.
-func checkConfiguration(configuration raft.Configuration) error {
+func checkRaftConfiguration(configuration raft.Configuration) error {
 	idSet := make(map[raft.ServerID]bool)
 	addressSet := make(map[raft.ServerAddress]bool)
 	var voters int

--- a/store/store.go
+++ b/store/store.go
@@ -1097,6 +1097,18 @@ type fsmSnapshot struct {
 	database []byte
 }
 
+func newFSMSnapshot(db *sql.DB, logger *log.Logger) *fsmSnapshot {
+	fsm := &fsmSnapshot{
+		startT: time.Now(),
+		logger: logger,
+	}
+
+	// The error code is not meaningful from Serialize(). The code needs to be able
+	// handle a nil byte slice being returned.
+	fsm.database, _ = db.Serialize()
+	return fsm
+}
+
 // Persist writes the snapshot to the given sink.
 func (f *fsmSnapshot) Persist(sink raft.SnapshotSink) error {
 	defer func() {
@@ -1222,18 +1234,6 @@ func (s *Store) databaseTypePretty() string {
 
 // Release is a no-op.
 func (f *fsmSnapshot) Release() {}
-
-func newFSMSnapshot(db *sql.DB, logger *log.Logger) *fsmSnapshot {
-	fsm := &fsmSnapshot{
-		startT: time.Now(),
-		logger: logger,
-	}
-
-	// The error code is not meaningful from Serialize(). The code needs to be able
-	// handle a nil byte slice being returned.
-	fsm.database, _ = db.Serialize()
-	return fsm
-}
 
 func databaseFromSnapshot(rc io.ReadCloser) ([]byte, error) {
 	var uint64Size uint64

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -817,7 +817,10 @@ func Test_SingleNodeRecoverNetworkChangeSnapshot(t *testing.T) {
 	// Wait for a snapshot to take place.
 	for {
 		time.Sleep(100 * time.Millisecond)
-		if s0.numSnapshots > 0 {
+		s0.numSnapshotsMu.Lock()
+		ns := s0.numSnapshots
+		s0.numSnapshotsMu.Unlock()
+		if ns > 0 {
 			break
 		}
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -672,9 +672,10 @@ func Test_SingleNodeRecoverNoChange(t *testing.T) {
 	}
 
 	// Set up for Recovery during open
+	peers := fmt.Sprintf(`[{"id": "%s","address": "%s"}]`, s.ID(), s.Addr())
 	peersPath := filepath.Join(s.Path(), "/raft/peers.json")
 	peersInfo := filepath.Join(s.Path(), "/raft/peers.info")
-	mustWriteFile(peersPath, `[{"id": "1","address": "127.0.0.1:41665"}]`) // Could be any values
+	mustWriteFile(peersPath, peers)
 	if err := s.Open(true); err != nil {
 		t.Fatalf("failed to open single-node store: %s", err.Error())
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -674,7 +674,7 @@ func Test_SingleNodeRecoverNoChange(t *testing.T) {
 	// Set up for Recovery during open
 	peersPath := filepath.Join(s.Path(), "/raft/peers.json")
 	peersInfo := filepath.Join(s.Path(), "/raft/peers.info")
-	mustWriteFile(peersPath, `[{"id": "1","address": 127.0.0.1:41665"}]`) // Could be any values
+	mustWriteFile(peersPath, `[{"id": "1","address": "127.0.0.1:41665"}]`) // Could be any values
 	if err := s.Open(true); err != nil {
 		t.Fatalf("failed to open single-node store: %s", err.Error())
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -690,15 +690,6 @@ func Test_SingleNodeRecoverNoChange(t *testing.T) {
 	if !pathExists(peersInfo) {
 		t.Fatalf("Peers info does not exist at %s", peersInfo)
 	}
-
-	// No recovery should take place this time.
-	if err := s.Open(true); err != nil {
-		t.Fatalf("failed to open single-node store: %s", err.Error())
-	}
-	if _, err := s.WaitForLeader(10 * time.Second); err != nil {
-		t.Fatalf("Error waiting for leader: %s", err)
-	}
-	queryTest()
 }
 
 // Test_SingleNodeRecoverNetworkChange tests a node recovery that
@@ -772,15 +763,99 @@ func Test_SingleNodeRecoverNetworkChange(t *testing.T) {
 	if !pathExists(peersInfo) {
 		t.Fatalf("Peers info does not exist at %s", peersInfo)
 	}
+}
 
-	// No recovery should take place this time.
-	if err := sR.Open(true); err != nil {
-		t.Fatalf("failed to open single-node recovered store: %s", err.Error())
+// Test_SingleNodeRecoverNetworkChangeSnapshot tests a node recovery that
+// involves a changed-network address, with snapshots underneath.
+func Test_SingleNodeRecoverNetworkChangeSnapshot(t *testing.T) {
+	s0 := mustNewStore(true)
+	defer os.RemoveAll(s0.Path())
+	s0.SnapshotThreshold = 4
+	s0.SnapshotInterval = 100 * time.Millisecond
+	if err := s0.Open(true); err != nil {
+		t.Fatalf("failed to open single-node store: %s", err.Error())
 	}
-	if _, err := sR.WaitForLeader(10 * time.Second); err != nil {
+	if _, err := s0.WaitForLeader(10 * time.Second); err != nil {
 		t.Fatalf("Error waiting for leader: %s", err)
 	}
-	queryTest(sR)
+
+	queryTest := func(s *Store, c int) {
+		qr := queryRequestFromString("SELECT COUNT(*) FROM foo", false, false)
+		qr.Level = command.QueryRequest_QUERY_REQUEST_LEVEL_NONE
+		r, err := s.Query(qr)
+		if err != nil {
+			t.Fatalf("failed to query single node: %s", err.Error())
+		}
+		if exp, got := `["COUNT(*)"]`, asJSON(r[0].Columns); exp != got {
+			t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+		}
+		if exp, got := fmt.Sprintf(`[[%d]]`, c), asJSON(r[0].Values); exp != got {
+			t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
+		}
+	}
+
+	er := executeRequestFromStrings([]string{
+		`CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)`,
+		`INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+	}, false, false)
+	_, err := s0.Execute(er)
+	if err != nil {
+		t.Fatalf("failed to execute on single node: %s", err.Error())
+	}
+	queryTest(s0, 1)
+
+	for i := 0; i < 9; i++ {
+		er := executeRequestFromStrings([]string{
+			`INSERT INTO foo(name) VALUES("fiona")`,
+		}, false, false)
+		if _, err := s0.Execute(er); err != nil {
+			t.Fatalf("failed to execute on single node: %s", err.Error())
+		}
+	}
+	queryTest(s0, 10)
+
+	// Wait for a snapshot to take place.
+	for {
+		time.Sleep(100 * time.Millisecond)
+		if s0.numSnapshots > 0 {
+			break
+		}
+	}
+
+	if err := s0.Close(true); err != nil {
+		t.Fatalf("failed to close single-node store: %s", err.Error())
+	}
+
+	// Create a new node, at the same path. Will presumably have a different
+	// Raft network address, since they are randomly assigned.
+	sR, srLn := mustNewStoreAtPathsLn(s0.Path(), "", true, false)
+	if IsNewNode(sR.Path()) {
+		t.Fatalf("store detected incorrectly as new")
+	}
+
+	// Set up for Recovery during open
+	peers := fmt.Sprintf(`[{"id": "%s","address": "%s"}]`, s0.ID(), srLn.Addr().String())
+	peersPath := filepath.Join(sR.Path(), "/raft/peers.json")
+	peersInfo := filepath.Join(sR.Path(), "/raft/peers.info")
+	mustWriteFile(peersPath, peers)
+	if err := sR.Open(true); err != nil {
+		t.Fatalf("failed to open single-node store: %s", err.Error())
+	}
+
+	if _, err := sR.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("Error waiting for leader on recovered node: %s", err)
+	}
+	queryTest(sR, 10)
+	if err := sR.Close(true); err != nil {
+		t.Fatalf("failed to close single-node recovered store: %s", err.Error())
+	}
+
+	if pathExists(peersPath) {
+		t.Fatalf("Peers JSON exists at %s", peersPath)
+	}
+	if !pathExists(peersInfo) {
+		t.Fatalf("Peers info does not exist at %s", peersInfo)
+	}
 }
 
 func Test_MultiNodeJoinRemove(t *testing.T) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -643,9 +643,6 @@ func Test_SingleNodeRecoverNoChange(t *testing.T) {
 		t.Fatalf("incorrect count for number of recoveries")
 	}
 
-	raftID := s.ID()
-	raftAddr := s.Addr()
-
 	queryTest := func() {
 		qr := queryRequestFromString("SELECT * FROM foo", false, false)
 		qr.Level = command.QueryRequest_QUERY_REQUEST_LEVEL_NONE
@@ -677,7 +674,7 @@ func Test_SingleNodeRecoverNoChange(t *testing.T) {
 	// Set up for Recovery during open
 	peersPath := filepath.Join(s.Path(), "/raft/peers.json")
 	peersInfo := filepath.Join(s.Path(), "/raft/peers.info")
-	mustWriteFile(peersPath, fmt.Sprintf("[{\"id\": \"%s\",\"address\": \"%s\"}]", raftID, raftAddr))
+	mustWriteFile(peersPath, `[{"id": "1","address": 127.0.0.1:41665"}]`) // Could be any values
 	if err := s.Open(true); err != nil {
 		t.Fatalf("failed to open single-node store: %s", err.Error())
 	}

--- a/system_test/cluster_test.go
+++ b/system_test/cluster_test.go
@@ -809,20 +809,21 @@ func Test_MultiNodeClusterRecoverSingle(t *testing.T) {
 	// Create a single node using the node's data directory. It should fail because
 	// quorum can't be met. This isn't quite right since the Raft address is also
 	// changing, but it generally proves it doesn't come up.
-	mux := mustNewOpenMux("127.0.0.1:10000")
-	failedSingle := mustNodeEncrypted(node1.Dir, true, false, mux, node1.Store.ID())
+	mux0, ln0 := mustNewOpenMux("127.0.0.1:10000")
+	failedSingle := mustNodeEncrypted(node1.Dir, true, false, mux0, node1.Store.ID())
 	_, err = failedSingle.WaitForLeader()
 	if err == nil {
 		t.Fatalf("no error waiting for leader")
 	}
 	failedSingle.Close(true)
+	ln0.Close()
 
 	// Try again, this time injecting a single-node peers file.
-	mux = mustNewOpenMux("127.0.0.1:10001")
+	mux1, ln1 := mustNewOpenMux("127.0.0.1:10001")
 	peers := fmt.Sprintf(`[{"id": "%s","address": "%s"}]`, node1.Store.ID(), "127.0.0.1:10001")
 	mustWriteFile(node1.PeersPath, peers)
 
-	okSingle := mustNodeEncrypted(node1.Dir, true, false, mux, node1.Store.ID())
+	okSingle := mustNodeEncrypted(node1.Dir, true, false, mux1, node1.Store.ID())
 	_, err = okSingle.WaitForLeader()
 	if err != nil {
 		t.Fatalf("failed waiting for leader: %s", err.Error())
@@ -831,6 +832,7 @@ func Test_MultiNodeClusterRecoverSingle(t *testing.T) {
 		t.Fatalf("got incorrect results from recovered node: %s", rows)
 	}
 	okSingle.Close(true)
+	ln1.Close()
 }
 
 // Test_MultiNodeClusterRecoverFull tests recovery of a full 3-node cluster,
@@ -838,14 +840,14 @@ func Test_MultiNodeClusterRecoverSingle(t *testing.T) {
 func Test_MultiNodeClusterRecoverFull(t *testing.T) {
 	var err error
 
-	mux1 := mustNewOpenMux("127.0.0.1:10001")
+	mux1, ln1 := mustNewOpenMux("127.0.0.1:10001")
 	node1 := mustNodeEncrypted(mustTempDir(), true, false, mux1, "1")
 	_, err = node1.WaitForLeader()
 	if err != nil {
 		t.Fatalf("failed waiting for leader: %s", err.Error())
 	}
 
-	mux2 := mustNewOpenMux("127.0.0.1:10002")
+	mux2, ln2 := mustNewOpenMux("127.0.0.1:10002")
 	node2 := mustNodeEncrypted(mustTempDir(), false, false, mux2, "2")
 	if err := node2.Join(node1); err != nil {
 		t.Fatalf("node failed to join leader: %s", err.Error())
@@ -855,7 +857,7 @@ func Test_MultiNodeClusterRecoverFull(t *testing.T) {
 		t.Fatalf("failed waiting for leader: %s", err.Error())
 	}
 
-	mux3 := mustNewOpenMux("127.0.0.1:10003")
+	mux3, ln3 := mustNewOpenMux("127.0.0.1:10003")
 	node3 := mustNodeEncrypted(mustTempDir(), false, false, mux3, "3")
 	if err := node3.Join(node1); err != nil {
 		t.Fatalf("node failed to join leader: %s", err.Error())
@@ -879,12 +881,15 @@ func Test_MultiNodeClusterRecoverFull(t *testing.T) {
 	if err := node1.Close(true); err != nil {
 		t.Fatalf("failed to close node1: %s", err.Error())
 	}
+	ln1.Close()
 	if err := node2.Close(true); err != nil {
 		t.Fatalf("failed to close node2: %s", err.Error())
 	}
+	ln2.Close()
 	if err := node3.Close(true); err != nil {
 		t.Fatalf("failed to close node3: %s", err.Error())
 	}
+	ln3.Close()
 
 	// Restart cluster, each node with different Raft addresses.
 	peers := fmt.Sprintf(`[{"id": "%s","address": "%s"}, {"id": "%s","address": "%s"}, {"id": "%s","address": "%s"}]`,
@@ -896,17 +901,20 @@ func Test_MultiNodeClusterRecoverFull(t *testing.T) {
 	mustWriteFile(node2.PeersPath, peers)
 	mustWriteFile(node3.PeersPath, peers)
 
-	mux4 := mustNewOpenMux("127.0.0.1:11001")
+	mux4, ln4 := mustNewOpenMux("127.0.0.1:11001")
 	node4 := mustNodeEncrypted(node1.Dir, false, false, mux4, "1")
 	defer node4.Deprovision()
+	defer ln4.Close()
 
-	mux5 := mustNewOpenMux("127.0.0.1:11002")
+	mux5, ln5 := mustNewOpenMux("127.0.0.1:11002")
 	node5 := mustNodeEncrypted(node2.Dir, false, false, mux5, "2")
 	defer node5.Deprovision()
+	defer ln5.Close()
 
-	mux6 := mustNewOpenMux("127.0.0.1:11003")
+	mux6, ln6 := mustNewOpenMux("127.0.0.1:11003")
 	node6 := mustNodeEncrypted(node3.Dir, false, false, mux6, "3")
 	defer node6.Deprovision()
+	defer ln6.Close()
 
 	_, err = node6.WaitForLeader()
 	if err != nil {

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -469,7 +469,7 @@ func mustNewNodeEncrypted(enableSingle, httpEncrypt, nodeEncrypt bool) *Node {
 	if nodeEncrypt {
 		mux = mustNewOpenTLSMux(x509.CertFile(dir), x509.KeyFile(dir), "")
 	} else {
-		mux = mustNewOpenMux("")
+		mux, _ = mustNewOpenMux("")
 	}
 	go mux.Serve()
 
@@ -562,7 +562,7 @@ func mustTempDir() string {
 	return path
 }
 
-func mustNewOpenMux(addr string) *tcp.Mux {
+func mustNewOpenMux(addr string) (*tcp.Mux, net.Listener) {
 	if addr == "" {
 		addr = "localhost:0"
 	}
@@ -579,7 +579,7 @@ func mustNewOpenMux(addr string) *tcp.Mux {
 	}
 
 	go mux.Serve()
-	return mux
+	return mux, ln
 }
 
 func mustNewOpenTLSMux(certFile, keyPath, addr string) *tcp.Mux {

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -37,6 +37,7 @@ type Node struct {
 	NodeKeyPath  string
 	HTTPCertPath string
 	HTTPKeyPath  string
+	PeersPath    string
 	Store        *store.Store
 	Service      *httpd.Service
 	Cluster      *cluster.Service
@@ -491,6 +492,7 @@ func mustNodeEncryptedOnDisk(dir string, enableSingle, httpEncrypt bool, mux *tc
 		NodeKeyPath:  nodeKeyPath,
 		HTTPCertPath: httpCertPath,
 		HTTPKeyPath:  httpKeyPath,
+		PeersPath:    filepath.Join(dir, "raft/peers.json"),
 	}
 
 	dbConf := store.NewDBConfig(!onDisk)
@@ -643,6 +645,13 @@ func asJSON(v interface{}) string {
 func isJSON(s string) bool {
 	var js map[string]interface{}
 	return json.Unmarshal([]byte(s), &js) == nil
+}
+
+func mustWriteFile(path, contents string) {
+	err := os.WriteFile(path, []byte(contents), 0644)
+	if err != nil {
+		panic("failed to write to file")
+	}
 }
 
 /* MIT License

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -23,7 +23,8 @@ func Test_SingleNodeBasicEndpoint(t *testing.T) {
 	}
 
 	dir := mustTempDir()
-	mux := mustNewOpenMux("")
+	mux, ln := mustNewOpenMux("")
+	defer ln.Close()
 	node = mustNodeEncryptedOnDisk(dir, true, false, mux, "", false)
 	if _, err := node.WaitForLeader(); err != nil {
 		t.Fatalf("node never became leader")
@@ -403,7 +404,8 @@ func Test_SingleNodeRestart(t *testing.T) {
 		t.Fatalf("failed to copy node test directory: %s", err)
 	}
 
-	mux := mustNewOpenMux("")
+	mux, ln := mustNewOpenMux("")
+	defer ln.Close()
 
 	node := mustNodeEncrypted(destdir, true, false, mux, "node1")
 	defer node.Deprovision()
@@ -498,7 +500,8 @@ func Test_SingleNodeReopen(t *testing.T) {
 		t.Logf("running test %s, on-disk=%v", t.Name(), onDisk)
 
 		dir := mustTempDir()
-		mux := mustNewOpenMux("")
+		mux, ln := mustNewOpenMux("")
+		defer ln.Close()
 		node := mustNodeEncrypted(dir, true, false, mux, "")
 
 		if _, err := node.WaitForLeader(); err != nil {
@@ -538,7 +541,8 @@ func Test_SingleNodeNoopReopen(t *testing.T) {
 		t.Logf("running test %s, on-disk=%v", t.Name(), onDisk)
 
 		dir := mustTempDir()
-		mux := mustNewOpenMux("")
+		mux, ln := mustNewOpenMux("")
+		defer ln.Close()
 		node := mustNodeEncryptedOnDisk(dir, true, false, mux, "", false)
 
 		if _, err := node.WaitForLeader(); err != nil {
@@ -626,7 +630,8 @@ func Test_SingleNodeNoopSnapReopen(t *testing.T) {
 		t.Logf("running test %s, on-disk=%v", t.Name(), onDisk)
 
 		dir := mustTempDir()
-		mux := mustNewOpenMux("")
+		mux, ln := mustNewOpenMux("")
+		defer ln.Close()
 		node := mustNodeEncryptedOnDisk(dir, true, false, mux, "", onDisk)
 
 		if _, err := node.WaitForLeader(); err != nil {
@@ -719,7 +724,8 @@ func Test_SingleNodeNoopSnapLogsReopen(t *testing.T) {
 		t.Logf("running test %s, on-disk=%v", t.Name(), onDisk)
 
 		dir := mustTempDir()
-		mux := mustNewOpenMux("")
+		mux, ln := mustNewOpenMux("")
+		defer ln.Close()
 		node := mustNodeEncryptedOnDisk(dir, true, false, mux, "", onDisk)
 		raftAddr = node.RaftAddr
 		t.Logf("node listening for Raft on %s", raftAddr)


### PR DESCRIPTION
Adds support to recover failed clusters, or clusters that restart with all new Raft network addresses.

Borrows heavily from the Consul approach.