### PR TITLE
Periodically record actual applied index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This release changes the mode of SQLite, when rqlite is running in _on-disk_ mod
 - [PR #1314](https://github.com/rqlite/rqlite/pull/1314): More preparations for WAL mode when running on-disk.
 - [PR #1315](https://github.com/rqlite/rqlite/pull/1315), [PR #1316](https://github.com/rqlite/rqlite/pull/1316): Enable WAL when running in on-disk mode.
 - [PR #1317](https://github.com/rqlite/rqlite/pull/1317): DB-layer now supports WAL replay.
+- [PR #1318](https://github.com/rqlite/rqlite/pull/1318): Periodically record actual applied index
   
 ## 7.21.0 (June 20th 2023)
 ### New features

--- a/log/log.go
+++ b/log/log.go
@@ -8,6 +8,10 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+const (
+	rqliteAppliedIndex = "rqlite_applied_index"
+)
+
 // Log is an object that can return information about the Raft log.
 type Log struct {
 	*raftboltdb.BoltStore
@@ -48,12 +52,7 @@ func (l *Log) Indexes() (uint64, uint64, error) {
 // LastCommandIndex returns the index of the last Command
 // log entry written to the Raft log. Returns an index of
 // zero if no such log exists.
-func (l *Log) LastCommandIndex() (uint64, error) {
-	fi, li, err := l.Indexes()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get indexes: %s", err)
-	}
-
+func (l *Log) LastCommandIndex(fi, li uint64) (uint64, error) {
 	// Check for empty log.
 	if li == 0 {
 		return 0, nil
@@ -69,6 +68,20 @@ func (l *Log) LastCommandIndex() (uint64, error) {
 		}
 	}
 	return 0, nil
+}
+
+// SetAppliedIndex sets the AppliedIndex value.
+func (l *Log) SetAppliedIndex(index uint64) error {
+	return l.SetUint64([]byte(rqliteAppliedIndex), index)
+}
+
+// GetAppliedIndex returns the AppliedIndex value.
+func (l *Log) GetAppliedIndex() (uint64, error) {
+	i, err := l.GetUint64([]byte(rqliteAppliedIndex))
+	if err != nil {
+		return 0, nil
+	}
+	return i, nil
 }
 
 // Stats returns stats about the BBoltDB database.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -33,7 +33,7 @@ func Test_LogNewEmpty(t *testing.T) {
 		t.Fatalf("got non-zero value for last index of empty log: %d", li)
 	}
 
-	lci, err := l.LastCommandIndex()
+	lci, err := l.LastCommandIndex(fi, li)
 	if err != nil {
 		t.Fatalf("failed to get last command index: %s", err)
 	}
@@ -83,7 +83,7 @@ func Test_LogNewExistNotEmpty(t *testing.T) {
 		t.Fatalf("got wrong value for last index of not empty log: %d", li)
 	}
 
-	lci, err := l.LastCommandIndex()
+	lci, err := l.LastCommandIndex(fi, li)
 	if err != nil {
 		t.Fatalf("failed to get last command index: %s", err)
 	}
@@ -185,7 +185,7 @@ func Test_LogNewExistNotEmptyNoFreelistSync(t *testing.T) {
 		t.Fatalf("got wrong value for last index of not empty log: %d", li)
 	}
 
-	lci, err := l.LastCommandIndex()
+	lci, err := l.LastCommandIndex(fi, li)
 	if err != nil {
 		t.Fatalf("failed to get last command index: %s", err)
 	}
@@ -288,7 +288,7 @@ func Test_LogLastCommandIndexNotExist(t *testing.T) {
 		t.Fatalf("got wrong for last index of not empty log: %d", li)
 	}
 
-	lci, err := l.LastCommandIndex()
+	lci, err := l.LastCommandIndex(fi, li)
 	if err != nil {
 		t.Fatalf("failed to get last command index: %s", err)
 	}
@@ -317,12 +317,45 @@ func Test_LogLastCommandIndexNotExist(t *testing.T) {
 		t.Fatalf("failed to create new log: %s", err)
 	}
 
-	lci, err = l.LastCommandIndex()
+	fi, li, err = l.Indexes()
+	if err != nil {
+		t.Fatalf("failed to get indexes: %s", err)
+	}
+	lci, err = l.LastCommandIndex(fi, li)
 	if err != nil {
 		t.Fatalf("failed to get last command index: %s", err)
 	}
 	if lci != 0 {
 		t.Fatalf("got wrong value for last command index of not empty log: %d", lci)
+	}
+}
+
+func Test_LogAppliedIndex(t *testing.T) {
+	path := mustTempFile()
+	defer os.Remove(path)
+
+	l, err := New(path, false)
+	if err != nil {
+		t.Fatalf("failed to create new log: %s", err)
+	}
+
+	ai, err := l.GetAppliedIndex()
+	if err != nil {
+		t.Fatalf("failed to get applied index: %s", err)
+	}
+	if ai != 0 {
+		t.Fatalf("got wrong applied index for non-existent key: %d", ai)
+	}
+
+	if l.SetAppliedIndex(1234); err != nil {
+		t.Fatalf("failed to set applied index: %s", err)
+	}
+	ai, err = l.GetAppliedIndex()
+	if err != nil {
+		t.Fatalf("failed to get applied index: %s", err)
+	}
+	if ai != 1234 {
+		t.Fatalf("got wrong applied index: %d", ai)
 	}
 }
 


### PR DESCRIPTION
This ensures the system doesn't apply uncommitted log entries to the FSM, if it runs the in-memory startup. There have been no reports of this in the field -- it is an edge case -- but this removes any chance of it.