### PR TITLE
Don't HTML escape JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Implementation changes and bug fixes
 - [PR #999](https://github.com/rqlite/rqlite/pull/999): Add end-to-end encrypted node test.
 - [PR #1008](https://github.com/rqlite/rqlite/pull/1008): Upgrade to SQLite 3.38.0. Fixes [issue #1005](https://github.com/rqlite/rqlite/issues/1005)
+- [PR #1009](https://github.com/rqlite/rqlite/pull/1009): Don't HTML escape JSON output.
 
 ## 7.3.1 (February 6th 2022)
 Fixes an issue in the 7.3.0 release that prevented clusters, which used TLS for internode communications, from operating correctly. All deployments using TLS should be upgraded to this version.

--- a/command/encoding/json_test.go
+++ b/command/encoding/json_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/rqlite/rqlite/command"
 )
 
+func Test_JSONNoEscaping(t *testing.T) {
+	m := map[string]string{
+		"a": "b",
+		"c": "d ->> e",
+	}
+	b, err := JSONMarshal(m)
+	if err != nil {
+		t.Fatalf("failed to marshal simple map: %s", err.Error())
+	}
+	if exp, got := `{"a":"b","c":"d ->> e"}`, string(b); exp != got {
+		t.Fatalf("incorrect marshal result: exp %s, got %s", exp, got)
+	}
+}
+
 // Test_MarshalExecuteResult tests JSON marshaling of an ExecuteResult
 func Test_MarshalExecuteResult(t *testing.T) {
 	var b []byte

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1809,7 +1809,7 @@ func Test_JSON1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to perform simple SELECT: %s", err.Error())
 	}
-	if exp, got := `[{"columns":["customer.phone -\u003e\u003e '$.mobile'"],"types":[""],"values":[["789111"]]}]`, asJSON(q); exp != got {
+	if exp, got := `[{"columns":["customer.phone ->> '$.mobile'"],"types":[""],"values":[["789111"]]}]`, asJSON(q); exp != got {
 		t.Fatalf("unexpected results for JSON query, expected %s, got %s", exp, got)
 	}
 }

--- a/system_test/full_system_test.py
+++ b/system_test/full_system_test.py
@@ -929,6 +929,7 @@ class TestBootstrapping(unittest.TestCase):
     deprovision_node(n0)
     deprovision_node(n1)
     deprovision_node(n2)
+    deprovision_node(n3)
 
 class TestAutoClustering(unittest.TestCase):
   DiscoModeConsulKV = "consul-kv"


### PR DESCRIPTION
JSON output from rqlite is not meant for raw display on web pages, so no need to escape. Escaping would also interfere with some characters output by SQLite.