### PR TITLE
Re-use existing SQLite database on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.25.2 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1799](https://github.com/rqlite/rqlite/pull/1799): Re-use SQLite database instead of restoring from Snapshot
+
 ## 8.25.1 (June 10th 2024)
 ### Implementation changes and bug fixes
 - [PR #1797](https://github.com/rqlite/rqlite/pull/1797): Upgrade Hashicorp Raft to v1.7.0.

--- a/db/state.go
+++ b/db/state.go
@@ -157,6 +157,11 @@ func RemoveFiles(path string) error {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	return RemoveWALFiles(path)
+}
+
+// RemoveWALFiles any WAL and SHM files associated with the path but not the database file itself.
+func RemoveWALFiles(path string) error {
 	if err := os.Remove(path + "-wal"); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -132,6 +132,7 @@ const (
 	numLoads                          = "num_loads"
 	numRestores                       = "num_restores"
 	numRestoresFailed                 = "num_restores_failed"
+	numRestoresSkippedOnStart         = "num_restores_skipped_on_start"
 	numAutoRestores                   = "num_auto_restores"
 	numAutoRestoresSkipped            = "num_auto_restores_skipped"
 	numAutoRestoresFailed             = "num_auto_restores_failed"
@@ -187,6 +188,7 @@ func ResetStats() {
 	stats.Add(numLoads, 0)
 	stats.Add(numRestores, 0)
 	stats.Add(numRestoresFailed, 0)
+	stats.Add(numRestoresSkippedOnStart, 0)
 	stats.Add(numRecoveries, 0)
 	stats.Add(numProviderChecks, 0)
 	stats.Add(numProviderProvides, 0)
@@ -513,6 +515,7 @@ func (s *Store) Open() (retErr error) {
 		return fmt.Errorf("failed to create on-disk database: %s", err)
 	}
 	if dbReused {
+		stats.Add(numRestoresSkippedOnStart, 1)
 		s.logger.Printf("reusing existing database at %s, skipping copy from Snapshot store", s.dbPath)
 	}
 	config.NoSnapshotRestoreOnStart = dbReused


### PR DESCRIPTION
The checksums provide protection against a corrupted SQLite file. A SQLite file that passes the checksum test is the same logical database that would be restored if a copy was read and installed from the Snapshot store.