### PR TITLE
Ignore freshness when serving queries on Leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [PR #1049](https://github.com/rqlite/rqlite/pull/1049): Ignore freshness when serving queries on Leader. Fixes [issue #1048](https://github.com/rqlite/rqlite/issues/1048). Thanks to @Tjstretchalot for the bug report.
 
 ## 7.5.1 (June 13th 2022)
+### Implementation changes and bug fixes
 - [PR #1043](https://github.com/rqlite/rqlite/pull/1043): Allow cluster-connect timeout to be configurable. Fixes [issue #1042](https://github.com/rqlite/rqlite/issues/1042).
 
 ## 7.5.0 (May 26th 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.5.2 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1049](https://github.com/rqlite/rqlite/pull/1049): Ignore freshness when serving queries on Leader. Fixes [issue #1048](https://github.com/rqlite/rqlite/issues/1048). Thanks to @Tjstretchalot for the bug report.
+
 ## 7.5.1 (June 13th 2022)
 - [PR #1043](https://github.com/rqlite/rqlite/pull/1043): Allow cluster-connect timeout to be configurable. Fixes [issue #1042](https://github.com/rqlite/rqlite/issues/1042).
 

--- a/DOC/CONSISTENCY.md
+++ b/DOC/CONSISTENCY.md
@@ -14,6 +14,8 @@ With _none_, the node simply queries its local SQLite database, and does not car
 ### Limiting read staleness
 You can tell the node not return results (effectively) older than a certain time, however. If a read request sets the query parameter `freshness` to a [Go duration string](https://golang.org/pkg/time/#Duration), the node serving the read will check that less time has passed since it was last in contact with the Leader, than that specified via freshness. If more time has passed the node will return an error. `freshness` is ignored for all consistency levels except `none`, and is also ignored if set to zero.
 
+> :warning: The `freshness` parameter is ignored if the node serving the query is the Leader. Any read, when served by the leader, is always going to be within any possible freshness bound.
+
 If you decide to deploy [read-only nodes](https://github.com/rqlite/rqlite/blob/master/DOC/READ_ONLY_NODES.md) however, _none_ combined with `freshness` can be a particularly effective at adding read scalability to your system. You can use lots of read-only nodes, yet be sure that a given node serving a request has not fallen too far behind the Leader (or even become disconnected from the cluster).
 
 ## Weak

--- a/DOC/CONSISTENCY.md
+++ b/DOC/CONSISTENCY.md
@@ -14,7 +14,7 @@ With _none_, the node simply queries its local SQLite database, and does not car
 ### Limiting read staleness
 You can tell the node not return results (effectively) older than a certain time, however. If a read request sets the query parameter `freshness` to a [Go duration string](https://golang.org/pkg/time/#Duration), the node serving the read will check that less time has passed since it was last in contact with the Leader, than that specified via freshness. If more time has passed the node will return an error. `freshness` is ignored for all consistency levels except `none`, and is also ignored if set to zero.
 
-> :warning: The `freshness` parameter is always ignored if the node serving the query is the Leader. Any read, when served by the leader, is always going to be within any possible freshness bound.
+> :warning: **The `freshness` parameter is always ignored if the node serving the query is the Leader**. Any read, when served by the leader, is always going to be within any possible freshness bound.
 
 If you decide to deploy [read-only nodes](https://github.com/rqlite/rqlite/blob/master/DOC/READ_ONLY_NODES.md) however, _none_ combined with `freshness` can be a particularly effective at adding read scalability to your system. You can use lots of read-only nodes, yet be sure that a given node serving a request has not fallen too far behind the Leader (or even become disconnected from the cluster).
 

--- a/DOC/CONSISTENCY.md
+++ b/DOC/CONSISTENCY.md
@@ -14,7 +14,7 @@ With _none_, the node simply queries its local SQLite database, and does not car
 ### Limiting read staleness
 You can tell the node not return results (effectively) older than a certain time, however. If a read request sets the query parameter `freshness` to a [Go duration string](https://golang.org/pkg/time/#Duration), the node serving the read will check that less time has passed since it was last in contact with the Leader, than that specified via freshness. If more time has passed the node will return an error. `freshness` is ignored for all consistency levels except `none`, and is also ignored if set to zero.
 
-> :warning: The `freshness` parameter is ignored if the node serving the query is the Leader. Any read, when served by the leader, is always going to be within any possible freshness bound.
+> :warning: The `freshness` parameter is always ignored if the node serving the query is the Leader. Any read, when served by the leader, is always going to be within any possible freshness bound.
 
 If you decide to deploy [read-only nodes](https://github.com/rqlite/rqlite/blob/master/DOC/READ_ONLY_NODES.md) however, _none_ combined with `freshness` can be a particularly effective at adding read scalability to your system. You can use lots of read-only nodes, yet be sure that a given node serving a request has not fallen too far behind the Leader (or even become disconnected from the cluster).
 

--- a/store/store.go
+++ b/store/store.go
@@ -803,8 +803,8 @@ func (s *Store) Query(qr *command.QueryRequest) ([]*command.QueryRows, error) {
 		return nil, ErrNotLeader
 	}
 
-	if qr.Level == command.QueryRequest_QUERY_REQUEST_LEVEL_NONE && qr.Freshness > 0 &&
-		time.Since(s.raft.LastContact()).Nanoseconds() > qr.Freshness {
+	if s.raft.State() != raft.Leader && qr.Level == command.QueryRequest_QUERY_REQUEST_LEVEL_NONE &&
+		qr.Freshness > 0 && time.Since(s.raft.LastContact()).Nanoseconds() > qr.Freshness {
 		return nil, ErrStaleRead
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1475,6 +1475,7 @@ func Test_MultiNodeExecuteQuery(t *testing.T) {
 	}
 }
 
+// Test_SingleNodeExecuteQueryFreshness tests that freshness is ignored on the Leader.
 func Test_SingleNodeExecuteQueryFreshness(t *testing.T) {
 	s0, ln0 := mustNewStore(true)
 	defer os.RemoveAll(s0.Path())
@@ -1505,7 +1506,7 @@ func Test_SingleNodeExecuteQueryFreshness(t *testing.T) {
 	}
 	qr := queryRequestFromString("SELECT * FROM foo", false, false)
 	qr.Level = command.QueryRequest_QUERY_REQUEST_LEVEL_NONE
-	qr.Freshness = mustParseDuration("100h").Nanoseconds()
+	qr.Freshness = mustParseDuration("1ns").Nanoseconds()
 	r, err := s0.Query(qr)
 	if err != nil {
 		t.Fatalf("failed to query leader node: %s", err.Error())


### PR DESCRIPTION
It doesn't make sense to check the last leader-contact time when the node itself is the leader. Any read, when served by the leader, is going to be within the freshness bound.

Fixes https://github.com/rqlite/rqlite/issues/1048