### PR TITLE
Support skipping verifying frame data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ When officially released 8.0 will support (mostly) seamless upgrades from the 7.
 - [PR #1430](https://github.com/rqlite/rqlite/pull/1430): Check that any supplied Join addresses are not HTTP servers.
 - [PR #1437](https://github.com/rqlite/rqlite/pull/1437), [PR #1438](https://github.com/rqlite/rqlite/pull/1438), [PR #1439](https://github.com/rqlite/rqlite/pull/1439): Actually timeout if needed during `nodes/` access. Fixes [issue #1435](https://github.com/rqlite/rqlite/issues/1435). Thanks @dwco-z
 - [PR #1440](https://github.com/rqlite/rqlite/pull/1440): Add a Compacting WAL rewriter. Thanks @benbjohnson.
-- [PR #1441](https://github.com/rqlite/rqlite/pull/1441): Integrate Compacting WAL writer
+- [PR #1441](https://github.com/rqlite/rqlite/pull/1441), [PR #1443](https://github.com/rqlite/rqlite/pull/1443): Integrate Compacting WAL writer
 
 ## 7.21.4 (July 8th 2023)
 ### Implementation changes and bug fixes

--- a/db/db.go
+++ b/db/db.go
@@ -40,6 +40,8 @@ const (
 	numETx               = "execute_transactions"
 	numQTx               = "query_transactions"
 	numRTx               = "request_transactions"
+
+	CheckpointQuery = "PRAGMA wal_checkpoint(TRUNCATE)" // rqlite WAL compaction requires truncation
 )
 
 var (
@@ -485,7 +487,7 @@ func (db *DB) CheckpointWithTimeout(dur time.Duration) (err error) {
 	var nMoved int
 
 	f := func() error {
-		err := db.rwDB.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)").Scan(&ok, &nPages, &nMoved)
+		err := db.rwDB.QueryRow(CheckpointQuery).Scan(&ok, &nPages, &nMoved)
 		stats.Add(numCheckpointedPages, int64(nPages))
 		stats.Add(numCheckpointedMoves, int64(nMoved))
 		if err != nil {

--- a/db/wal/compacting_scanner.go
+++ b/db/wal/compacting_scanner.go
@@ -49,7 +49,8 @@ func NewFastCompactingScanner(r io.ReadSeeker) (*CompactingScanner, error) {
 // If fullScan is true, the scanner will perform a full scan of the WAL file, performing
 // a checksum on each frame. If fullScan is false, the scanner will only scan the file
 // sufficiently to find the last valid frame for each page. This is faster when the
-// caller knows that the WAL file is valid and does not need to be checked.
+// caller knows that the entire WAL file is valid, and will not contain pages from a
+// previous checkpointing operation.
 func NewCompactingScanner(r io.ReadSeeker, fullScan bool) (*CompactingScanner, error) {
 	walReader := NewReader(r)
 	err := walReader.ReadHeader()

--- a/db/wal/compacting_scanner.go
+++ b/db/wal/compacting_scanner.go
@@ -38,6 +38,13 @@ type CompactingScanner struct {
 	frames cFrames
 }
 
+// NewFastCompactingScanner creates a new CompactingScanner with the given io.ReadSeeker.
+// It performs a fast scan of the WAL file, assuming that the file is valid and does not
+// need to be checked.
+func NewFastCompactingScanner(r io.ReadSeeker) (*CompactingScanner, error) {
+	return NewCompactingScanner(r, false)
+}
+
 // NewCompactingScanner creates a new CompactingScanner with the given io.ReadSeeker.
 // If fullScan is true, the scanner will perform a full scan of the WAL file, performing
 // a checksum on each frame. If fullScan is false, the scanner will only scan the file

--- a/db/wal/compacting_scanner_test.go
+++ b/db/wal/compacting_scanner_test.go
@@ -13,7 +13,7 @@ func Test_CompactingScanner_Scan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := NewCompactingScanner(bytes.NewReader(b))
+	s, err := NewCompactingScanner(bytes.NewReader(b), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func Test_CompactingScanner_Scan_Commit0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := NewCompactingScanner(bytes.NewReader(b))
+	s, err := NewCompactingScanner(bytes.NewReader(b), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/db/wal/full_scanner.go
+++ b/db/wal/full_scanner.go
@@ -11,7 +11,7 @@ type FullScanner struct {
 }
 
 // NewFullScanner creates a new FullScanner with the given io.Reader.
-func NewFullScanner(r io.Reader) (*FullScanner, error) {
+func NewFullScanner(r io.ReadSeeker) (*FullScanner, error) {
 	wr := NewReader(r)
 	err := wr.ReadHeader()
 	if err != nil {

--- a/db/wal/writer_test.go
+++ b/db/wal/writer_test.go
@@ -123,7 +123,7 @@ func Test_Writer_CompactingScanner(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer destF.Close()
-		s, err := NewCompactingScanner(srcF)
+		s, err := NewCompactingScanner(srcF, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -1708,7 +1708,7 @@ func (s *Store) Snapshot() (raft.FSMSnapshot, error) {
 			}
 			defer walFD.Close() // Make sure it closes.
 
-			scanner, err := wal.NewCompactingScanner(walFD)
+			scanner, err := wal.NewCompactingScanner(walFD, false)
 			if err != nil {
 				return nil, err
 			}

--- a/store/store.go
+++ b/store/store.go
@@ -1708,7 +1708,7 @@ func (s *Store) Snapshot() (raft.FSMSnapshot, error) {
 			}
 			defer walFD.Close() // Make sure it closes.
 
-			scanner, err := wal.NewCompactingScanner(walFD, false)
+			scanner, err := wal.NewFastCompactingScanner(walFD)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This halves the Compacting Scan time, and doesn't seem necessary since rqlite is the only system writing the WAL files.