### PR TITLE
Jitter the WAL size check interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [PR #1656](https://github.com/rqlite/rqlite/pull/1656): Add low-level WAL compaction timings and metrics.
 - [PR #1660](https://github.com/rqlite/rqlite/pull/1660): Upgrade to SQLite 3.45.1.
 - [PR #1659](https://github.com/rqlite/rqlite/pull/1659): Use `go generate` to generate Go Protobuf code. Thanks @mauri870
+- [PR #1661](https://github.com/rqlite/rqlite/pull/1661): Jitter the WAL size check interval.
 
 ## 8.18.5 (January 30th 2024)
 ### Implementation changes and bug fixes

--- a/random/random.go
+++ b/random/random.go
@@ -28,7 +28,7 @@ func String() string {
 	return output.String()
 }
 
-// Float64 returns a random float64
+// Float64 returns a random float64 between 0 and 1.
 func Float64() float64 {
 	mu.Lock()
 	defer mu.Unlock()

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -2,6 +2,7 @@ package random
 
 import (
 	"testing"
+	"time"
 )
 
 func Test_StringLength(t *testing.T) {
@@ -47,5 +48,14 @@ func Test_IntnUniqueness(t *testing.T) {
 			t.Errorf("Intn() returned a non-unique int: %d", n)
 		}
 		intns[n] = true
+	}
+}
+
+func Test_Jitter(t *testing.T) {
+	for n := 0; n < 100; n++ {
+		d := Jitter(100 * time.Millisecond)
+		if d < 100*time.Millisecond || d >= 200*time.Millisecond {
+			t.Errorf("Jitter(100ms) returned a duration of %s; want between 0 and 200ms", d)
+		}
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -31,6 +31,7 @@ import (
 	wal "github.com/rqlite/rqlite/v8/db/wal"
 	rlog "github.com/rqlite/rqlite/v8/log"
 	"github.com/rqlite/rqlite/v8/progress"
+	"github.com/rqlite/rqlite/v8/random"
 	"github.com/rqlite/rqlite/v8/snapshot"
 )
 
@@ -2179,7 +2180,7 @@ func (s *Store) runWALSnapshotting() (closeCh, doneCh chan struct{}) {
 	ticker := time.NewTicker(time.Hour) // Just need an initialized ticker to start with.
 	ticker.Stop()
 	if s.SnapshotInterval > 0 && s.SnapshotThresholdWALSize > 0 {
-		ticker.Reset(s.SnapshotInterval)
+		ticker.Reset(random.Jitter(s.SnapshotInterval))
 	}
 
 	go func() {


### PR DESCRIPTION
We don't want every node in the cluster to perform a WAL size snapshot at the same time.