### PR TITLE
Set 'synchronous' to OFF for on-disk databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.20.4 (unreleased)
+This release changes the "syncing" mode SQLite uses with on-disk files, by switching "synchronous" to OFF. The [SQLite docs](https://www.sqlite.org/pragma.html#pragma_synchronous) state that this risks database corruption in the event of a crash, but that's OK, as rqlite always blows away any SQLite database on startup and rebuilds it from the Raft log. Testing should this results in (at least) a 3x speed-up in write performance.
+
+### Implementation changes and bug fixes
+- [PR #1301](https://github.com/rqlite/rqlite/pull/1301): Set sychronous mode to `OFF` for SQLite on-disk files.
+
 ## 7.20.3 (June 12th 2023))
 ### Implementation changes and bug fixes
 - [PR #1298](https://github.com/rqlite/rqlite/pull/1298): Move FSMSnapshot to own source file.

--- a/db/db.go
+++ b/db/db.go
@@ -137,6 +137,14 @@ func Open(dbPath string, fkEnabled bool) (*DB, error) {
 		return nil, err
 	}
 
+	// Set synchronous to OFF, to improve performance. The SQLite docs state that
+	// this risks database corruption in the event of a crash, but that's OK, as
+	// rqlite blows away the database on startup and always rebuilds it from the
+	// Raft log.
+	if _, err := rwDB.Exec("PRAGMA synchronous=OFF"); err != nil {
+		return nil, err
+	}
+
 	roOpts := []string{
 		"mode=ro",
 		fmt.Sprintf("_fk=%s", strconv.FormatBool(fkEnabled)),

--- a/store/store.go
+++ b/store/store.go
@@ -420,7 +420,7 @@ func (s *Store) Open() (retErr error) {
 	if s.StartupOnDisk || (!s.dbConf.Memory && !s.snapsExistOnOpen && s.lastCommandIdxOnOpen == 0) {
 		s.db, err = createOnDisk(nil, s.dbPath, s.dbConf.FKConstraints)
 		if err != nil {
-			return fmt.Errorf("failed to create on-disk database")
+			return fmt.Errorf("failed to create on-disk database: %s", err)
 		}
 		s.onDiskCreated = true
 		s.logger.Printf("created on-disk database at open")
@@ -428,7 +428,7 @@ func (s *Store) Open() (retErr error) {
 		// We need an in-memory database, at least for bootstrapping purposes.
 		s.db, err = createInMemory(nil, s.dbConf.FKConstraints)
 		if err != nil {
-			return fmt.Errorf("failed to create in-memory database")
+			return fmt.Errorf("failed to create in-memory database: %s", err)
 		}
 		s.logger.Printf("created in-memory database at open")
 	}


### PR DESCRIPTION
The SQLite docs state that this risks database corruption in the event of a crash, but that's OK, as rqlite always blows away the database on startup and rebuilds it from the Raft log.

In my testing this results in 3x speed-up in write performance -- you get 3x the INSERT rate.