### PR TITLE
fix minor unreachable code caused by t.Fatal

### DIFF
--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -102,12 +102,12 @@ func Test_MergeQueuedStatements(t *testing.T) {
 			t.Fatalf("statements don't match for test %d", i)
 		}
 		if len(r.flushChans) != len(tt.exp.flushChans) {
-			t.Fatalf("incorrect number of flush channels for test %d", i)
 			for i := range r.flushChans {
 				if r.flushChans[i] != tt.exp.flushChans[i] {
-					t.Fatalf("wrong channel for test %d", i)
+					t.Errorf("wrong channel for test %d", i)
 				}
 			}
+			t.Fatalf("incorrect number of flush channels for test %d", i)
 		}
 	}
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1261,13 +1261,14 @@ func Test_MultiNodeStoreNotifyBootstrap(t *testing.T) {
 	if leader0 == leader1 && leader0 == leader2 {
 		return
 	}
-	t.Fatalf("leader not the same on each node")
 
 	// Calling Notify() on a node that is part of a cluster should
 	// be a no-op.
 	if err := s0.Notify(s1.ID(), ln1.Addr().String()); err != nil {
-		t.Fatalf("failed to notify store that is part of cluster: %s", err.Error())
+		t.Errorf("failed to notify store that is part of cluster: %s", err.Error())
 	}
+
+	t.Fatalf("leader not the same on each node")
 }
 
 func Test_MultiNodeJoinNonVoterRemove(t *testing.T) {


### PR DESCRIPTION
https://pkg.go.dev/testing#T.Fatalf
> Fatalf is equivalent to Logf followed by FailNow.

https://pkg.go.dev/testing#T.FailNow
> FailNow marks the function as having failed and stops its execution by calling runtime.Goexit (which then runs all deferred calls in the current goroutine).