### PR TITLE
aws: reuse session and S3 manager

### DIFF
--- a/auto/restore/downloader.go
+++ b/auto/restore/downloader.go
@@ -38,8 +38,11 @@ func DownloadFile(ctx context.Context, cfgPath string) (path string, errOK bool,
 	if err != nil {
 		return "", false, fmt.Errorf("failed to parse auto-restore file: %s", err.Error())
 	}
-	sc := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
+	sc, err := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
 		s3cfg.Bucket, s3cfg.Path, s3cfg.ForcePathStyle)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to create aws S3 client: %s", err.Error())
+	}
 	d := NewDownloader(sc)
 
 	// Create a temporary file to download to.

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func Test_NewS3Client(t *testing.T) {
-	c := NewS3Client("endpoint1", "region1", "access", "secret", "bucket2", "key3", true)
+	c, err := NewS3Client("endpoint1", "region1", "access", "secret", "bucket2", "key3", true)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
 	if c.region != "region1" {
 		t.Fatalf("expected region to be %q, got %q", "region1", c.region)
 	}
@@ -38,22 +41,34 @@ func Test_NewS3Client(t *testing.T) {
 
 func Test_S3Client_String(t *testing.T) {
 	// Test native S3 with implicit endpoint
-	c := NewS3Client("", "region1", "access", "secret", "bucket2", "key3", false)
+	c, err := NewS3Client("", "region1", "access", "secret", "bucket2", "key3", false)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
 	if c.String() != "s3://bucket2/key3" {
 		t.Fatalf("expected String() to be %q, got %q", "s3://bucket2/key3", c.String())
 	}
 	// Test native S3 with explicit endpoint
-	c = NewS3Client("s3.amazonaws.com", "region1", "access", "secret", "bucket2", "key3", false)
+	c, err = NewS3Client("s3.amazonaws.com", "region1", "access", "secret", "bucket2", "key3", false)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
 	if c.String() != "s3://bucket2/key3" {
 		t.Fatalf("expected String() to be %q, got %q", "s3://bucket2/key3", c.String())
 	}
 	// Test non-native S3 (explicit endpoint) with non-path style (e.g. Wasabi)
-	c = NewS3Client("s3.ca-central-1.wasabisys.com", "region1", "access", "secret", "bucket2", "key3", false)
+	c, err = NewS3Client("s3.ca-central-1.wasabisys.com", "region1", "access", "secret", "bucket2", "key3", false)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
 	if c.String() != "s3://bucket2.s3.ca-central-1.wasabisys.com/key3" {
 		t.Fatalf("expected String() to be %q, got %q", "s3://bucket2.s3.ca-central-1.wasabisys.com/key3", c.String())
 	}
 	// Test non-native S3 (explicit endpoint) with forced path style (e.g. MinIO)
-	c = NewS3Client("s3.minio.example.com", "region1", "access", "secret", "bucket2", "key3", true)
+	c, err = NewS3Client("s3.minio.example.com", "region1", "access", "secret", "bucket2", "key3", true)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
 	if c.String() != "s3://s3.minio.example.com/bucket2/key3" {
 		t.Fatalf("expected String() to be %q, got %q", "s3://s3.minio.example.com/bucket2/key3", c.String())
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -250,8 +250,11 @@ func startAutoBackups(ctx context.Context, cfg *Config, str *store.Store) (*back
 		return nil, fmt.Errorf("failed to parse auto-backup file: %s", err.Error())
 	}
 	provider := store.NewProvider(str, uCfg.Vacuum, !uCfg.NoCompress)
-	sc := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
+	sc, err := aws.NewS3Client(s3cfg.Endpoint, s3cfg.Region, s3cfg.AccessKeyID, s3cfg.SecretAccessKey,
 		s3cfg.Bucket, s3cfg.Path, s3cfg.ForcePathStyle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create aws S3 client: %s", err.Error())
+	}
 	u := backup.NewUploader(sc, provider, time.Duration(uCfg.Interval), !uCfg.NoCompress)
 	u.Start(ctx, str.IsLeader)
 	return u, nil


### PR DESCRIPTION
The AWS session and s3 manager are concurrent safe, they should be reused whenever possible:

    Sessions are safe to use concurrently as long as the Session is not
    being modified. Sessions should be cached when possible, because
    creating a new Session will load all configuration values from the
    environment, and config files each time the Session is created.

See https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/session

Currently, an aws session and s3 client/manager are created every time a call to Upload, CurrentID or Download is made. I changed it so it creates one session and S3 manager during app startup and reuse it afterwards.