### PR TITLE
fix:solve the float64 problem during JSON deserialization

### DIFF
--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -362,7 +362,9 @@ func sendRequest(ctx *cli.Context, makeNewRequest func(string) (*http.Request, e
 }
 
 func parseResponse(response *[]byte, ret interface{}) error {
-	return json.Unmarshal(*response, ret)
+	decoder := json.NewDecoder(strings.NewReader(string(*response)))
+	decoder.UseNumber()
+	return decoder.Decode(ret)
 }
 
 // cliJSON fetches JSON from a URL, and displays it at the CLI.


### PR DESCRIPTION
During the execution of SQL through the console, the result of numeric type will be deserialized to float64 and displayed as scientific notation