### PR TITLE
Add full WAL-support to DB layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Implementation changes and bug fixes
 - [PR #1305](https://github.com/rqlite/rqlite/pull/1305): Upgrade dependencies via `go get`.
 - [PR #1306](https://github.com/rqlite/rqlite/pull/1306): Add some (currently unused) WAL control code.
+- [PR #1307](https://github.com/rqlite/rqlite/pull/1307): Add full WAL-support to database layer. Not yet enabled by full application.
 
 ## 7.20.5 (June 14th 2023)
 ### Implementation changes and bug fixes

--- a/db/db.go
+++ b/db/db.go
@@ -24,14 +24,16 @@ const (
 )
 
 const (
-	numExecutions      = "executions"
-	numExecutionErrors = "execution_errors"
-	numQueries         = "queries"
-	numQueryErrors     = "query_errors"
-	numRequests        = "requests"
-	numETx             = "execute_transactions"
-	numQTx             = "query_transactions"
-	numRTx             = "request_transactions"
+	numCheckpoints      = "checkpoints"
+	numCheckpointErrors = "checkpoint_errors"
+	numExecutions       = "executions"
+	numExecutionErrors  = "execution_errors"
+	numQueries          = "queries"
+	numQueryErrors      = "query_errors"
+	numRequests         = "requests"
+	numETx              = "execute_transactions"
+	numQTx              = "query_transactions"
+	numRTx              = "request_transactions"
 )
 
 // DBVersion is the SQLite version.
@@ -50,6 +52,8 @@ func init() {
 // ResetStats resets the expvar stats for this module. Mostly for test purposes.
 func ResetStats() {
 	stats.Init()
+	stats.Add(numCheckpoints, 0)
+	stats.Add(numCheckpointErrors, 0)
 	stats.Add(numExecutions, 0)
 	stats.Add(numExecutionErrors, 0)
 	stats.Add(numQueries, 0)
@@ -65,6 +69,7 @@ type DB struct {
 	path      string // Path to database file, if running on-disk.
 	memory    bool   // In-memory only.
 	fkEnabled bool   // Foreign key constraints enabled
+	wal       bool
 
 	rwDB *sql.DB // Database connection for database reads and writes.
 	roDB *sql.DB // Database connection database reads.
@@ -133,7 +138,7 @@ func IsWALModeEnabled(b []byte) bool {
 
 // Open opens a file-based database, creating it if it does not exist. After this
 // function returns, an actual SQLite file will always exist.
-func Open(dbPath string, fkEnabled bool) (*DB, error) {
+func Open(dbPath string, fkEnabled, wal bool) (*DB, error) {
 	rwDSN := fmt.Sprintf("file:%s?_fk=%s", dbPath, strconv.FormatBool(fkEnabled))
 	rwDB, err := sql.Open("sqlite3", rwDSN)
 	if err != nil {
@@ -146,6 +151,12 @@ func Open(dbPath string, fkEnabled bool) (*DB, error) {
 	// Raft log.
 	if _, err := rwDB.Exec("PRAGMA synchronous=OFF"); err != nil {
 		return nil, err
+	}
+
+	if wal {
+		if _, err := rwDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+			return nil, err
+		}
 	}
 
 	roOpts := []string{
@@ -173,6 +184,7 @@ func Open(dbPath string, fkEnabled bool) (*DB, error) {
 	return &DB{
 		path:      dbPath,
 		fkEnabled: fkEnabled,
+		wal:       wal,
 		rwDB:      rwDB,
 		roDB:      roDB,
 		rwDSN:     rwDSN,
@@ -236,13 +248,13 @@ func OpenInMemory(fkEnabled bool) (*DB, error) {
 // LoadIntoMemory loads an in-memory database with that at the path.
 // Not safe to call while other operations are happening with the
 // source database.
-func LoadIntoMemory(dbPath string, fkEnabled bool) (*DB, error) {
+func LoadIntoMemory(dbPath string, fkEnabled, wal bool) (*DB, error) {
 	dstDB, err := OpenInMemory(fkEnabled)
 	if err != nil {
 		return nil, err
 	}
 
-	srcDB, err := Open(dbPath, false)
+	srcDB, err := Open(dbPath, fkEnabled, wal)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +402,15 @@ func (db *DB) FileSize() (int64, error) {
 
 // Checkpoint performs a WAL checkpoint. If the checkpoint does not complete
 // within the given duration, an error is returned.
-func (db *DB) Checkpoint(dur time.Duration) error {
+func (db *DB) Checkpoint(dur time.Duration) (err error) {
+	defer func() {
+		if err != nil {
+			stats.Add(numCheckpointErrors, 1)
+		} else {
+			stats.Add(numCheckpoints, 1)
+		}
+	}()
+
 	var ok int
 	var nPages int
 	var nMoved int
@@ -423,6 +443,21 @@ func (db *DB) Checkpoint(dur time.Duration) error {
 			return fmt.Errorf("checkpoint timeout")
 		}
 	}
+}
+
+// DisableCheckpoint disables the automatic checkpointing that occurs when
+// the WAL reaches a certain size. This is key for full control of snapshotting.
+// and can be useful for testing.
+func (db *DB) DisableCheckpointing() error {
+	_, err := db.rwDB.Exec("PRAGMA wal_autocheckpoint=-1")
+	return err
+}
+
+// EnableCheckpointing enables the automatic checkpointing that occurs when
+// the WAL reaches a certain size.
+func (db *DB) EnableCheckpointing() error {
+	_, err := db.rwDB.Exec("PRAGMA wal_autocheckpoint=1000")
+	return err
 }
 
 // InMemory returns whether this database is in-memory.
@@ -848,7 +883,7 @@ func (db *DB) Request(req *command.Request, xTime bool) ([]*command.ExecuteQuery
 // Backup writes a consistent snapshot of the database to the given file.
 // This function can be called when changes to the database are in flight.
 func (db *DB) Backup(path string) error {
-	dstDB, err := Open(path, false)
+	dstDB, err := Open(path, false, false)
 	if err != nil {
 		return err
 	}
@@ -1039,28 +1074,25 @@ func (db *DB) pragmas() (map[string]interface{}, error) {
 		"ro": db.roDB,
 	}
 
-	m := make(map[string]interface{})
+	connsMap := make(map[string]interface{})
 	for k, v := range conns {
-		var sync string
-		if err := v.QueryRow("PRAGMA synchronous").Scan(&sync); err != nil {
-			return nil, err
+		pragmasMap := make(map[string]string)
+		for _, p := range []string{
+			"synchronous",
+			"journal_mode",
+			"foreign_keys",
+			"wal_autocheckpoint",
+		} {
+			var s string
+			if err := v.QueryRow(fmt.Sprintf("PRAGMA %s", p)).Scan(&s); err != nil {
+				return nil, err
+			}
+			pragmasMap[p] = s
 		}
-		var jm string
-		if err := v.QueryRow("PRAGMA journal_mode").Scan(&jm); err != nil {
-			return nil, err
-		}
-		var fk string
-		if err := v.QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
-			return nil, err
-		}
-		m[k] = map[string]string{
-			"synchronous":  sync,
-			"journal_mode": jm,
-			"foreign_keys": fk,
-		}
+		connsMap[k] = pragmasMap
 	}
 
-	return m, nil
+	return connsMap, nil
 }
 
 func (db *DB) memStats() (map[string]int64, error) {

--- a/db/db_common_test.go
+++ b/db/db_common_test.go
@@ -1008,6 +1008,11 @@ func testDBFileSize(t *testing.T, db *DB) {
 		t.Fatalf("failed to read database file size: %s", err)
 	}
 }
+func testDBWALSize(t *testing.T, db *DB) {
+	if _, err := db.WALSize(); err != nil {
+		t.Fatalf("failed to read database WAL file size: %s", err)
+	}
+}
 
 func testStmtReadOnly(t *testing.T, db *DB) {
 	r, err := db.ExecuteStringStmt(`CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)`)
@@ -1302,6 +1307,7 @@ func Test_DatabaseCommonOperations(t *testing.T) {
 		{"Dump", testDump},
 		{"Size", testSize},
 		{"DBFileSize", testDBFileSize},
+		{"DBWALSize", testDBWALSize},
 		{"StmtReadOnly", testStmtReadOnly},
 		{"JSON1", testJSON1},
 		{"DBSTAT_table", testDBSTAT_table},

--- a/db/db_common_test.go
+++ b/db/db_common_test.go
@@ -967,7 +967,7 @@ func testSerialize(t *testing.T, db *DB) {
 		t.Fatalf("failed to write serialized database to file: %s", err.Error())
 	}
 
-	newDB, err := Open(dstDB.Name(), false)
+	newDB, err := Open(dstDB.Name(), false, false)
 	if err != nil {
 		t.Fatalf("failed to open on-disk serialized database: %s", err.Error())
 	}
@@ -1196,7 +1196,7 @@ func testCopy(t *testing.T, db *DB) {
 
 	dstFile := mustTempFile()
 	defer os.Remove(dstFile)
-	dstDB, err := Open(dstFile, false)
+	dstDB, err := Open(dstFile, false, false)
 	if err != nil {
 		t.Fatalf("failed to open destination database: %s", err)
 	}
@@ -1252,7 +1252,7 @@ func testBackup(t *testing.T, db *DB) {
 		t.Fatalf("failed to backup database: %s", err.Error())
 	}
 
-	newDB, err := Open(dstDB, false)
+	newDB, err := Open(dstDB, false, false)
 	if err != nil {
 		t.Fatalf("failed to open backup database: %s", err.Error())
 	}
@@ -1310,10 +1310,17 @@ func Test_DatabaseCommonOperations(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		db, path := mustCreateDatabase()
+		db, path := mustCreateOnDiskDatabase()
 		defer db.Close()
 		defer os.Remove(path)
 		t.Run(tc.name+":disk", func(t *testing.T) {
+			tc.testFunc(t, db)
+		})
+
+		db, path = mustCreateOnDiskDatabaseWAL()
+		defer db.Close()
+		defer os.Remove(path)
+		t.Run(tc.name+":wal", func(t *testing.T) {
 			tc.testFunc(t, db)
 		})
 

--- a/db/db_inmem_test.go
+++ b/db/db_inmem_test.go
@@ -47,7 +47,7 @@ func Test_TableCreationInMemory(t *testing.T) {
 }
 
 func Test_LoadIntoMemory(t *testing.T) {
-	db, path := mustCreateDatabase()
+	db, path := mustCreateOnDiskDatabase()
 	defer db.Close()
 	defer os.Remove(path)
 
@@ -64,7 +64,7 @@ func Test_LoadIntoMemory(t *testing.T) {
 		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
 	}
 
-	inmem, err := LoadIntoMemory(path, false)
+	inmem, err := LoadIntoMemory(path, false, false)
 	if err != nil {
 		t.Fatalf("failed to create loaded in-memory database: %s", err.Error())
 	}
@@ -80,7 +80,7 @@ func Test_LoadIntoMemory(t *testing.T) {
 }
 
 func Test_DeserializeIntoMemory(t *testing.T) {
-	db, path := mustCreateDatabase()
+	db, path := mustCreateOnDiskDatabase()
 	defer db.Close()
 	defer os.Remove(path)
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -116,7 +116,7 @@ func Test_ConcurrentQueriesInMemory(t *testing.T) {
 }
 
 func Test_SimpleTransaction(t *testing.T) {
-	db, path := mustCreateDatabase()
+	db, path := mustCreateOnDiskDatabase()
 	defer db.Close()
 	defer os.Remove(path)
 
@@ -159,7 +159,7 @@ func Test_SimpleTransaction(t *testing.T) {
 }
 
 func Test_PartialFailTransaction(t *testing.T) {
-	db, path := mustCreateDatabase()
+	db, path := mustCreateOnDiskDatabase()
 	defer db.Close()
 	defer os.Remove(path)
 
@@ -201,12 +201,23 @@ func Test_PartialFailTransaction(t *testing.T) {
 	}
 }
 
-func mustCreateDatabase() (*DB, string) {
+func mustCreateOnDiskDatabase() (*DB, string) {
 	var err error
 	f := mustTempFile()
-	db, err := Open(f, false)
+	db, err := Open(f, false, false)
 	if err != nil {
-		panic("failed to open database")
+		panic("failed to open database in DELETE mode")
+	}
+
+	return db, f
+}
+
+func mustCreateOnDiskDatabaseWAL() (*DB, string) {
+	var err error
+	f := mustTempFile()
+	db, err := Open(f, false, true)
+	if err != nil {
+		panic("failed to open database in WAL mode")
 	}
 
 	return db, f

--- a/store/store.go
+++ b/store/store.go
@@ -2042,7 +2042,7 @@ func createOnDisk(b []byte, path string, fkConstraints bool) (*sql.DB, error) {
 			return nil, err
 		}
 	}
-	return sql.Open(path, fkConstraints)
+	return sql.Open(path, fkConstraints, false)
 }
 
 func readUint64(b []byte) (uint64, error) {


### PR DESCRIPTION
If the Store creates an on-disk database, it still enables DELETE mode.