### PR TITLE
Guard against nil History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.11.1 (December 17th 2023)
+## 8.11.1 (unreleased)
 ### Implementation changes and bug fixes
 - [PR #1490](https://github.com/rqlite/rqlite/pull/1490): Guard against `nil` History in rqlite shell. Fixes [issue #1486](https://github.com/rqlite/rqlite/issues/1486).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.11.1 (December 17th 2023)
 ### Implementation changes and bug fixes
-- [PR #1490](https://github.com/rqlite/rqlite/pull/1490): Guard against `nil` History in rqlite shell. Fixes [issue #1478](https://github.com/rqlite/rqlite/issues/1478).
+- [PR #1490](https://github.com/rqlite/rqlite/pull/1490): Guard against `nil` History in rqlite shell. Fixes [issue #1486](https://github.com/rqlite/rqlite/issues/1486).
 
 ## 8.11.0 (December 17th 2023)
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.11.1 (December 17th 2023)
+### Implementation changes and bug fixes
+- [PR #1490](https://github.com/rqlite/rqlite/pull/1490): Guard against `nil` History in rqlite shell. Fixes [issue #1478](https://github.com/rqlite/rqlite/issues/1478).
+
 ## 8.11.0 (December 17th 2023)
 ### New features
 - [PR #1489](https://github.com/rqlite/rqlite/pull/1489): Add `.boot` command to rqlite shell, to support _Booting_ nodes.

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -231,11 +231,13 @@ func main() {
 		}
 
 		hw := history.Writer()
-		sz := history.Size()
-		history.Write(term.History, sz, hw)
-		hw.Close()
-		if sz <= 0 {
-			history.Delete()
+		if hw != nil {
+			sz := history.Size()
+			history.Write(term.History, sz, hw)
+			hw.Close()
+			if sz <= 0 {
+				history.Delete()
+			}
 		}
 		ctx.String("bye~\n")
 		return nil


### PR DESCRIPTION
If UserHomeDir() doesn't have a value, this can happen. Fixes https://github.com/rqlite/rqlite/issues/1486. May also be caused by failure to open the history file. In any event, this is not something that should block the CLI from working.