### PR TITLE
Return a clearer response if no DB results

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -115,7 +115,7 @@ func (d *DBResults) MarshalJSON() ([]byte, error) {
 	} else if d.QueryRows != nil {
 		return encoding.JSONMarshal(d.QueryRows)
 	}
-	return nil, fmt.Errorf("no DB results set")
+	return json.Marshal(make([]interface{}, 0)) // Any empty list.
 }
 
 // Response represents a response from the HTTP service.

--- a/http/service.go
+++ b/http/service.go
@@ -115,7 +115,7 @@ func (d *DBResults) MarshalJSON() ([]byte, error) {
 	} else if d.QueryRows != nil {
 		return encoding.JSONMarshal(d.QueryRows)
 	}
-	return json.Marshal(make([]interface{}, 0)) // Any empty list.
+	return json.Marshal(make([]interface{}, 0))
 }
 
 // Response represents a response from the HTTP service.

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -22,8 +22,8 @@ import (
 func Test_ResponseJSONMarshal(t *testing.T) {
 	resp := NewResponse()
 	_, err := json.Marshal(resp)
-	if err == nil {
-		t.Fatalf("no error JSON marshaling invalid Response")
+	if err != nil {
+		t.Fatalf("error JSON marshaling empty Response: %s", err.Error())
 	}
 
 	resp = NewResponse()


### PR DESCRIPTION
This shouldn't happen, but it might, this will allow the underlying error to be returned to the caller. The body of the response will now look something like:

{
    "results": [],
    "error": "some error",
    "time": 0.021976516
}