### PR TITLE
Fix order of variables passed to rtls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.13.2 (December 21st 2023)
+### Implementation changes and bug fixes
+- [PR #1512](https://github.com/rqlite/rqlite/pull/1512): Fix swapping of CACert and ServerName.
+
 ## 8.13.1 (December 21st 2023)
 ### Implementation changes and bug fixes
 - [PR #1510](https://github.com/rqlite/rqlite/pull/1510): Remove obsolete `-http-no-verify` command-line flag.

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -439,7 +439,7 @@ func createClusterClient(cfg *Config, clstr *cluster.Service) (*cluster.Client, 
 	var err error
 	if cfg.NodeX509Cert != "" || cfg.NodeX509CACert != "" {
 		dialerTLSConfig, err = rtls.CreateClientConfig(cfg.NodeX509Cert, cfg.NodeX509Key,
-			cfg.NodeVerifyServerName, cfg.NodeX509CACert, cfg.NoNodeVerify)
+			cfg.NodeX509CACert, cfg.NodeVerifyServerName, cfg.NoNodeVerify)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create TLS config for cluster dialer: %s", err.Error())
 		}


### PR DESCRIPTION
If these had been typed, would have all been good.

https://github.com/rqlite/rqlite/issues/1507