### PR TITLE
release: add missing dash in linux quickstart instructions

### DIFF
--- a/scripts/release_creator.py
+++ b/scripts/release_creator.py
@@ -33,7 +33,7 @@ To download and start rqlite, execute the following in a shell.
 ```
 curl -L https://github.com/rqlite/rqlite/releases/download/{release}/rqlite-{release}-linux-amd64.tar.gz -o rqlite-{release}-linux-amd64.tar.gz
 tar xvfz rqlite-{release}-linux-amd64.tar.gz
-cd rqlite-{release}linux-amd64
+cd rqlite-{release}-linux-amd64
 ./rqlited ~/node.1
 ```
 


### PR DESCRIPTION
There is a missing dash that causes the `cd` command to fail, if one is following/automating the instructions blindly.