### PR TITLE
Move uploader goroutine into Uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 ### Implementation changes and bug fixes
 - [PR #1456](https://github.com/rqlite/rqlite/pull/1459): Standardize on chunk size.
 - [PR #1456](https://github.com/rqlite/rqlite/pull/1459): Set `TrailingLogs=0` to truncate log during user-initiated Snapshotting.
-- [PR #1462](https://github.com/rqlite/rqlite/pull/1462): Refactor redirect logic in HTTP service
-  
+- [PR #1462](https://github.com/rqlite/rqlite/pull/1462): Refactor redirect logic in HTTP service.
+- [PR #1465](https://github.com/rqlite/rqlite/pull/1465): Move uploader goroutine into Uploader.
+
 ## 8.0.1 (December 8th 2023)
 This release fixes an edge case issue during restore-from-SQLite. It's possible if a rqlite system crashes shortly after restoring from SQLite it may not have loaded the data correctly.
 

--- a/auto/backup/uploader_test.go
+++ b/auto/backup/uploader_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_NewUploader(t *testing.T) {
+	ResetStats()
 	storageClient := &mockStorageClient{}
 	dataProvider := &mockDataProvider{}
 	interval := time.Second
@@ -60,7 +61,6 @@ func Test_UploaderSingleUpload(t *testing.T) {
 func Test_UploaderSingleUploadCompress(t *testing.T) {
 	ResetStats()
 	var uploadedData []byte
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 	sc := &mockStorageClient{
@@ -94,7 +94,6 @@ func Test_UploaderSingleUploadCompress(t *testing.T) {
 
 func Test_UploaderDoubleUpload(t *testing.T) {
 	ResetStats()
-
 	var uploadedData []byte
 	var err error
 
@@ -125,7 +124,6 @@ func Test_UploaderDoubleUpload(t *testing.T) {
 
 func Test_UploaderFailThenOK(t *testing.T) {
 	ResetStats()
-
 	var uploadedData []byte
 	uploadCount := 0
 	var err error
@@ -160,6 +158,7 @@ func Test_UploaderFailThenOK(t *testing.T) {
 }
 
 func Test_UploaderOKThenFail(t *testing.T) {
+	ResetStats()
 	var uploadedData []byte
 	uploadCount := 0
 	var err error
@@ -195,6 +194,7 @@ func Test_UploaderOKThenFail(t *testing.T) {
 }
 
 func Test_UploaderContextCancellation(t *testing.T) {
+	ResetStats()
 	var uploadCount int32
 
 	sc := &mockStorageClient{
@@ -218,7 +218,6 @@ func Test_UploaderContextCancellation(t *testing.T) {
 
 func Test_UploaderEnabledFalse(t *testing.T) {
 	ResetStats()
-
 	sc := &mockStorageClient{}
 	dp := &mockDataProvider{data: "my upload data"}
 	uploader := NewUploader(sc, dp, 100*time.Millisecond, false)
@@ -235,9 +234,9 @@ func Test_UploaderEnabledFalse(t *testing.T) {
 }
 
 func Test_UploaderEnabledTrue(t *testing.T) {
+	ResetStats()
 	var uploadedData []byte
 	var err error
-	ResetStats()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -262,6 +261,7 @@ func Test_UploaderEnabledTrue(t *testing.T) {
 }
 
 func Test_UploaderStats(t *testing.T) {
+	ResetStats()
 	sc := &mockStorageClient{}
 	dp := &mockDataProvider{data: "my upload data"}
 	interval := 100 * time.Millisecond

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -241,7 +241,7 @@ func startAutoBackups(ctx context.Context, cfg *Config, str *store.Store) (*back
 	sc := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
 		s3cfg.Bucket, s3cfg.Path)
 	u := backup.NewUploader(sc, provider, time.Duration(uCfg.Interval), !uCfg.NoCompress)
-	go u.Start(ctx, nil)
+	u.Start(ctx, nil)
 	return u, nil
 }
 


### PR DESCRIPTION
Possible fix for https://app.circleci.com/pipelines/github/rqlite/rqlite/3648/workflows/d1235267-093d-4ac7-8d8d-061bc2ac9744/jobs/26157

The idea is be sure one test's goroutines are fully closed before starting the next test.