### PR TITLE
Remove faulty bcrypt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.11.2 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1492](https://github.com/rqlite/rqlite/pull/1492): Remove faulty bcrypt hashed password support. Fixes [issue #1488](https://github.com/rqlite/rqlite/issues/1488). Thanks @jtackaberry
+
 ## 8.11.1 (December 17th 2023)
 ### Implementation changes and bug fixes
 - [PR #1490](https://github.com/rqlite/rqlite/pull/1490): Guard against `nil` History in rqlite shell. Fixes [issue #1486](https://github.com/rqlite/rqlite/issues/1486).

--- a/auth/credential_store.go
+++ b/auth/credential_store.go
@@ -107,10 +107,7 @@ func (c *CredentialsStore) Load(r io.Reader) error {
 // Check returns true if the password is correct for the given username.
 func (c *CredentialsStore) Check(username, password string) bool {
 	pw, ok := c.store[username]
-	if !ok {
-		return false
-	}
-	return password == pw
+	return ok && pw == password
 }
 
 // Password returns the password for the given user.
@@ -174,12 +171,12 @@ func (c *CredentialsStore) AA(username, password, perm string) bool {
 		return true
 	}
 
-	// At this point a username needs to have been supplied
+	// At this point a username needs to have been supplied.
 	if username == "" {
 		return false
 	}
 
-	// Are the creds good?
+	// Authenticate the user.
 	if !c.Check(username, password) {
 		return false
 	}
@@ -193,8 +190,5 @@ func (c *CredentialsStore) AA(username, password, perm string) bool {
 // in the request, it returns false.
 func (c *CredentialsStore) HasPermRequest(b BasicAuther, perm string) bool {
 	username, _, ok := b.BasicAuth()
-	if !ok {
-		return false
-	}
-	return c.HasPerm(username, perm)
+	return ok && c.HasPerm(username, perm)
 }

--- a/auth/credential_store_bench_test.go
+++ b/auth/credential_store_bench_test.go
@@ -33,33 +33,3 @@ func BenchmarkCredentialStore(b *testing.B) {
 		store.CheckRequest(b1)
 	}
 }
-
-func BenchmarkCredentialStoreNoCache(b *testing.B) {
-	const jsonStream = `
-		[
-			{
-				"username": "username1",
-				"password": "$2a$10$fKRHxrEuyDTP6tXIiDycr.nyC8Q7UMIfc31YMyXHDLgRDyhLK3VFS"
-			},
-			{	"username": "username2",
-				"password": "password2"
-			}
-		]
-	`
-
-	store := NewCredentialsStore()
-	store.UseCache = false
-	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
-		panic("failed to load multiple credentials")
-	}
-
-	b1 := &testBasicAuther{
-		username: "username1",
-		password: "password1",
-		ok:       true,
-	}
-
-	for n := 0; n < b.N; n++ {
-		store.CheckRequest(b1)
-	}
-}

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -16,53 +16,6 @@ func (t *testBasicAuther) BasicAuth() (string, string, bool) {
 	return t.username, t.password, t.ok
 }
 
-func Test_HashCache(t *testing.T) {
-	hc := NewHashCache()
-
-	if hc.Check("user", "hash1") {
-		t.Fatalf("hash cache check OK for empty cache")
-	}
-	if hc.Check("user", "") {
-		t.Fatalf("hash cache check OK for empty cache")
-	}
-	if hc.Check("", "") {
-		t.Fatalf("hash cache check OK for empty cache")
-	}
-
-	hc.Store("user1", "hash1")
-	if !hc.Check("user1", "hash1") {
-		t.Fatalf("hash cache check not OK for user1")
-	}
-	if hc.Check("user", "hash1") {
-		t.Fatalf("hash cache check OK for bad user")
-	}
-
-	hc.Store("user1", "hash2")
-	if !hc.Check("user1", "hash1") {
-		t.Fatalf("hash cache check not OK for user1")
-	}
-	if !hc.Check("user1", "hash2") {
-		t.Fatalf("hash cache check not OK for user1")
-	}
-
-	hc.Store("user3", "hash3")
-	if !hc.Check("user1", "hash1") {
-		t.Fatalf("hash cache check not OK for user1")
-	}
-	if !hc.Check("user1", "hash2") {
-		t.Fatalf("hash cache check not OK for user1")
-	}
-	if hc.Check("user", "hash1") {
-		t.Fatalf("hash cache check OK for bad user")
-	}
-	if !hc.Check("user3", "hash3") {
-		t.Fatalf("hash cache check not OK for user3")
-	}
-	if hc.Check("user3", "hash1") {
-		t.Fatalf("hash cache check OK for user3, with bad hash")
-	}
-}
-
 func Test_AuthLoadEmpty(t *testing.T) {
 	const jsonStream = `[]`
 
@@ -349,7 +302,7 @@ func Test_AuthLoadHashedSingleRequest(t *testing.T) {
 		[
 			{
 				"username": "username1",
-				"password": "$2a$10$fKRHxrEuyDTP6tXIiDycr.nyC8Q7UMIfc31YMyXHDLgRDyhLK3VFS"
+				"password": "password1"
 			},
 			{	"username": "username2",
 				"password": "password2"

--- a/auth/credential_store_test.go
+++ b/auth/credential_store_test.go
@@ -286,6 +286,9 @@ func Test_AuthPermsAA(t *testing.T) {
 	if !store.AA("username2", "password2", "baz") {
 		t.Fatalf("username2 not authenticated and authorized for baz")
 	}
+	if store.AA("username2", "password1", "baz") {
+		t.Fatalf("username2 authenticated and authorized for baz with wrong password")
+	}
 	if !store.AA("username2", "password2", "qux") {
 		t.Fatalf("username2 not authenticated and authorized for qux")
 	}
@@ -294,76 +297,6 @@ func Test_AuthPermsAA(t *testing.T) {
 	}
 	if store.AA("username2", "password2", "quz") {
 		t.Fatalf("username2 was authenticated and authorized for quz")
-	}
-}
-
-func Test_AuthLoadHashedSingleRequest(t *testing.T) {
-	const jsonStream = `
-		[
-			{
-				"username": "username1",
-				"password": "password1"
-			},
-			{	"username": "username2",
-				"password": "password2"
-			}
-		]
-	`
-
-	store := NewCredentialsStore()
-	if err := store.Load(strings.NewReader(jsonStream)); err != nil {
-		t.Fatalf("failed to load multiple credentials: %s", err.Error())
-	}
-
-	b1 := &testBasicAuther{
-		username: "username1",
-		password: "password1",
-		ok:       true,
-	}
-	b2 := &testBasicAuther{
-		username: "username2",
-		password: "password2",
-		ok:       true,
-	}
-
-	b3 := &testBasicAuther{
-		username: "username1",
-		password: "wrong",
-		ok:       true,
-	}
-	b4 := &testBasicAuther{
-		username: "username2",
-		password: "wrong",
-		ok:       true,
-	}
-	b5 := &testBasicAuther{
-		username: "username1",
-		password: "password2",
-		ok:       true,
-	}
-	b6 := &testBasicAuther{
-		username: "username2",
-		password: "password1",
-		ok:       true,
-	}
-
-	if check := store.CheckRequest(b1); !check {
-		t.Fatalf("username1 (b1) credential not checked correctly via request")
-	}
-	if check := store.CheckRequest(b2); !check {
-		t.Fatalf("username2 (b2) credential not checked correctly via request")
-	}
-	if check := store.CheckRequest(b3); check {
-		t.Fatalf("username1 (b3) credential not checked correctly via request")
-	}
-	if check := store.CheckRequest(b4); check {
-		t.Fatalf("username2 (b4) credential not checked correctly via request")
-	}
-	if check := store.CheckRequest(b5); check {
-		t.Fatalf("username2 (b5) credential not checked correctly via request")
-	}
-	if check := store.CheckRequest(b6); check {
-		t.Fatalf("username2 (b5) credential not checked correctly via request")
 	}
 }
 


### PR DESCRIPTION
See https://github.com/rqlite/rqlite/issues/1488

bcrypt support wasn't adding any extra security, and had the potential of making end users think they were more secure than they were.