### PR TITLE
Don't attempt to dial nodes while holding onto Pools lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.23.2 (unreleased)
 ### Implementation changes and bug fixes
 - [PR #1749](https://github.com/rqlite/rqlite/pull/1749): Load _Queued Writes_ sequence numbers using `atomic`. Thanks @arturmelanchyk
+- [PR #1753](https://github.com/rqlite/rqlite/pull/1753): Don't attempt to dial nodes will holding onto Pools lock.
 
 ## 8.23.1 (April 5th 2024)
 ### Implementation changes and bug fixes

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	initialPoolSize   = 4
 	maxPoolCapacity   = 64
 	defaultMaxRetries = 8
 
@@ -67,9 +66,8 @@ type Client struct {
 	localNodeAddr string
 	localServ     *Service
 
-	poolMu        sync.RWMutex
-	poolInitialSz int
-	pools         map[string]pool.Pool
+	poolMu sync.RWMutex
+	pools  map[string]pool.Pool
 }
 
 // NewClient returns a client instance for talking to a remote node.
@@ -80,10 +78,9 @@ type Client struct {
 // usually retry these operations.
 func NewClient(dl Dialer, t time.Duration) *Client {
 	return &Client{
-		dialer:        dl,
-		timeout:       t,
-		poolInitialSz: initialPoolSize,
-		pools:         make(map[string]pool.Pool),
+		dialer:  dl,
+		timeout: t,
+		pools:   make(map[string]pool.Pool),
 	}
 }
 
@@ -462,7 +459,7 @@ func (c *Client) dial(nodeAddr string) (net.Conn, error) {
 
 			// New pool is needed for given address.
 			factory := func() (net.Conn, error) { return c.dialer.Dial(nodeAddr, c.timeout) }
-			p, err := pool.NewChannelPool(c.poolInitialSz, maxPoolCapacity, factory)
+			p, err := pool.NewChannelPool(maxPoolCapacity, factory)
 			if err != nil {
 				return err
 			}

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -63,11 +63,11 @@ type Client struct {
 	dialer  Dialer
 	timeout time.Duration
 
-	lMu           sync.RWMutex
+	localMu       sync.RWMutex
 	localNodeAddr string
 	localServ     *Service
 
-	mu            sync.RWMutex
+	poolMu        sync.RWMutex
 	poolInitialSz int
 	pools         map[string]pool.Pool
 }
@@ -91,8 +91,8 @@ func NewClient(dl Dialer, t time.Duration) *Client {
 // using this client. Along with the Service instance it allows this
 // client to serve requests for this node locally without the network hop.
 func (c *Client) SetLocal(nodeAddr string, serv *Service) error {
-	c.lMu.Lock()
-	defer c.lMu.Unlock()
+	c.localMu.Lock()
+	defer c.localMu.Unlock()
 	c.localNodeAddr = nodeAddr
 	c.localServ = serv
 	return nil
@@ -100,8 +100,8 @@ func (c *Client) SetLocal(nodeAddr string, serv *Service) error {
 
 // GetNodeAPIAddr retrieves the API Address for the node at nodeAddr
 func (c *Client) GetNodeAPIAddr(nodeAddr string, timeout time.Duration) (string, error) {
-	c.lMu.RLock()
-	defer c.lMu.RUnlock()
+	c.localMu.RLock()
+	defer c.localMu.RUnlock()
 	if c.localNodeAddr == nodeAddr && c.localServ != nil {
 		// Serve it locally!
 		stats.Add(numGetNodeAPIRequestLocal, 1)
@@ -418,8 +418,8 @@ func (c *Client) Join(jr *command.JoinRequest, nodeAddr string, creds *proto.Cre
 
 // Stats returns stats on the Client instance
 func (c *Client) Stats() (map[string]interface{}, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.poolMu.RLock()
+	defer c.poolMu.RUnlock()
 
 	stats := map[string]interface{}{
 		"timeout":         c.timeout.String(),
@@ -446,15 +446,15 @@ func (c *Client) dial(nodeAddr string) (net.Conn, error) {
 	var pl pool.Pool
 	var ok bool
 
-	c.mu.RLock()
+	c.poolMu.RLock()
 	pl, ok = c.pools[nodeAddr]
-	c.mu.RUnlock()
+	c.poolMu.RUnlock()
 
 	// Do we need a new pool for the given address?
 	if !ok {
 		if err := func() error {
-			c.mu.Lock()
-			defer c.mu.Unlock()
+			c.poolMu.Lock()
+			defer c.poolMu.Unlock()
 			pl, ok = c.pools[nodeAddr]
 			if ok {
 				return nil // Pool was inserted just after we checked.

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -198,7 +198,6 @@ func (s *Service) GetAPIAddr() string {
 func (s *Service) GetNodeAPIURL() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
 	scheme := "http"
 	if s.https {
 		scheme = "https"

--- a/tcp/pool/channel.go
+++ b/tcp/pool/channel.go
@@ -114,7 +114,6 @@ func (c *channelPool) put(conn net.Conn) error {
 	default:
 		// pool is full, close passed connection
 		atomic.AddInt64(&c.nOpenConns, -1)
-
 		return conn.Close()
 	}
 }

--- a/tcp/pool/channel.go
+++ b/tcp/pool/channel.go
@@ -63,7 +63,6 @@ func (c *channelPool) Get() (net.Conn, error) {
 			return nil, err
 		}
 		atomic.AddInt64(&c.nOpenConns, 1)
-
 		return c.wrapConn(conn), nil
 	}
 }

--- a/tcp/pool/channel_test.go
+++ b/tcp/pool/channel_test.go
@@ -159,7 +159,7 @@ func TestPool_Close(t *testing.T) {
 
 func TestPoolConcurrent(t *testing.T) {
 	p, _ := newChannelPool()
-	pipe := make(chan net.Conn, 0)
+	pipe := make(chan net.Conn)
 
 	go func() {
 		p.Close()


### PR DESCRIPTION
This couples dialing between nodes, and if one is unreachable, it can slow down connecting to other nodes for any reason, such as queries.