### PR TITLE
Align CircleCI and release-build flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,7 @@ jobs:
       - checkout
       - restore_and_save_cache
       - run: go version
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/single_node.py
           environment:
@@ -183,8 +182,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: |
             cd system_test/e2e
@@ -199,8 +197,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/joining.py
           environment:
@@ -213,8 +210,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/multi_node.py
           environment:
@@ -227,8 +223,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/multi_node_adv.py
           environment:
@@ -243,8 +238,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/auto_clustering.py
           environment:
@@ -257,8 +251,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run:
           command: python3 system_test/e2e/auto_state.py
           environment:
@@ -271,8 +264,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_cache
-      - run: go install -tags osusergo,netgo
-          -ldflags="-extldflags=-static" ./...
+      - run: go install ./...
       - run: mkdir /home/circleci/extensions
       - run: gcc -g -fPIC -shared db/testdata/rot13.c -o /home/circleci/extensions/rot13.so
       - run: gcc -g -fPIC -shared db/testdata/carray.c -o /home/circleci/extensions/carray.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### New features
 - [PR #1859](https://github.com/rqlite/rqlite/pull/1859), [PR #1860](https://github.com/rqlite/rqlite/pull/1860): `-extensions-path` supports multiple comma-delimited paths.
 
+### Implementation changes and bug fixes
+- [PR #1861](https://github.com/rqlite/rqlite/pull/1861): Align CircleCI and release build `go install` flags.
+
 ## v8.28.4 (August 16th 2024)
 There are no functional changes in this release to rqlite itself.
 ### Implementation changes and bug fixes


### PR DESCRIPTION
This ensures that end-to-end test binaries are built in the same way as the actual release binaries.