### PR TITLE
Improve nodes/ JSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ When officially released 8.0 will support (mostly) seamless upgrades from the 7.
 - [PR #1418](https://github.com/rqlite/rqlite/pull/1418): Add basic CORS support. Fixes [issue #687](https://github.com/rqlite/rqlite/issues/687). Thanks @kkoreilly
 - [PR #1422](https://github.com/rqlite/rqlite/pull/1422): Add mTLS support to rqlite CLI. Fixes [issue #1421](https://github.com/rqlite/rqlite/issues/1421)
 - [PR #1427](https://github.com/rqlite/rqlite/pull/1427): Upgrade to SQLite 3.44.0.
-- [PR #1433](https://github.com/rqlite/rqlite/pull/1433): Support an optional better form the `nodes/`` output. Fixes [issue #1415](https://github.com/rqlite/rqlite/issues/1415)
+- [PR #1433](https://github.com/rqlite/rqlite/pull/1433): Support an optional better form the `nodes/` output. Fixes [issue #1415](https://github.com/rqlite/rqlite/issues/1415)
   
 ### Implementation changes and bug fixes
 - [PR #1368](https://github.com/rqlite/rqlite/pull/1374): Switch to always-on expvar and pprof.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ When officially released 8.0 will support (mostly) seamless upgrades from the 7.
 - [PR #1418](https://github.com/rqlite/rqlite/pull/1418): Add basic CORS support. Fixes [issue #687](https://github.com/rqlite/rqlite/issues/687). Thanks @kkoreilly
 - [PR #1422](https://github.com/rqlite/rqlite/pull/1422): Add mTLS support to rqlite CLI. Fixes [issue #1421](https://github.com/rqlite/rqlite/issues/1421)
 - [PR #1427](https://github.com/rqlite/rqlite/pull/1427): Upgrade to SQLite 3.44.0.
+- [PR #1433](https://github.com/rqlite/rqlite/pull/1433): Support an optional better form the `nodes/`` output. Fixes [issue #1415](https://github.com/rqlite/rqlite/issues/1415)
   
 ### Implementation changes and bug fixes
 - [PR #1368](https://github.com/rqlite/rqlite/pull/1374): Switch to always-on expvar and pprof.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ When officially released 8.0 will support (mostly) seamless upgrades from the 7.
 - [PR #1418](https://github.com/rqlite/rqlite/pull/1418): Add basic CORS support. Fixes [issue #687](https://github.com/rqlite/rqlite/issues/687). Thanks @kkoreilly
 - [PR #1422](https://github.com/rqlite/rqlite/pull/1422): Add mTLS support to rqlite CLI. Fixes [issue #1421](https://github.com/rqlite/rqlite/issues/1421)
 - [PR #1427](https://github.com/rqlite/rqlite/pull/1427): Upgrade to SQLite 3.44.0.
-- [PR #1433](https://github.com/rqlite/rqlite/pull/1433): Support an optional better form the `nodes/` output. Fixes [issue #1415](https://github.com/rqlite/rqlite/issues/1415)
+- [PR #1433](https://github.com/rqlite/rqlite/pull/1433): Support an optional better form for the `nodes/` output. Fixes [issue #1415](https://github.com/rqlite/rqlite/issues/1415)
   
 ### Implementation changes and bug fixes
 - [PR #1368](https://github.com/rqlite/rqlite/pull/1374): Switch to always-on expvar and pprof.

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"time"
+
+	"github.com/rqlite/rqlite/store"
+)
+
+// Node represents a single node in the cluster and can include
+// information about the node's reachability and leadership status.
+// If there was an error communicating with the node, the Error
+// field will be populated.
+type Node struct {
+	ID        string  `json:"id,omitempty"`
+	APIAddr   string  `json:"api_addr,omitempty"`
+	Addr      string  `json:"addr,omitempty"`
+	Voter     bool    `json:"voter"`
+	Reachable bool    `json:"reachable"`
+	Leader    bool    `json:"leader,omitempty"`
+	Time      float64 `json:"time,omitempty"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// Test tests the node's reachability and leadership status. If an error
+// occurs, the Error field will be populated.
+func (n *Node) Test(ga GetAddresser, leaderAddr string, timeout time.Duration) {
+	start := time.Now()
+	apiAddr, err := ga.GetNodeAPIAddr(n.Addr, timeout)
+	if err != nil {
+		n.Error = err.Error()
+		n.Reachable = false
+		return
+	}
+	n.Time = time.Since(start).Seconds()
+	n.APIAddr = apiAddr
+	n.Reachable = true
+	n.Leader = apiAddr == leaderAddr
+}
+
+// NewNodesFromServers creates a slice of Nodes from a slice of Servers.
+func NewNodesFromServers(servers []*store.Server) ([]*Node, error) {
+	nodes := make([]*Node, len(servers))
+	for i, s := range servers {
+		nodes[i] = NewNodeFromServer(s)
+	}
+	return nodes, nil
+}
+
+// NewNodeFromServer creates a Node from a Server.
+func NewNodeFromServer(s *store.Server) *Node {
+	return &Node{
+		ID:    s.ID,
+		Addr:  s.Addr,
+		Voter: s.Suffrage == "Voter",
+	}
+}

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -17,7 +17,7 @@ type Node struct {
 	Addr      string  `json:"addr,omitempty"`
 	Voter     bool    `json:"voter"`
 	Reachable bool    `json:"reachable"`
-	Leader    bool    `json:"leader,omitempty"`
+	Leader    bool    `json:"leader"`
 	Time      float64 `json:"time,omitempty"`
 	Error     string  `json:"error,omitempty"`
 }
@@ -44,7 +44,7 @@ func (n *Node) Test(ga GetAddresser, leaderAddr string, timeout time.Duration) {
 	n.Time = time.Since(start).Seconds()
 	n.APIAddr = apiAddr
 	n.Reachable = true
-	n.Leader = apiAddr == leaderAddr
+	n.Leader = n.Addr == leaderAddr
 }
 
 type Nodes []*Node

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -76,6 +76,16 @@ func (n Nodes) Voters() Nodes {
 	return v
 }
 
+// HasAddr returns whether any node in the Nodes slice has the given Raft address.
+func (n Nodes) HasAddr(addr string) bool {
+	for _, node := range n {
+		if node.Addr == addr {
+			return true
+		}
+	}
+	return false
+}
+
 // Test tests the reachability and leadership status of all nodes. It does this
 // in parallel, and blocks until all nodes have been tested.
 func (n Nodes) Test(ga GetAddresser, leaderAddr string, timeout time.Duration) {

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -49,12 +50,17 @@ func (n *Node) Test(ga GetAddresser, leaderAddr string, timeout time.Duration) {
 
 type Nodes []*Node
 
+func (n Nodes) Len() int           { return len(n) }
+func (n Nodes) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n Nodes) Less(i, j int) bool { return n[i].ID < n[j].ID }
+
 // NewNodesFromServers creates a slice of Nodes from a slice of Servers.
 func NewNodesFromServers(servers []*store.Server) Nodes {
 	nodes := make([]*Node, len(servers))
 	for i, s := range servers {
 		nodes[i] = NewNodeFromServer(s)
 	}
+	sort.Sort(Nodes(nodes))
 	return nodes
 }
 
@@ -66,6 +72,7 @@ func (n Nodes) Voters() Nodes {
 			v = append(v, node)
 		}
 	}
+	sort.Sort(v)
 	return v
 }
 

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -173,3 +173,28 @@ func (e *NodesRespEncoder) encodeLegacy(nodes Nodes) ([]byte, error) {
 	}
 	return json.Marshal(legacyOutput)
 }
+
+// NodesRespDecoder decodes JSON data into a slice of Nodes.
+type NodesRespDecoder struct {
+	reader io.Reader
+}
+
+// NewNodesRespDecoder creates a new Decoder instance with the specified io.Reader.
+func NewNodesRespDecoder(r io.Reader) *NodesRespDecoder {
+	return &NodesRespDecoder{reader: r}
+}
+
+// Decode reads JSON from its reader and decodes it into the provided Nodes slice.
+func (d *NodesRespDecoder) Decode(nodes *Nodes) error {
+	// Temporary structure to facilitate decoding.
+	var data struct {
+		Nodes Nodes `json:"nodes"`
+	}
+
+	if err := json.NewDecoder(d.reader).Decode(&data); err != nil {
+		return err
+	}
+
+	*nodes = data.Nodes
+	return nil
+}

--- a/http/nodes.go
+++ b/http/nodes.go
@@ -89,6 +89,16 @@ func (n Nodes) HasAddr(addr string) bool {
 	return false
 }
 
+// GetNode returns the Node with the given ID, or nil if no such node exists.
+func (n Nodes) GetNode(id string) *Node {
+	for _, node := range n {
+		if node.ID == id {
+			return node
+		}
+	}
+	return nil
+}
+
 // Test tests the reachability and leadership status of all nodes. It does this
 // in parallel, and blocks until all nodes have been tested.
 func (n Nodes) Test(ga GetAddresser, leaderAddr string, timeout time.Duration) {

--- a/http/nodes_test.go
+++ b/http/nodes_test.go
@@ -1,0 +1,94 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rqlite/rqlite/store"
+)
+
+func Test_NewNodeFromServer(t *testing.T) {
+	server := &store.Server{ID: "1", Addr: "192.168.1.1", Suffrage: "Voter"}
+	node := NewNodeFromServer(server)
+
+	if node.ID != server.ID || node.Addr != server.Addr || !node.Voter {
+		t.Fatalf("NewNodeFromServer did not correctly initialize Node from Server")
+	}
+}
+
+func Test_NewNodesFromServers(t *testing.T) {
+	servers := []*store.Server{
+		{ID: "1", Addr: "192.168.1.1", Suffrage: "Voter"},
+		{ID: "2", Addr: "192.168.1.2", Suffrage: "Nonvoter"},
+	}
+	nodes := NewNodesFromServers(servers)
+
+	if len(nodes) != len(servers) {
+		t.Fatalf("NewNodesFromServers did not create the correct number of nodes")
+	}
+	for i, node := range nodes {
+		if node.ID != servers[i].ID || node.Addr != servers[i].Addr {
+			t.Fatalf("NewNodesFromServers did not correctly initialize Node %d from Server", i)
+		}
+	}
+}
+
+func Test_NodesVoters(t *testing.T) {
+	nodes := Nodes{
+		{ID: "1", Voter: true},
+		{ID: "2", Voter: false},
+	}
+	voters := nodes.Voters()
+
+	if len(voters) != 1 || !voters[0].Voter {
+		t.Fatalf("Voters method did not correctly filter voter nodes")
+	}
+}
+
+func Test_NodeTestLeader(t *testing.T) {
+	node := &Node{ID: "1", Addr: "leader-raft-addr", APIAddr: "leader-api-addr"}
+	mockGA := newMockGetAddresser("leader-api-addr", nil)
+
+	node.Test(mockGA, "leader-raft-addr", 10*time.Second)
+	if !node.Reachable || !node.Leader {
+		t.Fatalf("Test method did not correctly update node status %s", asJSON(node))
+	}
+}
+
+func Test_NodeTestNotLeader(t *testing.T) {
+	node := &Node{ID: "1", Addr: "follower-raft-addr", APIAddr: "follower-api-addr"}
+	mockGA := newMockGetAddresser("follower-api-addr", nil)
+
+	node.Test(mockGA, "leader-raft-addr", 10*time.Second)
+	if !node.Reachable || node.Leader {
+		t.Fatalf("Test method did not correctly update node status %s", asJSON(node))
+	}
+}
+
+// mockGetAddresser is a mock implementation of the GetAddresser interface.
+type mockGetAddresser struct {
+	// Add more fields if needed to simulate different behaviors.
+	apiAddr string
+	err     error
+}
+
+// newMockGetAddresser creates a new instance of mockGetAddresser.
+// You can customize the return values for GetNodeAPIAddr by setting apiAddr and err.
+func newMockGetAddresser(apiAddr string, err error) *mockGetAddresser {
+	return &mockGetAddresser{apiAddr: apiAddr, err: err}
+}
+
+// GetNodeAPIAddr is the mock implementation of the GetNodeAPIAddr method.
+func (m *mockGetAddresser) GetNodeAPIAddr(addr string, timeout time.Duration) (string, error) {
+	return m.apiAddr, m.err
+}
+
+func asJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("failed to JSON marshal value: %s", err.Error()))
+	}
+	return string(b)
+}

--- a/http/service.go
+++ b/http/service.go
@@ -1031,8 +1031,12 @@ func (s *Service) handleNodes(w http.ResponseWriter, r *http.Request) {
 	}
 	nodes.Test(s.cluster, lAddr, timeout)
 
-	legacy, _ := isLegacy(r)
-	enc := NewNodesRespEncoder(w, legacy)
+	ver, err := verParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	enc := NewNodesRespEncoder(w, (ver == "1" || ver == ""))
 	pretty, _ := isPretty(r)
 	if pretty {
 		enc.SetIndent("", "    ")
@@ -1813,14 +1817,15 @@ func fmtParam(req *http.Request) (string, error) {
 	return strings.TrimSpace(q.Get("fmt")), nil
 }
 
+// verParam returns the requested version, if present.
+func verParam(req *http.Request) (string, error) {
+	q := req.URL.Query()
+	return strings.TrimSpace(q.Get("ver")), nil
+}
+
 // isPretty returns whether the HTTP response body should be pretty-printed.
 func isPretty(req *http.Request) (bool, error) {
 	return queryParam(req, "pretty")
-}
-
-// isLegacy returns whether the HTTP request is requesting legacy behavior.
-func isLegacy(req *http.Request) (bool, error) {
-	return queryParam(req, "legacy")
 }
 
 // isRedirect returns whether the HTTP request is requesting a explicit

--- a/http/service.go
+++ b/http/service.go
@@ -91,10 +91,15 @@ type Store interface {
 	Backup(br *command.BackupRequest, dst io.Writer) error
 }
 
+// GetAddresser is the interface that wraps the GetNodeAPIAddr method.
+// GetNodeAPIAddr returns the HTTP API URL for the node at the given Raft address.
+type GetAddresser interface {
+	GetNodeAPIAddr(addr string, timeout time.Duration) (string, error)
+}
+
 // Cluster is the interface node API services must provide
 type Cluster interface {
-	// GetNodeAPIAddr returns the HTTP API URL for the node at the given Raft address.
-	GetNodeAPIAddr(nodeAddr string, timeout time.Duration) (string, error)
+	GetAddresser
 
 	// Execute performs an Execute Request on a remote node.
 	Execute(er *command.ExecuteRequest, nodeAddr string, creds *cluster.Credentials, timeout time.Duration) ([]*command.ExecuteResult, error)

--- a/http/service.go
+++ b/http/service.go
@@ -1036,7 +1036,7 @@ func (s *Service) handleNodes(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	enc := NewNodesRespEncoder(w, (ver == "1" || ver == ""))
+	enc := NewNodesRespEncoder(w, ver != "2")
 	pretty, _ := isPretty(r)
 	if pretty {
 		enc.SetIndent("", "    ")

--- a/system_test/cluster_test.go
+++ b/system_test/cluster_test.go
@@ -701,8 +701,8 @@ func Test_MultiNodeClusterNodes(t *testing.T) {
 	if len(nodes) != len(c) {
 		t.Fatalf("nodes/ output returned wrong number of nodes, got %d, exp %d", len(nodes), len(c))
 	}
-	ns, ok := nodes[leader.ID]
-	if !ok {
+	ns := nodes.GetNode(leader.ID)
+	if ns == nil {
 		t.Fatalf("failed to find leader with ID %s in node status", leader.ID)
 	}
 	if !ns.Leader {
@@ -728,7 +728,10 @@ func Test_MultiNodeClusterNodes(t *testing.T) {
 		t.Fatalf("got incorrect number of followers: %d", len(followers))
 	}
 	f := followers[0]
-	ns = nodes[f.ID]
+	ns = nodes.GetNode(f.ID)
+	if ns == nil {
+		t.Fatalf("failed to find follower with ID %s in node status", f.ID)
+	}
 	if ns.Addr != f.RaftAddr {
 		t.Fatalf("node has wrong Raft address for follower")
 	}

--- a/system_test/e2e/helpers.py
+++ b/system_test/e2e/helpers.py
@@ -531,7 +531,7 @@ class Node(object):
   def _status_url(self):
     return 'http://' + self.APIAddr() + '/status'
   def _nodes_url(self):
-    return 'http://' + self.APIAddr() + '/nodes?nonvoters&legacy' # Getting all nodes back makes testing easier
+    return 'http://' + self.APIAddr() + '/nodes?nonvoters' # Getting all nodes back makes testing easier
   def _ready_url(self, noleader=False):
     nl = ""
     if noleader:

--- a/system_test/e2e/helpers.py
+++ b/system_test/e2e/helpers.py
@@ -531,7 +531,7 @@ class Node(object):
   def _status_url(self):
     return 'http://' + self.APIAddr() + '/status'
   def _nodes_url(self):
-    return 'http://' + self.APIAddr() + '/nodes?nonvoters' # Getting all nodes back makes testing easier
+    return 'http://' + self.APIAddr() + '/nodes?nonvoters&legacy' # Getting all nodes back makes testing easier
   def _ready_url(self, noleader=False):
     nl = ""
     if noleader:

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -248,7 +248,7 @@ func (n NodesStatus) HasAddr(addr string) bool {
 
 // Nodes returns the sNodes endpoint output for node.
 func (n *Node) Nodes(includeNonVoters bool) (NodesStatus, error) {
-	v, _ := url.Parse("http://" + n.APIAddr + "/nodes")
+	v, _ := url.Parse("http://" + n.APIAddr + "/nodes?legacy")
 	if includeNonVoters {
 		q := v.Query()
 		q.Set("nonvoters", "true")

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -228,9 +228,9 @@ func (n *Node) Notify(id, raftAddr string) error {
 	return n.Client.Notify(nr, raftAddr, nil, 5*time.Second)
 }
 
-// Nodes returns the sNodes endpoint output for node.
+// Nodes returns the Nodes endpoint output for node.
 func (n *Node) Nodes(includeNonVoters bool) (httpd.Nodes, error) {
-	v, _ := url.Parse("http://" + n.APIAddr + "/nodes")
+	v, _ := url.Parse("http://" + n.APIAddr + "/nodes?ver=2")
 	if includeNonVoters {
 		q := v.Query()
 		q.Set("nonvoters", "true")

--- a/system_test/single_node_test.go
+++ b/system_test/single_node_test.go
@@ -974,10 +974,7 @@ func Test_SingleNodeNodes(t *testing.T) {
 	if len(nodes) != 1 {
 		t.Fatalf("wrong number of nodes in response")
 	}
-	n, ok := nodes[node.ID]
-	if !ok {
-		t.Fatalf("node not found by ID in response")
-	}
+	n := nodes[0]
 	if n.Addr != node.RaftAddr {
 		t.Fatalf("node has wrong Raft address")
 	}


### PR DESCRIPTION
Make the JSON response construction cleaner. This output format can be enabled by pass `ver=2` to the URL.