### PR TITLE
Support accessing rqlite in browsers by setting appropriate Access-Control-Allow headers and handling OPTIONS requests

### DIFF
--- a/cmd/rqlited/flags.go
+++ b/cmd/rqlited/flags.go
@@ -47,6 +47,9 @@ type Config struct {
 	// HTTPAdv is the advertised HTTP server network.
 	HTTPAdv string
 
+	// HTTPAllowOrigin is the value to set for Access-Control-Allow-Origin HTTP header.
+	HTTPAllowOrigin string
+
 	// AuthFile is the path to the authentication file. May not be set.
 	AuthFile string `filepath:"true"`
 
@@ -411,6 +414,7 @@ func ParseFlags(name, desc string, build *BuildInfo) (*Config, error) {
 	flag.StringVar(&config.NodeID, "node-id", "", "Unique ID for node. If not set, set to advertised Raft address")
 	flag.StringVar(&config.HTTPAddr, HTTPAddrFlag, "localhost:4001", "HTTP server bind address. To enable HTTPS, set X.509 certificate and key")
 	flag.StringVar(&config.HTTPAdv, HTTPAdvAddrFlag, "", "Advertised HTTP address. If not set, same as HTTP server bind address")
+	flag.StringVar(&config.HTTPAllowOrigin, "http-allow-origin", "", "Value to set for Access-Control-Allow-Origin HTTP header")
 	flag.StringVar(&config.HTTPx509CACert, "http-ca-cert", "", "Path to X.509 CA certificate for HTTPS")
 	flag.StringVar(&config.HTTPx509Cert, HTTPx509CertFlag, "", "Path to HTTPS X.509 certificate")
 	flag.StringVar(&config.HTTPx509Key, HTTPx509KeyFlag, "", "Path to HTTPS X.509 private key")

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -381,6 +381,7 @@ func startHTTPService(cfg *Config, str *store.Store, cltr *cluster.Client, credS
 		"compiler":   runtime.Compiler,
 		"build_time": cmd.Buildtime,
 	}
+	s.AllowOrigin = cfg.HTTPAllowOrigin
 	return s, s.Start()
 }
 

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -123,6 +123,35 @@ func Test_HasVersionHeader(t *testing.T) {
 	}
 }
 
+func Test_HasAllowOriginHeader(t *testing.T) {
+	m := &MockStore{}
+	c := &mockClusterService{}
+	s := New("127.0.0.1:0", m, c, nil)
+	if err := s.Start(); err != nil {
+		t.Fatalf("failed to start service")
+	}
+	defer s.Close()
+	url := fmt.Sprintf("http://%s", s.Addr().String())
+
+	client := &http.Client{}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("failed to make request")
+	}
+	if resp.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("incorrect allow-origin present in HTTP response header")
+	}
+
+	s.AllowOrigin = "https://www.philipotoole.com"
+	resp, err = client.Get(url)
+	if err != nil {
+		t.Fatalf("failed to make request")
+	}
+	if resp.Header.Get("Access-Control-Allow-Origin") != "https://www.philipotoole.com" {
+		t.Fatalf("incorrect allow-origin in HTTP response header")
+	}
+}
+
 func Test_HasContentTypeJSON(t *testing.T) {
 	m := &MockStore{}
 	c := &mockClusterService{}


### PR DESCRIPTION
This PR fixes #687, closes #1168, and closes #1175.

This PR implements the solution decided on in #1168 by allowing user control of `Access-Control-Allow-Origin` and setting `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, and `Access-Control-Allow-Credentials` to values that allow CORS compatible access to rqlite. Additionally, it handles `OPTIONS` requests to allow for CORS preflight requests to work. These steps enable rqlite servers to be accessed through HTTP requests in browsers.