### PR TITLE
Remove on-disk-startup control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.21.4 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1336](https://github.com/rqlite/rqlite/pull/1336): Remove on-disk-startup control.
+
 ## 7.21.3 (July 7th 2023)
 ### Implementation changes and bug fixes
 - [PR #1329](https://github.com/rqlite/rqlite/pull/1329): Try a different version of V2 Snapshot codec.

--- a/cmd/rqlited/flags.go
+++ b/cmd/rqlited/flags.go
@@ -476,7 +476,7 @@ func ParseFlags(name, desc string, build *BuildInfo) (*Config, error) {
 	flag.BoolVar(&config.PprofEnabled, "pprof", true, "Serve pprof data on HTTP server")
 	flag.BoolVar(&config.OnDisk, "on-disk", false, "Use an on-disk SQLite database")
 	flag.StringVar(&config.OnDiskPath, "on-disk-path", "", "Path for SQLite on-disk database file. If not set, use a file in data directory")
-	flag.BoolVar(&config.OnDiskStartup, "on-disk-startup", false, "Do not initialize on-disk database in memory first at startup")
+	flag.BoolVar(&config.OnDiskStartup, "on-disk-startup", false, "Ignored, on-disk startup optimization control no longer necessary")
 	flag.BoolVar(&config.FKConstraints, "fk", false, "Enable SQLite foreign key constraints")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&config.RaftNonVoter, "raft-non-voter", false, "Configure as non-voting node")

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -304,7 +304,6 @@ func createStore(cfg *Config, ln *tcp.Layer) (*store.Store, error) {
 	})
 
 	// Set optional parameters on store.
-	str.StartupOnDisk = cfg.OnDiskStartup
 	str.SetRequestCompression(cfg.CompressionBatch, cfg.CompressionSize)
 	str.RaftLogLevel = cfg.RaftLogLevel
 	str.NoFreeListSync = cfg.RaftNoFreelistSync

--- a/store/store.go
+++ b/store/store.go
@@ -1566,18 +1566,18 @@ func (s *Store) Restore(rc io.ReadCloser) error {
 	}
 
 	var db *sql.DB
-	if !s.dbConf.Memory {
+	if s.dbConf.Memory {
+		db, err = createInMemory(b, s.dbConf.FKConstraints)
+		if err != nil {
+			return fmt.Errorf("createInMemory: %s", err)
+		}
+	} else {
 		db, err = createOnDisk(b, s.dbPath, s.dbConf.FKConstraints, !s.dbConf.DisableWAL)
 		if err != nil {
 			return fmt.Errorf("open on-disk file during restore: %s", err)
 		}
 		s.onDiskCreated = true
 		s.logger.Println("successfully switched to on-disk database due to restore")
-	} else {
-		db, err = createInMemory(b, s.dbConf.FKConstraints)
-		if err != nil {
-			return fmt.Errorf("createInMemory: %s", err)
-		}
 	}
 	s.db = db
 

--- a/store/store.go
+++ b/store/store.go
@@ -327,7 +327,9 @@ func (s *Store) Open() (retErr error) {
 	s.openT = time.Now()
 	s.logger.Printf("opening store with node ID %s", s.raftID)
 
-	if !s.dbConf.Memory {
+	if s.dbConf.Memory {
+		s.logger.Printf("configured for an in-memory database")
+	} else {
 		s.logger.Printf("configured for an on-disk database at %s", s.dbPath)
 		parentDir := filepath.Dir(s.dbPath)
 		s.logger.Printf("ensuring directory for on-disk database exists at %s", parentDir)
@@ -335,8 +337,6 @@ func (s *Store) Open() (retErr error) {
 		if err != nil {
 			return err
 		}
-	} else {
-		s.logger.Printf("configured for an in-memory database")
 	}
 
 	// Create all the required Raft directories.

--- a/store/store_restart_test.go
+++ b/store/store_restart_test.go
@@ -206,21 +206,10 @@ func openStoreCloseStartup(t *testing.T, s *Store) {
 	}
 }
 
-// Test_OpenStoreCloseStartupOnDiskSingleNode tests that the on-disk
-// optimization can be disabled in various scenarios.
+// Test_OpenStoreCloseStartupOnDiskSingleNode tests that on-disk
+// works fine during various restart scenarios.
 func Test_OpenStoreCloseStartupOnDiskSingleNode(t *testing.T) {
 	s, ln := mustNewStore(t, false)
-	s.StartupOnDisk = true
-	defer ln.Close()
-
-	openStoreCloseStartup(t, s)
-}
-
-// Test_OpenStoreCloseStartupMemorySingleNode tests that the on-disk
-// optimization works fine.
-func Test_OpenStoreCloseStartupMemorySingleNode(t *testing.T) {
-	s, ln := mustNewStore(t, false)
-	s.StartupOnDisk = false
 	defer ln.Close()
 
 	openStoreCloseStartup(t, s)


### PR DESCRIPTION
With the move to WAL and "synchronous mode" to OFF, on-disk startup times are very close to in-memory. There is no need for this control anymore and it complicates the start-up code.