### PR TITLE
Shutdown the HTTP service first during testing

### DIFF
--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -79,8 +79,8 @@ func (n *Node) Close(graceful bool) error {
 
 // Deprovision shuts down and removes all resources associated with the node.
 func (n *Node) Deprovision() {
-	n.Store.Close(true)
 	n.Service.Close()
+	n.Store.Close(true)
 	n.Cluster.Close()
 	os.RemoveAll(n.Dir)
 }


### PR DESCRIPTION
The HTTP service depends on the Store, not the other way around. This should address https://app.circleci.com/pipelines/github/rqlite/rqlite/3793/workflows/f87affa5-3671-498a-afba-f0ef104a9a0c/jobs/28530