### PR TITLE
Move to "named" registration of the SQLite3 driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.26.9 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1842](https://github.com/rqlite/rqlite/pull/1842): Move to "named" registration of the SQLite3 driver.
+
 ## v8.26.8 (July 28th 2024)
 This release blocks execution of `PRAGMA` statements which will break rqlite.
 ### Implementation changes and bug fixes

--- a/db/db.go
+++ b/db/db.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	dbRegisterName   = "rqlite-sqlite3"
 	SQLiteHeaderSize = 32
 	bkDelay          = 250
 	durToOpenLog     = 2 * time.Second
@@ -84,6 +85,7 @@ var DBVersion string
 var stats *expvar.Map
 
 func init() {
+	sql.Register(dbRegisterName, &sqlite3.SQLiteDriver{})
 	DBVersion, _, _ = sqlite3.Version()
 	stats = expvar.NewMap("db")
 	ResetStats()
@@ -159,7 +161,7 @@ func Open(dbPath string, fkEnabled, wal bool) (retDB *DB, retErr error) {
 	/////////////////////////////////////////////////////////////////////////
 	// Main RW connection
 	rwDSN := MakeDSN(dbPath, ModeReadWrite, fkEnabled, wal)
-	rwDB, err := sql.Open("sqlite3", rwDSN)
+	rwDB, err := sql.Open(dbRegisterName, rwDSN)
 	if err != nil {
 		return nil, fmt.Errorf("open: %s", err.Error())
 	}
@@ -172,7 +174,7 @@ func Open(dbPath string, fkEnabled, wal bool) (retDB *DB, retErr error) {
 	/////////////////////////////////////////////////////////////////////////
 	// Read-only connection
 	roDSN := MakeDSN(dbPath, ModeReadOnly, fkEnabled, wal)
-	roDB, err := sql.Open("sqlite3", roDSN)
+	roDB, err := sql.Open(dbRegisterName, roDSN)
 	if err != nil {
 		return nil, err
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -710,7 +710,7 @@ func Test_CheckIntegrityOnDisk(t *testing.T) {
 	defer os.Remove(path)
 
 	dsn := fmt.Sprintf("file:%s", path)
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(dbRegisterName, dsn)
 	if err != nil {
 		t.Fatalf("failed to create SQLite database: %s", err.Error())
 	}

--- a/db/state.go
+++ b/db/state.go
@@ -221,7 +221,7 @@ func EnsureDeleteMode(path string) error {
 		return nil
 	}
 	rwDSN := fmt.Sprintf("file:%s", path)
-	conn, err := sql.Open("sqlite3", rwDSN)
+	conn, err := sql.Open(dbRegisterName, rwDSN)
 	if err != nil {
 		return fmt.Errorf("open: %s", err.Error())
 	}

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -104,7 +104,7 @@ func Test_IsValidSQLiteOnDisk(t *testing.T) {
 	defer os.Remove(path)
 
 	dsn := fmt.Sprintf("file:%s", path)
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(dbRegisterName, dsn)
 	if err != nil {
 		t.Fatalf("failed to create SQLite database: %s", err.Error())
 	}
@@ -134,7 +134,7 @@ func Test_IsWALModeEnabledOnDiskDELETE(t *testing.T) {
 	defer os.Remove(path)
 
 	dsn := fmt.Sprintf("file:%s", path)
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(dbRegisterName, dsn)
 	if err != nil {
 		t.Fatalf("failed to create SQLite database: %s", err.Error())
 	}
@@ -170,7 +170,7 @@ func Test_IsWALModeEnabledOnDiskWAL(t *testing.T) {
 	defer os.Remove(path)
 
 	dsn := fmt.Sprintf("file:%s", path)
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(dbRegisterName, dsn)
 	if err != nil {
 		t.Fatalf("failed to create SQLite database: %s", err.Error())
 	}


### PR DESCRIPTION
This sets us up for any future Extensions or Connect Hooks support.