### PR TITLE
List the newest snapshot, not oldest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.16.2 (January 9th 2024)
+This releases fixes a bug related to Raft snapshot management. While it's an edge case, and can only happen if rqlited is hard-killed at a very specific point, all users should upgrade to this release.
+### Implementation changes and bug fixes
+- [PR #1580](https://github.com/rqlite/rqlite/pull/1580): List newest Snapshot, not oldest.
+
 ## 8.16.1 (January 8th 2024)
 ### Implementation changes and bug fixes
 - [PR #1574](https://github.com/rqlite/rqlite/pull/1574): Use "GZIP best speed" for internode traffic compression.


### PR DESCRIPTION
If rqlite was killed after snapshot-creation, but before reaping took place, Snapshot List() would return the oldest snapshot, not the newest. This is not compliant with Hashicorp Raft requirements.