### PR TITLE
Fix server name override with inter-node TLS

### DIFF
--- a/cluster/service_mux_test.go
+++ b/cluster/service_mux_test.go
@@ -106,7 +106,7 @@ func mustNewTLSMux() (net.Listener, *tcp.Mux) {
 	key := x509.KeyExampleDotComFile("")
 	defer os.Remove(key)
 
-	mux, err := tcp.NewTLSMux(ln, nil, cert, key, "", true, false)
+	mux, err := tcp.NewTLSMux(ln, nil, cert, key, "", "", true, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create TLS mux: %s", err))
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -405,7 +405,7 @@ func startNodeMux(cfg *Config, ln net.Listener) (*tcp.Mux, error) {
 		}
 		log.Println(b.String())
 		mux, err = tcp.NewTLSMux(ln, adv, cfg.NodeX509Cert, cfg.NodeX509Key, cfg.NodeX509CACert,
-			cfg.NoNodeVerify, cfg.NodeVerifyClient)
+			cfg.NodeVerifyServerName, cfg.NoNodeVerify, cfg.NodeVerifyClient)
 	} else {
 		mux, err = tcp.NewMux(ln, adv)
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -399,9 +399,9 @@ func startNodeMux(cfg *Config, ln net.Listener) (*tcp.Mux, error) {
 			b.WriteString(fmt.Sprintf(", CA cert %s", cfg.NodeX509CACert))
 		}
 		if cfg.NodeVerifyClient {
-			b.WriteString(", mutual TLS disabled")
-		} else {
 			b.WriteString(", mutual TLS enabled")
+		} else {
+			b.WriteString(", mutual TLS disabled")
 		}
 		log.Println(b.String())
 		mux, err = tcp.NewTLSMux(ln, adv, cfg.NodeX509Cert, cfg.NodeX509Key, cfg.NodeX509CACert,

--- a/rtls/config.go
+++ b/rtls/config.go
@@ -14,7 +14,7 @@ const (
 	NoServerName = ""
 )
 
-// CreateClientConfig creates a TLS configuration for use by a system that does both
+// CreateConfig creates a TLS configuration for use by a system that does both
 // client and server authentication using the same cert, key, and CA cert. If noverify
 // is true, the client will not verify the server's certificate. If mutual is true, the
 // server will verify the client's certificate.

--- a/rtls/config.go
+++ b/rtls/config.go
@@ -18,9 +18,9 @@ const (
 // client and server authentication using the same cert, key, and CA cert. If noverify
 // is true, the client will not verify the server's certificate. If mutual is true, the
 // server will verify the client's certificate.
-func CreateConfig(certFile, keyFile, caCertFile string, noverify, mutual bool) (*tls.Config, error) {
+func CreateConfig(certFile, keyFile, caCertFile, serverName string, noverify, mutual bool) (*tls.Config, error) {
 	var err error
-	config := createBaseTLSConfig(NoServerName, noverify)
+	config := createBaseTLSConfig(serverName, noverify)
 
 	// load the certificate and key
 	if certFile != "" && keyFile != "" {

--- a/rtls/config_test.go
+++ b/rtls/config_test.go
@@ -25,8 +25,8 @@ func Test_CreateConfig(t *testing.T) {
 	}
 	caCertFile := mustWriteTempFile(t, caCertPEM)
 
-	// create a config with no server or client verification
-	config, err := CreateConfig(certFile, keyFile, caCertFile, true, false)
+	// create a config with no server or client verification and no custom server name
+	config, err := CreateConfig(certFile, keyFile, caCertFile, "", true, false)
 	if err != nil {
 		t.Fatalf("failed to create config: %v", err)
 	}
@@ -69,7 +69,7 @@ func Test_CreateConfig(t *testing.T) {
 	}
 
 	// create a config with server cert verification only
-	config, err = CreateConfig(certFile, keyFile, caCertFile, false, false)
+	config, err = CreateConfig(certFile, keyFile, caCertFile, "", false, false)
 	if err != nil {
 		t.Fatalf("failed to create config: %v", err)
 	}
@@ -81,7 +81,7 @@ func Test_CreateConfig(t *testing.T) {
 	}
 
 	// create a config with both server and client verification
-	config, err = CreateConfig(certFile, keyFile, "", false, true)
+	config, err = CreateConfig(certFile, keyFile, "", "", false, true)
 	if err != nil {
 		t.Fatalf("failed to create config: %v", err)
 	}
@@ -90,6 +90,15 @@ func Test_CreateConfig(t *testing.T) {
 	}
 	if config.InsecureSkipVerify {
 		t.Fatalf("expected InsecureSkipVerify to be false, got true")
+	}
+
+	// create a config with explicit node server name
+	config, err = CreateConfig(certFile, keyFile, "", "rqlite.example.com", false, true)
+	if err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+	if config.ServerName != "rqlite.example.com" {
+		t.Fatalf("expected ServerNAme to be 'rqlite.example.com', got %s", config.ServerName)
 	}
 }
 

--- a/system_test/helpers.go
+++ b/system_test/helpers.go
@@ -775,7 +775,7 @@ func mustNewOpenTLSMux(certFile, keyPath, addr string) *tcp.Mux {
 	}
 
 	var mux *tcp.Mux
-	mux, err = tcp.NewTLSMux(ln, nil, certFile, keyPath, "", true, false)
+	mux, err = tcp.NewTLSMux(ln, nil, certFile, keyPath, "", "", true, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create node-to-node mux: %s", err.Error()))
 	}

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -97,13 +97,13 @@ func NewMux(ln net.Listener, adv net.Addr) (*Mux, error) {
 // using TLS. If adv is nil, then the addr of ln is used. If insecure is true,
 // then the server will not verify the client's certificate. If mutual is true,
 // then the server will require the client to present a trusted certificate.
-func NewTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert string, insecure, mutual bool) (*Mux, error) {
+func NewTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert, serverName string, insecure, mutual bool) (*Mux, error) {
 	mux, err := NewMux(ln, adv)
 	if err != nil {
 		return nil, err
 	}
 
-	mux.tlsConfig, err = rtls.CreateConfig(cert, key, caCert, insecure, mutual)
+	mux.tlsConfig, err = rtls.CreateConfig(cert, key, caCert, serverName, insecure, mutual)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create TLS config: %s", err)
 	}

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -176,7 +176,7 @@ func TestTLSMux(t *testing.T) {
 	key := x509.KeyExampleDotComFile("")
 	defer os.Remove(key)
 
-	mux, err := NewTLSMux(tcpListener, nil, cert, key, "", true, false)
+	mux, err := NewTLSMux(tcpListener, nil, cert, key, "", "", true, false)
 	if err != nil {
 		t.Fatalf("failed to create mux: %s", err.Error())
 	}
@@ -199,7 +199,7 @@ func TestTLSMux(t *testing.T) {
 func TestTLSMux_Fail(t *testing.T) {
 	tcpListener := mustTCPListener("127.0.0.1:0")
 	defer tcpListener.Close()
-	_, err := NewTLSMux(tcpListener, nil, "xxxx", "yyyy", "", true, false)
+	_, err := NewTLSMux(tcpListener, nil, "xxxx", "yyyy", "", "", true, false)
 	if err == nil {
 		t.Fatalf("created mux unexpectedly with bad resources")
 	}


### PR DESCRIPTION
With #1509 I was still unable to get the cluster bootstrap properly.

> [rqlited] 2023/12/21 21:45:32 launch command: /bin/rqlited -node-id rqlite-0 -http-addr 0.0.0.0:4001 -http-adv-addr rqlite-0.rqlite-headless.data.svc.cluster.local:4001 -raft-addr 0.0.0.0:4002 -raft-adv-addr rqlite-0.rqlite-headless.data.svc.cluster.local:4002 -auth=/config/sensitive/users.json -join-as=_system_rqlite -node-cert=/config/sensitive/node.crt -node-key=/config/sensitive/node.key -node-verify-server-name=rqlite.data.svc.cluster.local -node-ca-cert=/config/sensitive/node-ca.crt -http-cert=/config/client-tls/tls.crt -http-key=/config/client-tls/tls.key -http-ca-cert=/config/sensitive/client-ca.crt -disco-mode=dns-srv -disco-config={"name":"rqlite-headless","service":"raft"} -bootstrap-expect=3 -join-interval=1s -join-attempts=120 -raft-shutdown-stepdown -fk=true /rqlite
> [...]
> 2023-12-21T21:45:35.989Z [ERROR] raft: failed to make requestVote RPC: target="{Voter rqlite-2 rqlite-2.rqlite-headless.data.svc.cluster.local:4002}" error="tls: failed to verify certificate: x509: certificate is valid for rqlite.data.svc.cluster.local, not rqlite-2.rqlite-headless.data.svc.cluster.local" term=2

It turns out if I pass cfg.NodeVerifyServerName through on the mux side as well, it works.  I tested it both with mTLS disabled and enabled.

The problem is I don't really understand *why* it works (which is just to say I don't understand why it was failing to begin with).   The logs above come from rqlite-0, and the raft logs there are reporting that rqlite-2 is presenting an invalid certificate.  Is the raft library somehow (whether directly or indirectly) using the tls.Config created for the listener for outgoing connections?

Possibly you have some insight there.  But what I can at least say is that it works. :)

The PR also contains a couple other minor fixes (as separate commits).