### PR TITLE
Use defer only to make sure WAL file is closed

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1946,7 +1946,7 @@ func (s *Store) fsmSnapshot() (fSnap raft.FSMSnapshot, retErr error) {
 			if err != nil {
 				return nil, err
 			}
-			defer walFD.Close() // Make sure it closes.
+			defer walFD.Close()
 			scanner, err := wal.NewFastCompactingScanner(walFD)
 			if err != nil {
 				return nil, err
@@ -1955,8 +1955,6 @@ func (s *Store) fsmSnapshot() (fSnap raft.FSMSnapshot, retErr error) {
 			if err != nil {
 				return nil, err
 			}
-			walFD.Close() // We need it closed before truncating it.
-
 			stats.Get(snapshotCreateWALCompactDuration).(*expvar.Int).Set(time.Since(compactStartTime).Milliseconds())
 			compactedBuf = bytes.NewBuffer(compactedBytes)
 


### PR DESCRIPTION
Load testing shows this results in shorter snapshot times.