### PR TITLE
Add FullNeeded() to Snapshot store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Implementation changes and bug fixes
 - [PR #1454](https://github.com/rqlite/rqlite/pull/1454): Reduce Raft snapshot threshold to 2048.
+- [PR #1456](https://github.com/rqlite/rqlite/pull/1456): Wrap Snaphot Store _FullNeeded_ logic in a function.
 
 ## 8.0.0 (December 5th 2023)
 This release introduces support for much larger data sets. Previously the [Raft snapshotting](https://raft.github.io/) process became more memory intensive and time-consuming as the SQLite database became larger. This set an practical upper limit on the size of the SQLite database. With the 8.0 release rqlite has been fundamentally redesigned such that snapshotting consumes approximately the same amount of resources, regardless of the size of the SQLite database.

--- a/snapshot/sink_test.go
+++ b/snapshot/sink_test.go
@@ -107,6 +107,12 @@ func Test_SinkFullSnapshot(t *testing.T) {
 		t.Fatalf("Snapshot data does not match")
 	}
 
+	if fn, err := store.FullNeeded(); err != nil {
+		t.Fatalf("Failed to check if full snapshot needed: %v", err)
+	} else if fn {
+		t.Errorf("Expected full snapshot not to be needed, but it is")
+	}
+
 	// Write a second full snapshot, it should be installed without issue.
 	sink = NewSink(store, makeRaftMeta("snap-5678", 4, 3, 2))
 	if sink == nil {
@@ -206,6 +212,17 @@ func Test_SinkCreateFullThenWALSnapshots(t *testing.T) {
 		if err := sink.Close(); err != nil {
 			t.Fatalf("Failed to close sink: %v", err)
 		}
+
+		if fn, err := store.FullNeeded(); err != nil {
+			t.Fatalf("Failed to check if full snapshot needed: %v", err)
+		} else if fn {
+			t.Errorf("Expected full snapshot not to be needed, but it is")
+		}
+	}
+	if fn, err := store.FullNeeded(); err != nil {
+		t.Fatalf("Failed to check if full snapshot needed: %v", err)
+	} else if !fn {
+		t.Errorf("Expected full snapshot to be needed, but it is not")
 	}
 	createSnapshot("snap-1234", 3, 2, 1, "testdata/db-and-wals/backup.db")
 	createSnapshot("snap-2345", 4, 3, 2, "testdata/db-and-wals/wal-00")

--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -151,6 +151,15 @@ func (s *Store) Open(id string) (*raft.SnapshotMeta, io.ReadCloser, error) {
 	return meta, fd, nil
 }
 
+// FullNeeded returns true if a full snapshot is needed.
+func (s *Store) FullNeeded() (bool, error) {
+	snaps, err := s.getSnapshots()
+	if err != nil {
+		return false, err
+	}
+	return len(snaps) == 0, nil
+}
+
 // Stats returns stats about the Snapshot Store.
 func (s *Store) Stats() (map[string]interface{}, error) {
 	snapshots, err := s.getSnapshots()

--- a/snapshot/store_test.go
+++ b/snapshot/store_test.go
@@ -94,6 +94,12 @@ func Test_StoreEmpty(t *testing.T) {
 		t.Errorf("Expected no snapshots, got %d", len(snaps))
 	}
 
+	if fn, err := store.FullNeeded(); err != nil {
+		t.Fatalf("Failed to check if full snapshot needed: %v", err)
+	} else if !fn {
+		t.Errorf("Expected full snapshot needed, but it is not")
+	}
+
 	_, _, err = store.Open("non-existent")
 	if err == nil {
 		t.Fatalf("Expected error opening non-existent snapshot, got nil")

--- a/store/store.go
+++ b/store/store.go
@@ -159,6 +159,9 @@ func ResetStats() {
 type SnapshotStore interface {
 	raft.SnapshotStore
 
+	// FullNeeded returns true if a full snapshot is needed.
+	FullNeeded() (bool, error)
+
 	// Stats returns stats about the Snapshot Store.
 	Stats() (map[string]interface{}, error)
 }
@@ -1668,12 +1671,10 @@ func (s *Store) Database(leader bool) ([]byte, error) {
 func (s *Store) Snapshot() (raft.FSMSnapshot, error) {
 	startT := time.Now()
 
-	currSnaps, err := s.snapshotStore.List()
+	fullNeeded, err := s.snapshotStore.FullNeeded()
 	if err != nil {
 		return nil, err
 	}
-	fullNeeded := len(currSnaps) == 0
-
 	fPLog := fullPretty(fullNeeded)
 	s.logger.Printf("initiating %s snapshot on node ID %s", fPLog, s.raftID)
 	defer func() {


### PR DESCRIPTION
It may be necessary to override the FullNeeded definition, so wrap it.