### PR TITLE
Improve auto-backup efficiency and only run on Leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [PR #1574](https://github.com/rqlite/rqlite/pull/1574): Use "GZIP best speed" for internode traffic compression.
 - [PR #1575](https://github.com/rqlite/rqlite/pull/1575): Upload Provider uses Snapshot-locking backup.
 - [PR #1576](https://github.com/rqlite/rqlite/pull/1576): Add fast path for vacuumed, non-compressed backups.
+- [PR #1579](https://github.com/rqlite/rqlite/pull/1579): Only run auto-backups on Leader (as per docs) and improve check efficiency.
 
 ## 8.16.0 (January 6th 2024)
 ### New features

--- a/auto/backup/uploader_test.go
+++ b/auto/backup/uploader_test.go
@@ -45,7 +45,7 @@ func Test_UploaderSingleUpload(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		if i == 0 {
 			return 1, true
 		}
@@ -85,7 +85,7 @@ func Test_UploaderSingleUploadCompress(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		if i == 0 {
 			return 1, true
 		}
@@ -120,7 +120,7 @@ func Test_UploaderDoubleUpload(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		if i == 0 {
 			return 1, true
 		}
@@ -163,7 +163,7 @@ func Test_UploaderFailThenOK(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		return 1, true
 	}
 	uploader := NewUploader(sc, dp, time.Second, UploadNoCompress)
@@ -201,7 +201,7 @@ func Test_UploaderOKThenFail(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		return 1, true
 	}
 	uploader := NewUploader(sc, dp, time.Second, UploadNoCompress)
@@ -244,7 +244,7 @@ func Test_UploaderEnabledFalse(t *testing.T) {
 	ResetStats()
 	sc := &mockStorageClient{}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		return 1, true // Upload if asked (which it shouldn't be).
 	}
 	uploader := NewUploader(sc, dp, 100*time.Millisecond, false)
@@ -275,7 +275,7 @@ func Test_UploaderEnabledTrue(t *testing.T) {
 		},
 	}
 	dp := &mockDataProvider{data: "my upload data"}
-	dp.checkFn = func(i uint64) (uint64, bool) {
+	dp.checkFn = func(i int64) (int64, bool) {
 		return 1, true
 	}
 	uploader := NewUploader(sc, dp, time.Second, UploadNoCompress)
@@ -329,10 +329,10 @@ func (mc *mockStorageClient) String() string {
 type mockDataProvider struct {
 	data    string
 	err     error
-	checkFn func(i uint64) (uint64, bool)
+	checkFn func(i int64) (int64, bool)
 }
 
-func (mp *mockDataProvider) Check(i uint64) (uint64, bool) {
+func (mp *mockDataProvider) Check(i int64) (int64, bool) {
 	if mp.checkFn != nil {
 		return mp.checkFn(i)
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -256,7 +256,7 @@ func startAutoBackups(ctx context.Context, cfg *Config, str *store.Store) (*back
 	sc := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
 		s3cfg.Bucket, s3cfg.Path, s3cfg.ForcePathStyle)
 	u := backup.NewUploader(sc, provider, time.Duration(uCfg.Interval), !uCfg.NoCompress)
-	u.Start(ctx, nil)
+	u.Start(ctx, str.IsLeader)
 	return u, nil
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -85,8 +85,8 @@ func ResetStats() {
 
 // DB is the SQL database.
 type DB struct {
-	path      string // Path to database file, if running on-disk.
-	walPath   string // Path to WAL file, if running on-disk and WAL is enabled.
+	path      string // Path to database file.
+	walPath   string // Path to WAL file.
 	fkEnabled bool   // Foreign key constraints enabled
 	wal       bool
 

--- a/db/db.go
+++ b/db/db.go
@@ -479,6 +479,11 @@ func (db *DB) Stats() (map[string]interface{}, error) {
 		"pragmas":          pragmas,
 	}
 
+	lm, err := db.LastModified()
+	if err == nil {
+		stats["last_modified"] = lm
+	}
+
 	stats["path"] = db.path
 	if stats["size"], err = db.FileSize(); err != nil {
 		return nil, err

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -552,6 +552,7 @@ func Test_DBLastModified(t *testing.T) {
 		t.Fatalf("last modified time not updated")
 	}
 
+	// Checkpoint, check time is later.
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("failed to checkpoint database: %s", err.Error())
 	}
@@ -561,6 +562,15 @@ func Test_DBLastModified(t *testing.T) {
 	}
 	if lm3.Before(lm2) {
 		t.Fatalf("last modified time not updated after checkpoint")
+	}
+
+	// Call again, without changes, check time is same.
+	lm4, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("failed to get last modified time: %s", err.Error())
+	}
+	if !lm4.Equal(lm3) {
+		t.Fatalf("last modified time updated without changes")
 	}
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -521,6 +521,49 @@ func Test_EnsureDelete(t *testing.T) {
 	}
 }
 
+func Test_DBLastModified(t *testing.T) {
+	path := mustTempFile()
+	defer os.Remove(path)
+	db, err := Open(path, false, true)
+	if err != nil {
+		t.Fatalf("failed to open database in WAL mode: %s", err.Error())
+	}
+	defer db.Close()
+
+	lm, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("failed to get last modified time: %s", err.Error())
+	}
+	if lm.IsZero() {
+		t.Fatalf("last modified time is zero")
+	}
+
+	// Write some data, check time is later.
+	_, err = db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+
+	lm2, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("failed to get last modified time: %s", err.Error())
+	}
+	if lm2.Before(lm) {
+		t.Fatalf("last modified time not updated")
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("failed to checkpoint database: %s", err.Error())
+	}
+	lm3, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("failed to get last modified time: %s", err.Error())
+	}
+	if lm3.Before(lm2) {
+		t.Fatalf("last modified time not updated after checkpoint")
+	}
+}
+
 // Test_WALDatabaseCreatedOK tests that a WAL file is created, and that
 // a checkpoint succeeds
 func Test_WALDatabaseCreatedOK(t *testing.T) {

--- a/store/provider.go
+++ b/store/provider.go
@@ -28,11 +28,12 @@ func NewProvider(s *Store, v bool) *Provider {
 	}
 }
 
-// Check returns true if the Store has changed since the last time Check() was
-// called with the given value of i. Check() also returns the current value of
-// i, which should be passed to the next invocation of Check(). If Check()
-// returns false, the returned uint64 of can be ignored.
+// Check returns true if the Provider data has changed since the last time
+// Check() was called with the given value of i. Check() also returns the
+// current value of i, which should be passed to the next invocation of
+// Check(). If Check() returns false, the returned uint64 can be ignored.
 func (p *Provider) Check(i uint64) (uint64, bool) {
+	stats.Add(numProviderChecks, 1)
 	li, err := p.str.boltStore.LastIndex()
 	if err != nil {
 		return 0, false
@@ -42,7 +43,14 @@ func (p *Provider) Check(i uint64) (uint64, bool) {
 
 // Provider writes the SQLite database to the given path, ensuring the database
 // is in DELETE mode. If path exists, it will be overwritten.
-func (p *Provider) Provide(path string) error {
+func (p *Provider) Provide(path string) (retErr error) {
+	stats.Add(numProviderProvides, 1)
+	defer func() {
+		if retErr != nil {
+			stats.Add(numProviderProvidesFail, 1)
+		}
+	}()
+
 	fd, err := os.Create(path)
 	if err != nil {
 		return err

--- a/store/provider.go
+++ b/store/provider.go
@@ -31,14 +31,14 @@ func NewProvider(s *Store, v bool) *Provider {
 // Check returns true if the Provider data has changed since the last time
 // Check() was called with the given value of i. Check() also returns the
 // current value of i, which should be passed to the next invocation of
-// Check(). If Check() returns false, the returned uint64 can be ignored.
-func (p *Provider) Check(i uint64) (uint64, bool) {
+// Check(). If Check() returns false, the returned int64 can be ignored.
+func (p *Provider) Check(i int64) (int64, bool) {
 	stats.Add(numProviderChecks, 1)
-	li, err := p.str.boltStore.LastIndex()
+	lm, err := p.str.db.LastModified()
 	if err != nil {
 		return 0, false
 	}
-	return li, li > i
+	return lm.UnixNano(), lm.UnixNano() > i
 }
 
 // Provider writes the SQLite database to the given path, ensuring the database

--- a/store/provider.go
+++ b/store/provider.go
@@ -28,6 +28,18 @@ func NewProvider(s *Store, v bool) *Provider {
 	}
 }
 
+// Check returns true if the Store has changed since the last time Check() was
+// called with the given value of i. Check() also returns the current value of
+// i, which should be passed to the next invocation of Check(). If Check()
+// returns false, the returned uint64 of can be ignored.
+func (p *Provider) Check(i uint64) (uint64, bool) {
+	li, err := p.str.boltStore.LastIndex()
+	if err != nil {
+		return 0, false
+	}
+	return li, li > i
+}
+
 // Provider writes the SQLite database to the given path, ensuring the database
 // is in DELETE mode. If path exists, it will be overwritten.
 func (p *Provider) Provide(path string) error {

--- a/store/provider_test.go
+++ b/store/provider_test.go
@@ -151,6 +151,9 @@ func Test_SingleNodeProvideCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to execute on single node: %s", err.Error())
 	}
+	if _, err := s.WaitForAppliedFSM(2 * time.Second); err != nil {
+		t.Fatalf("failed to wait for FSM to apply")
+	}
 	i, changed = provider.Check(i)
 	if !changed {
 		t.Fatalf("check should have indicated change")
@@ -162,6 +165,9 @@ func Test_SingleNodeProvideCheck(t *testing.T) {
 	_, err = s.Query(qr)
 	if err != nil {
 		t.Fatalf("failed to query leader node: %s", err.Error())
+	}
+	if _, err := s.WaitForAppliedFSM(2 * time.Second); err != nil {
+		t.Fatalf("failed to wait for FSM to apply")
 	}
 	i, changed = provider.Check(i)
 	if changed {
@@ -193,6 +199,9 @@ func Test_SingleNodeProvideCheck(t *testing.T) {
 	_, err = s.Execute(er)
 	if err != nil {
 		t.Fatalf("failed to execute on single node: %s", err.Error())
+	}
+	if _, err := s.WaitForAppliedFSM(2 * time.Second); err != nil {
+		t.Fatalf("failed to wait for FSM to apply")
 	}
 	_, changed = provider.Check(i)
 	if !changed {

--- a/store/provider_test.go
+++ b/store/provider_test.go
@@ -49,7 +49,7 @@ func Test_SingleNodeProvide(t *testing.T) {
 	tempFile := mustCreateTempFile()
 	defer os.Remove(tempFile)
 	provider := NewProvider(s0, false)
-	if err := provider.Provide(tempFile); err != nil {
+	if _, err := provider.Provide(tempFile); err != nil {
 		t.Fatalf("failed to provide SQLite data: %s", err.Error())
 	}
 
@@ -106,7 +106,7 @@ func Test_SingleNodeProvideNoData(t *testing.T) {
 	tmpFile := mustCreateTempFile()
 	defer os.Remove(tmpFile)
 	provider := NewProvider(s, false)
-	if err := provider.Provide(tmpFile); err != nil {
+	if _, err := provider.Provide(tmpFile); err != nil {
 		t.Fatalf("store failed to provide: %s", err.Error())
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -120,6 +120,9 @@ const (
 	numAutoRestoresSkipped    = "num_auto_restores_skipped"
 	numAutoRestoresFailed     = "num_auto_restores_failed"
 	numRecoveries             = "num_recoveries"
+	numProviderChecks         = "num_provider_checks"
+	numProviderProvides       = "num_provider_provides"
+	numProviderProvidesFail   = "num_provider_provides_fail"
 	numUncompressedCommands   = "num_uncompressed_commands"
 	numCompressedCommands     = "num_compressed_commands"
 	numJoins                  = "num_joins"
@@ -163,6 +166,9 @@ func ResetStats() {
 	stats.Add(numRestores, 0)
 	stats.Add(numRestoresFailed, 0)
 	stats.Add(numRecoveries, 0)
+	stats.Add(numProviderChecks, 0)
+	stats.Add(numProviderProvides, 0)
+	stats.Add(numProviderProvidesFail, 0)
 	stats.Add(numAutoRestores, 0)
 	stats.Add(numAutoRestoresSkipped, 0)
 	stats.Add(numAutoRestoresFailed, 0)

--- a/store/store.go
+++ b/store/store.go
@@ -110,7 +110,6 @@ const (
 	numWALSnapshotsFailed     = "num_wal_snapshots_failed"
 	numSnapshotsFull          = "num_snapshots_full"
 	numSnapshotsIncremental   = "num_snapshots_incremental"
-	numProvides               = "num_provides"
 	numBoots                  = "num_boots"
 	numBackups                = "num_backups"
 	numLoads                  = "num_loads"
@@ -160,7 +159,6 @@ func ResetStats() {
 	stats.Add(numSnapshotsFull, 0)
 	stats.Add(numSnapshotsIncremental, 0)
 	stats.Add(numBoots, 0)
-	stats.Add(numProvides, 0)
 	stats.Add(numBackups, 0)
 	stats.Add(numLoads, 0)
 	stats.Add(numRestores, 0)

--- a/system_test/e2e/helpers.py
+++ b/system_test/e2e/helpers.py
@@ -371,6 +371,27 @@ class Node(object):
   def num_restores(self):
     return int(self.expvar()['store']['num_restores'])
 
+  def num_auto_backups(self):
+    '''
+    Return a tuple of the number of successful, failed, and skipped auto-backups.
+    '''
+    return (int(self.expvar()['uploader']['num_uploads_ok']),
+            int(self.expvar()['uploader']['num_uploads_fail']),
+            int(self.expvar()['uploader']['num_uploads_skipped']))
+
+  def wait_for_upload(self, i, timeout=TIMEOUT):
+    '''
+    Wait until the number of uploads is at least as great as the given value.
+    '''
+    t = 0
+    while t < timeout:
+      if self.num_auto_backups()[0] >= i:
+        return self.num_auto_backups()
+      time.sleep(1)
+      t+=1
+    n = self.num_auto_backups()
+    raise Exception('rqlite node failed to upload backup within %d seconds (%d, %d, %d)' % (timeout, n[0], n[1], n[2]))
+
   def wait_for_fsm_index(self, index, timeout=TIMEOUT):
     '''
     Wait until the given index has been applied to the state machine.


### PR DESCRIPTION
The docs always stated that the upload only ran on the Leader, but this wasn't the actual case.