### PR TITLE
1 RW DB connection only!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ When officially released 8.0 will support (mostly) seamless upgrades from the 7.
 - [PR #1386](https://github.com/rqlite/rqlite/pull/1386): Ensure full sync'ing and closing of files during WAL replay.
 - [PR #1388](https://github.com/rqlite/rqlite/pull/1388): Ensure databases open with WAL checkpoint disabled. Thanks @benbjohnson.
 - [PR #1390](https://github.com/rqlite/rqlite/pull/1390): Add Restore functions to Snapshot Store.
+- [PR #1394](https://github.com/rqlite/rqlite/pull/1394): Use only one RW database connection.
 
 ## 7.21.4 (July 8th 2023)
 ### Implementation changes and bug fixes

--- a/db/db.go
+++ b/db/db.go
@@ -345,9 +345,9 @@ func Open(dbPath string, fkEnabled, wal bool) (*DB, error) {
 		return nil, fmt.Errorf("failed to ping on-disk database: %s", err.Error())
 	}
 
-	// Set some reasonable connection pool behaviour.
-	rwDB.SetConnMaxIdleTime(30 * time.Second)
+	// Set connection pool behaviour.
 	rwDB.SetConnMaxLifetime(0)
+	rwDB.SetMaxOpenConns(1) // Key to ensure a new connection doesn't enable checkpointing
 	roDB.SetConnMaxIdleTime(30 * time.Second)
 	roDB.SetConnMaxLifetime(0)
 


### PR DESCRIPTION
Connections where coming from the pool, and if they were new, they had autocheckpointing set back to 1000!