### PR TITLE
Enhance Authentication and Authorization system

### DIFF
--- a/DOC/SECURITY.md
+++ b/DOC/SECURITY.md
@@ -86,3 +86,12 @@ Querying the node, as user _mary_.
 curl -G 'https://mary:secret2@localhost:4001/db/query?pretty&timings' \
 --data-urlencode 'q=SELECT * FROM foo'
 ```
+
+### Avoiding passwords at the command line
+The above example suffer from one shortcoming -- the password for user `bob` is entered at the command line. This is not ideal, as someone with access to the process table could learn the password. You can avoid this via the `-join-as` option, which will tell rqlite to retrieve the password from the configuration file.
+```bash
+rqlited -auth config.json -http-addr localhost:4003 -http-cert server.crt \
+-http-key key.pem -raft-addr :4004 -join https://localhost:4001 -join-as bob \
+-node-encrypt -node-cert node.crt -node-key node-key.pem -no-node-verify \
+~/node.2
+```

--- a/DOC/SECURITY.md
+++ b/DOC/SECURITY.md
@@ -67,9 +67,9 @@ An example configuration file is shown below.
   }
 ]
 ```
-This configuration file sets authentication for three usernames, _bob_, _mary_, and `*`. It sets a password for thw first two.
+This configuration file sets authentication for three usernames, _bob_, _mary_, and `*`. It sets a password for the first two.
 
-This configuration also sets permissions for all usernames. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as backup the cluster. `*` is a special username, which indicates that all users -- even anonymous users (requests without any BasicAuth information) -- have permission to check the cluster status. This can be useful if you wish to leave certain operations open to all users.
+This configuration also sets permissions for all usernames. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as backup the cluster. `*` is a special username, which indicates that all users -- even anonymous users (requests without any BasicAuth information) -- have permission to check the cluster status. This can be useful if you wish to leave certain operations open to all accesses.
 
 ## Secure cluster example
 Starting a node with HTTPS enabled, node-to-node encryption, and with the above configuration file. It is assumed the HTTPS X.509 certificate and key are at the paths `server.crt` and `key.pem` respectively, and the node-to-node certificate and key are at `node.crt` and `node-key.pem`

--- a/DOC/SECURITY.md
+++ b/DOC/SECURITY.md
@@ -63,13 +63,13 @@ An example configuration file is shown below.
   },
   {
     "username": "*",
-    "perms": ["status"]
+    "perms": ["status", "ready"]
   }
 ]
 ```
 This configuration file sets authentication for three usernames, _bob_, _mary_, and `*`. It sets a password for the first two.
 
-This configuration also sets permissions for all usernames. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as backup the cluster. `*` is a special username, which indicates that all users -- even anonymous users (requests without any BasicAuth information) -- have permission to check the cluster status. This can be useful if you wish to leave certain operations open to all accesses.
+This configuration also sets permissions for all usernames. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as backup the cluster. `*` is a special username, which indicates that all users -- even anonymous users (requests without any BasicAuth information) -- have permission to check the cluster and readiness. This can be useful if you wish to leave certain operations open to all accesses.
 
 ## Secure cluster example
 Starting a node with HTTPS enabled, node-to-node encryption, and with the above configuration file. It is assumed the HTTPS X.509 certificate and key are at the paths `server.crt` and `key.pem` respectively, and the node-to-node certificate and key are at `node.crt` and `node-key.pem`

--- a/DOC/SECURITY.md
+++ b/DOC/SECURITY.md
@@ -59,13 +59,17 @@ An example configuration file is shown below.
   {
     "username": "mary",
     "password": "$2a$10$fKRHxrEuyDTP6tXIiDycr.nyC8Q7UMIfc31YMyXHDLgRDyhLK3VFS",
-    "perms": ["query", "status"]
+    "perms": ["query", "backup"]
+  },
+  {
+    "username": "*",
+    "perms": ["status"]
   }
 ]
 ```
-This configuration file sets authentication for two usernames, _bob_ and _mary_, and it sets a password for each. No other users will be able to access the cluster.
+This configuration file sets authentication for three usernames, _bob_, _mary_, and `*`. It sets a password for thw first two.
 
-This configuration also sets permissions for both users. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as check the cluster status.
+This configuration also sets permissions for all usernames. _bob_ has permission to perform all operations, but _mary_ can only query the cluster, as well as backup the cluster. `*` is a special username, which indicates that all users -- even anonymous users (requests without any BasicAuth information) -- have permission to check the cluster status. This can be useful if you wish to leave certain operations open to all users.
 
 ## Secure cluster example
 Starting a node with HTTPS enabled, node-to-node encryption, and with the above configuration file. It is assumed the HTTPS X.509 certificate and key are at the paths `server.crt` and `key.pem` respectively, and the node-to-node certificate and key are at `node.crt` and `node-key.pem`

--- a/auth/credential_store.go
+++ b/auth/credential_store.go
@@ -56,7 +56,6 @@ func (c *CredentialsStore) Load(r io.Reader) error {
 		}
 		c.store[cred.Username] = cred.Password
 		c.perms[cred.Username] = make(map[string]bool, len(cred.Perms))
-
 		for _, p := range cred.Perms {
 			c.perms[cred.Username][p] = true
 		}

--- a/auth/credential_store.go
+++ b/auth/credential_store.go
@@ -86,6 +86,15 @@ func (c *CredentialsStore) Check(username, password string) bool {
 		bcrypt.CompareHashAndPassword([]byte(pw), []byte(password)) == nil
 }
 
+// Password returns the password for the given user.
+func (c *CredentialsStore) Password(username string) string {
+	pw, ok := c.store[username]
+	if !ok {
+		return ""
+	}
+	return pw
+}
+
 // CheckRequest returns true if b contains a valid username and password.
 func (c *CredentialsStore) CheckRequest(b BasicAuther) bool {
 	username, password, ok := b.BasicAuth()

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -40,6 +40,27 @@ func Test_AuthLoadSingle(t *testing.T) {
 	if check := store.Check("wrong", "wrong"); check {
 		t.Fatalf("single credential not loaded correctly")
 	}
+
+	if store.JoinAs != "" {
+		t.Fatalf("JoinAs user is incorrect: %s", store.JoinAs)
+	}
+}
+
+func Test_AuthLoadSingleJoinAs(t *testing.T) {
+	const jsonStream = `
+		[
+			{"username": "username1", "password": "password1", "join_as": true}
+		]
+	`
+
+	store := NewCredentialsStore()
+	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
+		t.Fatalf("failed to load single credential: %s", err.Error())
+	}
+
+	if store.JoinAs != "username1" {
+		t.Fatalf("JoinAs user is incorrect")
+	}
 }
 
 func Test_AuthLoadMultiple(t *testing.T) {
@@ -77,6 +98,38 @@ func Test_AuthLoadMultiple(t *testing.T) {
 	}
 	if check := store.Check("wrong", "wrong"); check {
 		t.Fatalf("multiple credential not loaded correctly")
+	}
+}
+
+func Test_AuthLoadMultipleJoinAs(t *testing.T) {
+	const jsonStream = `
+		[
+			{"username": "username1", "password": "password1"},
+			{"username": "username2", "password": "password2", "join_as": true}
+		]
+	`
+
+	store := NewCredentialsStore()
+	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
+		t.Fatalf("failed to load multiple credentials: %s", err.Error())
+	}
+
+	if store.JoinAs != "username2" {
+		t.Fatalf("JoinAs user is incorrect")
+	}
+}
+
+func Test_AuthLoadMultipleJoinAsDuplicate(t *testing.T) {
+	const jsonStream = `
+		[
+			{"username": "username1", "password": "password1", "join_as": true},
+			{"username": "username2", "password": "password2", "join_as": true}
+		]
+	`
+
+	store := NewCredentialsStore()
+	if err := store.Load(strings.NewReader(jsonStream)); err == nil {
+		t.Fatalf("successfully loaded invalid credential store")
 	}
 }
 

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -350,7 +350,7 @@ func Test_AuthPermsAllUsers(t *testing.T) {
 			},
 			{
 				"username": "*",
-				"perms": ["bar"]
+				"perms": ["bar", "abc"]
 			}
 		]
 	`
@@ -373,10 +373,16 @@ func Test_AuthPermsAllUsers(t *testing.T) {
 	if perm := store.HasPerm(AllUsers, "bar"); !perm {
 		t.Fatalf("* does not have bar perm")
 	}
+	if perm := store.HasPerm(AllUsers, "abc"); !perm {
+		t.Fatalf("* does not have abc perm")
+	}
 	if perm := store.HasPerm(AllUsers, "foo"); perm {
 		t.Fatalf("* has foo perm")
 	}
 	if perm := store.HasPerm("username1", "bar"); !perm {
 		t.Fatalf("username1 does not have bar perm via *")
+	}
+	if perm := store.HasPerm("username1", "abc"); !perm {
+		t.Fatalf("username1 does not have abc perm via *")
 	}
 }

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -41,32 +41,15 @@ func Test_AuthLoadSingle(t *testing.T) {
 		t.Fatalf("single credential not loaded correctly")
 	}
 
-	if store.Password("username1") != "password1" {
+	var pw string
+	var ok bool
+	pw, ok = store.Password("username1")
+	if pw != "password1" || !ok {
 		t.Fatalf("wrong password returned")
 	}
-	if store.Password("nonsense") != "" {
-		t.Fatalf("wrong password returned for nonexistent user")
-	}
-
-	if store.JoinAs != "" {
-		t.Fatalf("JoinAs user is incorrect: %s", store.JoinAs)
-	}
-}
-
-func Test_AuthLoadSingleJoinAs(t *testing.T) {
-	const jsonStream = `
-		[
-			{"username": "username1", "password": "password1", "join_as": true}
-		]
-	`
-
-	store := NewCredentialsStore()
-	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
-		t.Fatalf("failed to load single credential: %s", err.Error())
-	}
-
-	if store.JoinAs != "username1" {
-		t.Fatalf("JoinAs user is incorrect")
+	_, ok = store.Password("nonsense")
+	if ok {
+		t.Fatalf("password returned for nonexistent user")
 	}
 }
 
@@ -105,38 +88,6 @@ func Test_AuthLoadMultiple(t *testing.T) {
 	}
 	if check := store.Check("wrong", "wrong"); check {
 		t.Fatalf("multiple credential not loaded correctly")
-	}
-}
-
-func Test_AuthLoadMultipleJoinAs(t *testing.T) {
-	const jsonStream = `
-		[
-			{"username": "username1", "password": "password1"},
-			{"username": "username2", "password": "password2", "join_as": true}
-		]
-	`
-
-	store := NewCredentialsStore()
-	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
-		t.Fatalf("failed to load multiple credentials: %s", err.Error())
-	}
-
-	if store.JoinAs != "username2" {
-		t.Fatalf("JoinAs user is incorrect")
-	}
-}
-
-func Test_AuthLoadMultipleJoinAsDuplicate(t *testing.T) {
-	const jsonStream = `
-		[
-			{"username": "username1", "password": "password1", "join_as": true},
-			{"username": "username2", "password": "password2", "join_as": true}
-		]
-	`
-
-	store := NewCredentialsStore()
-	if err := store.Load(strings.NewReader(jsonStream)); err == nil {
-		t.Fatalf("successfully loaded invalid credential store")
 	}
 }
 

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -41,6 +41,13 @@ func Test_AuthLoadSingle(t *testing.T) {
 		t.Fatalf("single credential not loaded correctly")
 	}
 
+	if store.Password("username1") != "password1" {
+		t.Fatalf("wrong password returned")
+	}
+	if store.Password("nonsense") != "" {
+		t.Fatalf("wrong password returned for nonexistent user")
+	}
+
 	if store.JoinAs != "" {
 		t.Fatalf("JoinAs user is incorrect: %s", store.JoinAs)
 	}

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -339,3 +339,44 @@ func Test_AuthPermsNilLoadSingle(t *testing.T) {
 		t.Fatalf("wrong has foo perm")
 	}
 }
+
+func Test_AuthPermsAllUsers(t *testing.T) {
+	const jsonStream = `
+		[
+			{
+				"username": "username1",
+				"password": "password1",
+				"perms": ["foo"]
+			},
+			{
+				"username": "*",
+				"perms": ["bar"]
+			}
+		]
+	`
+
+	store := NewCredentialsStore()
+	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
+		t.Fatalf("failed to load single credential: %s", err.Error())
+	}
+
+	if check := store.Check("username1", "password1"); !check {
+		t.Fatalf("single credential not loaded correctly")
+	}
+	if check := store.Check("username1", "wrong"); check {
+		t.Fatalf("single credential not loaded correctly")
+	}
+
+	if perm := store.HasPerm("username1", "qux"); perm {
+		t.Fatalf("username1 has qux perm")
+	}
+	if perm := store.HasPerm(AllUsers, "bar"); !perm {
+		t.Fatalf("* does not have bar perm")
+	}
+	if perm := store.HasPerm(AllUsers, "foo"); perm {
+		t.Fatalf("* has foo perm")
+	}
+	if perm := store.HasPerm("username1", "bar"); !perm {
+		t.Fatalf("username1 does not have bar perm via *")
+	}
+}

--- a/cluster/join.go
+++ b/cluster/join.go
@@ -27,8 +27,14 @@ var (
 	ErrJoinFailed = errors.New("failed to join cluster")
 )
 
-// AddUserInfo adds username and password to the join address.
+// AddUserInfo adds username and password to the join address. If username is empty
+// joinAddr is returned unchanged. If joinAddr already contains a username, ErrUserInfoExists
+// is returned.
 func AddUserInfo(joinAddr, username, password string) (string, error) {
+	if username == "" {
+		return joinAddr, nil
+	}
+
 	u, err := url.Parse(joinAddr)
 	if err != nil {
 		return "", err

--- a/cluster/join.go
+++ b/cluster/join.go
@@ -48,6 +48,16 @@ func AddUserInfo(joinAddr, username, password string) (string, error) {
 	return u.String(), nil
 }
 
+// RemoveUserInfo returns the joinAddr with any username and password removed.
+func RemoveUserInfo(joinAddr string) string {
+	u, err := url.Parse(joinAddr)
+	if err != nil {
+		return joinAddr
+	}
+	u.User = nil
+	return u.String()
+}
+
 // Join attempts to join the cluster at one of the addresses given in joinAddr.
 // It walks through joinAddr in order, and sets the node ID and Raft address of
 // the joining node as id addr respectively. It returns the endpoint successfully

--- a/cluster/join.go
+++ b/cluster/join.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -18,9 +19,28 @@ import (
 )
 
 var (
+	// ErrUserInfoExists is returned when a join address already contains
+	// a username and a password.
+	ErrUserInfoExists = errors.New("userinfo exists")
+
 	// ErrJoinFailed is returned when a node fails to join a cluster
 	ErrJoinFailed = errors.New("failed to join cluster")
 )
+
+// AddUserInfo adds username and password to the join address.
+func AddUserInfo(joinAddr, username, password string) (string, error) {
+	u, err := url.Parse(joinAddr)
+	if err != nil {
+		return "", err
+	}
+
+	if u.User != nil && u.User.Username() != "" {
+		return "", ErrUserInfoExists
+	}
+
+	u.User = url.UserPassword(username, password)
+	return u.String(), nil
+}
 
 // Join attempts to join the cluster at one of the addresses given in joinAddr.
 // It walks through joinAddr in order, and sets the node ID and Raft address of

--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -47,6 +47,18 @@ func Test_AddUserInfo(t *testing.T) {
 	}
 }
 
+func Test_RemoveUserInfo(t *testing.T) {
+	if exp, got := "http://example.com", RemoveUserInfo("http://user1:pass1@example.com"); exp != got {
+		t.Fatalf("expected %s, got %s", exp, got)
+	}
+	if exp, got := "http://example.com", RemoveUserInfo("http://example.com"); exp != got {
+		t.Fatalf("expected %s, got %s", exp, got)
+	}
+	if exp, got := "nonsense", RemoveUserInfo("nonsense"); exp != got {
+		t.Fatalf("expected %s, got %s", exp, got)
+	}
+}
+
 func Test_SingleJoinOK(t *testing.T) {
 	var body map[string]interface{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -13,6 +13,32 @@ import (
 const numAttempts int = 3
 const attemptInterval = 5 * time.Second
 
+func Test_AddUserInfo(t *testing.T) {
+	var u string
+	var err error
+
+	u, err = AddUserInfo("http://example.com", "user1", "pass1")
+	if err != nil {
+		t.Fatalf("failed to add user info: %s", err.Error())
+	}
+	if exp, got := "http://user1:pass1@example.com", u; exp != got {
+		t.Fatalf("wrong URL created, exp %s, got %s", exp, got)
+	}
+
+	u, err = AddUserInfo("http://example.com", "user1", "")
+	if err != nil {
+		t.Fatalf("failed to add user info: %s", err.Error())
+	}
+	if exp, got := "http://user1:@example.com", u; exp != got {
+		t.Fatalf("wrong URL created, exp %s, got %s", exp, got)
+	}
+
+	u, err = AddUserInfo("http://user1:pass1@example.com", "user2", "pass2")
+	if err == nil {
+		t.Fatalf("failed to get expected error when UserInfo exists")
+	}
+}
+
 func Test_SingleJoinOK(t *testing.T) {
 	var body map[string]interface{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cluster/join_test.go
+++ b/cluster/join_test.go
@@ -33,6 +33,14 @@ func Test_AddUserInfo(t *testing.T) {
 		t.Fatalf("wrong URL created, exp %s, got %s", exp, got)
 	}
 
+	u, err = AddUserInfo("http://example.com", "", "pass1")
+	if err != nil {
+		t.Fatalf("failed to add user info: %s", err.Error())
+	}
+	if exp, got := "http://example.com", u; exp != got {
+		t.Fatalf("wrong URL created, exp %s, got %s", exp, got)
+	}
+
 	u, err = AddUserInfo("http://user1:pass1@example.com", "user2", "pass2")
 	if err == nil {
 		t.Fatalf("failed to get expected error when UserInfo exists")

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -328,7 +328,7 @@ func main() {
 			for i := range joins {
 				joins[i], err = cluster.AddUserInfo(joins[i], username, password)
 				if err != nil {
-					log.Fatalf("failed to user credential store join_as: %s", err.Error())
+					log.Fatalf("failed to use credential store join_as: %s", err.Error())
 				}
 			}
 			log.Println("added join_as identity from credential store")

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -323,7 +323,7 @@ func main() {
 		// Add credentials to any join addresses, if necessary.
 		if credStr != nil && credStr.JoinAs != "" {
 			var err error
-			password := credStr.Password(username)
+			password := credStr.Password(credStr.JoinAs)
 			for i := range joins {
 				joins[i], err = cluster.AddUserInfo(joins[i], credStr.JoinAs, password)
 				if err != nil {

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -323,10 +323,9 @@ func main() {
 		// Add credentials to any join addresses, if necessary.
 		if credStr != nil && credStr.JoinAs != "" {
 			var err error
-			username := credStr.JoinAs
 			password := credStr.Password(username)
 			for i := range joins {
-				joins[i], err = cluster.AddUserInfo(joins[i], username, password)
+				joins[i], err = cluster.AddUserInfo(joins[i], credStr.JoinAs, password)
 				if err != nil {
 					log.Fatalf("failed to use credential store join_as: %s", err.Error())
 				}

--- a/http/service.go
+++ b/http/service.go
@@ -1128,17 +1128,6 @@ func (s *Service) addBuildVersion(w http.ResponseWriter) {
 	w.Header().Add(VersionHTTPHeader, version)
 }
 
-// // checkCredentials returns if any authentication requirements
-// // have been successfully met.
-// func (s *Service) checkCredentials(r *http.Request) bool {
-// 	if s.credentialStore == nil {
-// 		return true
-// 	}
-
-// 	username, password, ok := r.BasicAuth()
-// 	return ok && s.credentialStore.Check(username, password)
-// }
-
 // writeResponse writes the given response to the given writer.
 func (s *Service) writeResponse(w http.ResponseWriter, r *http.Request, j *Response) {
 	var b []byte

--- a/http/service.go
+++ b/http/service.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rqlite/rqlite/auth"
 	"github.com/rqlite/rqlite/command"
 	"github.com/rqlite/rqlite/command/encoding"
 	"github.com/rqlite/rqlite/store"
@@ -296,10 +297,6 @@ func (s *Service) HTTPS() bool {
 // ServeHTTP allows Service to serve HTTP requests.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.addBuildVersion(w)
-	if !s.checkCredentials(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
 
 	switch {
 	case r.URL.Path == "/" || r.URL.Path == "":
@@ -1028,8 +1025,8 @@ func (s *Service) FormRedirect(r *http.Request, url string) string {
 	return fmt.Sprintf("%s%s%s", url, r.URL.Path, rq)
 }
 
-// CheckRequestPerm returns true if authentication is enabled and the user contained
-// in the BasicAuth request has either PermAll, or the given perm.
+// CheckRequestPerm checks if the request is authenticated and authorized
+// with the given Perm.
 func (s *Service) CheckRequestPerm(r *http.Request, perm string) (b bool) {
 	defer func() {
 		if b {
@@ -1038,14 +1035,29 @@ func (s *Service) CheckRequestPerm(r *http.Request, perm string) (b bool) {
 			stats.Add(numAuthFail, 1)
 		}
 	}()
+
+	// No credential store? Auth is not even enabled.
 	if s.credentialStore == nil {
 		return true
 	}
 
-	username, _, ok := r.BasicAuth()
+	// Is the required perm granted to all users, including anonymous users?
+	if s.credentialStore.HasAnyPerm(auth.AllUsers, perm, PermAll) {
+		return true
+	}
+
+	// At this point there needs to be BasicAuth information in the request.
+	username, password, ok := r.BasicAuth()
 	if !ok {
 		return false
 	}
+
+	// Are the BasicAuth creds good?
+	if !s.credentialStore.Check(username, password) {
+		return false
+	}
+
+	// Is the specified user authorized?
 	return s.credentialStore.HasAnyPerm(username, perm, PermAll)
 }
 
@@ -1116,16 +1128,16 @@ func (s *Service) addBuildVersion(w http.ResponseWriter) {
 	w.Header().Add(VersionHTTPHeader, version)
 }
 
-// checkCredentials returns if any authentication requirements
-// have been successfully met.
-func (s *Service) checkCredentials(r *http.Request) bool {
-	if s.credentialStore == nil {
-		return true
-	}
+// // checkCredentials returns if any authentication requirements
+// // have been successfully met.
+// func (s *Service) checkCredentials(r *http.Request) bool {
+// 	if s.credentialStore == nil {
+// 		return true
+// 	}
 
-	username, password, ok := r.BasicAuth()
-	return ok && s.credentialStore.Check(username, password)
-}
+// 	username, password, ok := r.BasicAuth()
+// 	return ok && s.credentialStore.Check(username, password)
+// }
 
 // writeResponse writes the given response to the given writer.
 func (s *Service) writeResponse(w http.ResponseWriter, r *http.Request, j *Response) {

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -412,7 +412,7 @@ func Test_401Routes_NoBasicAuth(t *testing.T) {
 		"/db/backup",
 		"/db/load",
 		"/join",
-		"/delete",
+		"/remove",
 		"/status",
 		"/nodes",
 		"/readyz",

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -677,7 +677,7 @@ class TestAuthJoin(unittest.TestCase):
     self.cluster = Cluster([n0, n1, n2])
 
   def tearDown(self):
-    close(self.auth_file )
+    self.auth_file.close()
     self.cluster.deprovision()
 
 class TestClusterRecovery(unittest.TestCase):

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -677,6 +677,7 @@ class TestAuthJoin(unittest.TestCase):
     self.cluster = Cluster([n0, n1, n2])
 
   def tearDown(self):
+    close(self.auth_file )
     self.cluster.deprovision()
 
 class TestClusterRecovery(unittest.TestCase):

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -34,6 +34,7 @@ class Node(object):
                raft_addr=None, raft_adv=None,
                raft_voter=True,
                raft_snap_threshold=8192, raft_snap_int="1s",
+               join_as=None,
                dir=None, on_disk=False):
     if api_addr is None:
       s, addr = random_addr()
@@ -59,6 +60,7 @@ class Node(object):
     self.raft_voter = raft_voter
     self.raft_snap_threshold = raft_snap_threshold
     self.raft_snap_int = raft_snap_int
+    self.join_as = join_as
     self.on_disk = on_disk
     self.process = None
     self.stdout_file = os.path.join(dir, 'rqlited.log')
@@ -114,6 +116,8 @@ class Node(object):
       command += ['-on-disk']
     if join is not None:
       command += ['-join', 'http://' + join]
+      if self.join_as is not None:
+        command += ['-join-as', self.join_as]
     command.append(self.dir)
 
     self.process = subprocess.Popen(command, stdout=self.stdout_fd, stderr=self.stderr_fd)


### PR DESCRIPTION
This change enhances the authentication and authorization system in two ways.

- Adds a new command-line option, `-join-as` which tells rqlite to read the username and password from the auth config file, when doing the join. This allows us to avoid putting passwords in the launch command.
- Adds support for a pseudouser in the auth config, indicated by `*`. This allows indicating that all requests -- even anonymous requests -- have any permissions assigned to `*`.