### PR TITLE
Notified node checks address resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.9.1 (unreleased)
 ### Implementation changes and bug fixes
 - [PR #1086](https://github.com/rqlite/rqlite/pull/1086): Restoring via follower should have same HTTP response body.
+- [PR #1087](https://github.com/rqlite/rqlite/pull/1087): Notified node checks address resolution.
 
 ## 7.9.0 (October 22nd 2022)
 This release makes it more convenient to load SQLite files directly into rqlite, as any node can now process the request. For this to work however, all nodes in your cluster must be running 7.9.0 (or later). Otherwse 7.9.0 is fully compatible with earlier release, so a rolling upgrade process is an option.

--- a/cluster/bootstrap.go
+++ b/cluster/bootstrap.go
@@ -119,9 +119,9 @@ func (b *Bootstrapper) Boot(id, raftAddr string, done func() bool, timeout time.
 			// one yet.
 			if !notifySuccess {
 				if err := b.notify(targets, id, raftAddr); err != nil {
-					b.logger.Printf("failed to notify %s, retrying", targets)
+					b.logger.Printf("failed to notify all targets: %s (will retry)", targets)
 				} else {
-					b.logger.Printf("succeeded notifying %s", targets)
+					b.logger.Printf("succeeded notifying all targets: %s", targets)
 					notifySuccess = true
 				}
 			}
@@ -174,7 +174,8 @@ func (b *Bootstrapper) notify(targets []string, id, raftAddr string) error {
 				// record information about which protocol a registered node is actually using.
 				if strings.HasPrefix(fullTarget, "https://") {
 					// It's already HTTPS, give up.
-					return fmt.Errorf("failed to notify node at %s: %s", fullTarget, resp.Status)
+					return fmt.Errorf("failed to notify node at %s: %s", rurl.RemoveBasicAuth(fullTarget),
+						resp.Status)
 				}
 				fullTarget = rurl.EnsureHTTPS(fullTarget)
 			default:

--- a/http/service.go
+++ b/http/service.go
@@ -424,13 +424,13 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	remoteID, ok := md["id"]
+	rID, ok := md["id"]
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	remoteAddr, ok := md["addr"]
+	rAddr, ok := md["addr"]
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -440,13 +440,28 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		voter = true
 	}
-
 	if voter.(bool) && !s.CheckRequestPerm(r, auth.PermJoin) {
 		http.Error(w, "joining as voter not allowed", http.StatusUnauthorized)
 		return
 	}
 
-	if err := s.store.Join(remoteID.(string), remoteAddr.(string), voter.(bool)); err != nil {
+	remoteID, remoteAddr := rID.(string), rAddr.(string)
+
+	s.logger.Printf("received join request from node with ID %s at %s",
+		remoteID, remoteAddr)
+
+	// Confirm that this node can resolve the remote address. This can happen due
+	// to incomplete DNS records across the underlying infrastructure. If it can't
+	// then don't consider this join attempt successful -- so the joining node
+	// will presumably try again.
+	if addr, err := resolvableAddress(remoteAddr); err != nil {
+		s.logger.Printf("failed to resolve %s (%s) while handling join request", addr, err)
+		http.Error(w, fmt.Sprintf("can't resolve %s (%s)", addr, err.Error()),
+			http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := s.store.Join(remoteID, remoteAddr, voter.(bool)); err != nil {
 		if err == store.ErrNotLeader {
 			leaderAPIAddr := s.LeaderAPIAddr()
 			if leaderAPIAddr == "" {
@@ -499,6 +514,9 @@ func (s *Service) handleNotify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	remoteID, remoteAddr := rID.(string), rAddr.(string)
+
+	s.logger.Printf("received notify request from node with ID %s at %s",
+		remoteID, remoteAddr)
 
 	// Confirm that this node can resolve the remote address. This can happen due
 	// to incomplete DNS records across the underlying infrastructure. If it can't

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -806,7 +806,7 @@ func Test_NotifyNoResolve(t *testing.T) {
 
 	client := &http.Client{}
 	host := fmt.Sprintf("http://%s", s.Addr().String())
-	resp, err := client.Post(host+"/notify", "application/json", mustMarshalNotifyMap("id1", "nonsense-domain"))
+	resp, err := client.Post(host+"/notify", "application/json", mustMarshalNotifyMap("id1", "nonsense-domain:4444"))
 	if err != nil {
 		t.Fatalf("failed to make load request")
 	}

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -490,7 +490,7 @@ func Test_401Join(t *testing.T) {
 	client := &http.Client{}
 	host := fmt.Sprintf("http://%s", s.Addr().String())
 
-	resp, err := client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001", "voter": true}`))
+	resp, err := client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001", "voter": true}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}
@@ -498,7 +498,7 @@ func Test_401Join(t *testing.T) {
 		t.Fatalf("failed to get expected StatusOK for join, got %d", resp.StatusCode)
 	}
 
-	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001"}`))
+	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001"}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}
@@ -506,7 +506,7 @@ func Test_401Join(t *testing.T) {
 		t.Fatalf("failed to get expected StatusOK for join, got %d", resp.StatusCode)
 	}
 
-	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001", "voter": false}`))
+	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001", "voter": false}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}
@@ -532,7 +532,7 @@ func Test_401JoinReadOnly(t *testing.T) {
 	client := &http.Client{}
 	host := fmt.Sprintf("http://%s", s.Addr().String())
 
-	resp, err := client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001", "voter": true}`))
+	resp, err := client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001", "voter": true}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}
@@ -540,7 +540,7 @@ func Test_401JoinReadOnly(t *testing.T) {
 		t.Fatalf("failed to get expected StatusUnauthorized for join, got %d", resp.StatusCode)
 	}
 
-	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001"}`))
+	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001"}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}
@@ -548,7 +548,7 @@ func Test_401JoinReadOnly(t *testing.T) {
 		t.Fatalf("failed to get expected StatusUnauthorized for join, got %d", resp.StatusCode)
 	}
 
-	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":":4001", "voter": false}`))
+	resp, err = client.Post(host+"/join", "application/json", strings.NewReader(`{"id": "1", "addr":"localhost:4001", "voter": false}`))
 	if err != nil {
 		t.Fatalf("failed to make join request")
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -894,6 +894,8 @@ func (s *Store) Load(lr *command.LoadRequest) error {
 // bootstrapping will be attempted using this Store. "Expected level" includes
 // this node, so this node must self-notify to ensure the cluster bootstraps
 // with the *advertised Raft address* which the Store doesn't know about.
+//
+// Notifying is idempotent. A node may repeatedly notify the Store without issue.
 func (s *Store) Notify(id, addr string) error {
 	s.notifyMu.Lock()
 	defer s.notifyMu.Unlock()

--- a/store/store.go
+++ b/store/store.go
@@ -929,7 +929,7 @@ func (s *Store) Notify(id, addr string) error {
 	if bf.Error() != nil {
 		s.logger.Printf("cluster bootstrap failed: %s", bf.Error())
 	} else {
-		s.logger.Printf("cluster bootstrap successful")
+		s.logger.Printf("cluster bootstrap successful, servers: %s", raftServers)
 	}
 	s.bootstrapped = true
 	return nil
@@ -938,7 +938,6 @@ func (s *Store) Notify(id, addr string) error {
 // Join joins a node, identified by id and located at addr, to this store.
 // The node must be ready to respond to Raft communications at that address.
 func (s *Store) Join(id, addr string, voter bool) error {
-	s.logger.Printf("received request from node with ID %s, at %s, to join this node", id, addr)
 	if s.raft.State() != raft.Leader {
 		return ErrNotLeader
 	}


### PR DESCRIPTION
If a non-resolvable address is passed to the Store, and then Store then adds that to the config, it can result in a cluster that seems to have insufficient members (since the remote node can't be contacted). This may trigger a new leader election.