### PR TITLE
No checkpoint on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v8.29.5 (unreleased)
 ### Implementation changes and bug fixes
 - [PR #1875](https://github.com/rqlite/rqlite/pull/1875): Add `UPSERT` unit test.
+- [PR #1877](https://github.com/rqlite/rqlite/pull/1875): Move to no-checkpoint-on-database-close.
 
 ## v8.29.4 (August 31st 2024)
 ### Implementation changes and bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.30.1 (unreleased)
+### Implementation changes and bug fixes
+- [PR #1877](https://github.com/rqlite/rqlite/pull/1875): Move to no-checkpoint-on-database-close.
+
 ## v8.30.0 (September 5th 2024)
 ### New features
 - [PR #1879](https://github.com/rqlite/rqlite/pull/1879): Add support for automatic [`PRAGMA optimize`](https://www.sqlite.org/pragma.html#pragma_optimize) of the SQLite database. Fixes issue [#1831](https://github.com/rqlite/rqlite/issues/1831).
@@ -6,7 +10,6 @@
 ### Implementation changes and bug fixes
 - [PR #1878](https://github.com/rqlite/rqlite/pull/1878): Upgrade SQLite to 3.46.1.
 - [PR #1875](https://github.com/rqlite/rqlite/pull/1875): Add `UPSERT` unit test.
-- [PR #1877](https://github.com/rqlite/rqlite/pull/1875): Move to no-checkpoint-on-database-close.
 
 ## v8.29.4 (August 31st 2024)
 ### Implementation changes and bug fixes

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"io"
@@ -30,7 +31,7 @@ func Test_OpenNonExistentDatabase(t *testing.T) {
 	}
 }
 
-func Test_WALRemovedOnClose(t *testing.T) {
+func Test_WALNotRemovedOnClose(t *testing.T) {
 	path := mustTempPath()
 	defer os.Remove(path)
 	db, err := Open(path, false, true)
@@ -54,8 +55,92 @@ func Test_WALRemovedOnClose(t *testing.T) {
 		t.Fatalf("error closing database: %s", err.Error())
 	}
 
-	if fileExists(db.WALPath()) {
-		t.Fatalf("WAL file not removed after closing the database")
+	if !fileExists(db.WALPath()) {
+		t.Fatalf("WAL file removed after closing the database")
+	}
+}
+
+// Test_WALNotCheckpointedOnClose tests that a) the database isn't checkpointed
+// on close, and that removing the WAL file doesn't affect the main database --
+// and that it can be opened. This is about testing that we can handle a hard
+// crash, where WAL files are left behind and we want to discard them.
+func Test_WALNotCheckpointedOnClose(t *testing.T) {
+	path := mustTempPath()
+	defer os.Remove(path)
+	db, err := Open(path, false, true)
+	if err != nil {
+		t.Fatalf("error opening nonexistent database")
+	}
+	defer db.Close()
+	if !db.WALEnabled() {
+		t.Fatalf("WAL mode not enabled")
+	}
+
+	_, err = db.ExecuteStringStmt("CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+	walPath := db.WALPath()
+	if !fileExists(walPath) {
+		t.Fatalf("WAL file does not exist after creating a table")
+	}
+
+	// Checkpoint to table exists in main database file.
+	if err := db.Checkpoint(CheckpointTruncate); err != nil {
+		t.Fatalf("failed to checkpoint database: %s", err.Error())
+	}
+
+	// Now, insert a record to bring back a non-zero-length WAL.
+	_, err = db.ExecuteStringStmt(`INSERT INTO foo(name) VALUES("fiona")`)
+	if err != nil {
+		t.Fatalf("error executing insertion into table: %s", err.Error())
+	}
+	if mustFileSize(walPath) == 0 {
+		t.Fatalf("WAL file size is zero after insertion")
+	}
+
+	// Ensure that the main SQLite file is not changed at close-time.
+	bytesPre := mustReadBytes(path)
+	if err := db.Close(); err != nil {
+		t.Fatalf("error closing database: %s", err.Error())
+	}
+	bytesPost := mustReadBytes(path)
+	if !bytes.Equal(bytesPre, bytesPost) {
+		t.Fatalf("database changed after closing")
+	}
+
+	if !fileExists(db.WALPath()) {
+		t.Fatalf("WAL file removed after closing the database")
+	}
+
+	// Remove the WAL file, and confirm we now have an empty table in
+	// the database.
+	if err := os.Remove(walPath); err != nil {
+		t.Fatalf("failed to remove WAL file: %s", err.Error())
+	}
+
+	db, err = Open(path, false, true)
+	if err != nil {
+		t.Fatalf("error opening database post WAL deletion")
+	}
+	defer db.Close()
+
+	// Query the count in the table, should be zero.
+	q, err := db.QueryStringStmt("SELECT COUNT(*) FROM foo")
+	if err != nil {
+		t.Fatalf("failed to query empty table: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["COUNT(*)"],"types":["integer"],"values":[[0]]}]`, asJSON(q); exp != got {
+		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
+	}
+
+	// Finally, run an integrity check on the database.
+	r, err := db.IntegrityCheck(true)
+	if err != nil {
+		t.Fatalf("failed to run integrity check on database: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["integrity_check"],"types":["text"],"values":[["ok"]]}]`, asJSON(r); exp != got {
+		t.Fatalf("unexpected results for integrity check of dst, expected %s, got %s", exp, got)
 	}
 }
 

--- a/db/driver.go
+++ b/db/driver.go
@@ -19,7 +19,10 @@ const (
 type CnkOnCloseMode int
 
 const (
+	// CnkOnCloseModeEnabled enables checkpoint on close.
 	CnkOnCloseModeEnabled CnkOnCloseMode = iota
+
+	// CnkOnCloseModeDisabled disables checkpoint on close.
 	CnkOnCloseModeDisabled
 )
 
@@ -27,6 +30,7 @@ const (
 type Driver struct {
 	name       string
 	extensions []string
+	chkOnClose CnkOnCloseMode
 }
 
 var defRegisterOnce sync.Once
@@ -42,7 +46,8 @@ func DefaultDriver() *Driver {
 		})
 	})
 	return &Driver{
-		name: defaultDriverName,
+		name:       defaultDriverName,
+		chkOnClose: CnkOnCloseModeDisabled,
 	}
 }
 
@@ -59,7 +64,8 @@ func CheckpointDriver() *Driver {
 		})
 	})
 	return &Driver{
-		name: chkDriverName,
+		name:       chkDriverName,
+		chkOnClose: CnkOnCloseModeEnabled,
 	}
 }
 
@@ -98,6 +104,11 @@ func (d *Driver) ExtensionNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// CheckpointOnCloseMode returns the checkpoint on close mode.
+func (d *Driver) CheckpointOnCloseMode() CnkOnCloseMode {
+	return d.chkOnClose
 }
 
 func makeConnectHookFn(chkpt CnkOnCloseMode) func(conn *sqlite3.SQLiteConn) error {

--- a/db/driver_test.go
+++ b/db/driver_test.go
@@ -23,7 +23,7 @@ func Test_DefaultDriver(t *testing.T) {
 func Test_NewDriver(t *testing.T) {
 	name := "test-driver"
 	extensions := []string{"test1", "test2"}
-	d := NewDriver(name, extensions)
+	d := NewDriver(name, extensions, CnkOnCloseModeEnabled)
 	if d == nil {
 		t.Fatalf("NewDriver returned nil")
 	}

--- a/db/driver_test.go
+++ b/db/driver_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"os"
 	"testing"
 )
 
@@ -18,6 +19,56 @@ func Test_DefaultDriver(t *testing.T) {
 	if d == nil {
 		t.Fatalf("DefaultDriver returned nil")
 	}
+
+	path := mustTempPath()
+	defer os.RemoveAll(path)
+	db, err := OpenWithDriver(d, path, false, true)
+	if err != nil {
+		t.Fatalf("OpenWithDriver failed: %s", err.Error())
+	}
+	mustExecute(db, "CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT)")
+	if !fileExists(db.WALPath()) {
+		t.Fatalf("WAL file not created")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %s", err.Error())
+	}
+	if !fileExists(db.WALPath()) {
+		t.Fatalf("WAL file removed on close")
+	}
+}
+
+func Test_CheckpointDriver(t *testing.T) {
+	d := CheckpointDriver()
+	if d == nil {
+		t.Fatalf("CheckpointDriver returned nil")
+	}
+	if d.Name() != chkDriverName {
+		t.Fatalf("CheckpointDriver returned incorrect name: %s", d.Name())
+	}
+
+	// Call it again, make sure it doesn't panic.
+	d = CheckpointDriver()
+	if d == nil {
+		t.Fatalf("CheckpointDriver returned nil")
+	}
+
+	path := mustTempPath()
+	defer os.RemoveAll(path)
+	db, err := OpenWithDriver(d, path, false, true)
+	if err != nil {
+		t.Fatalf("OpenWithDriver failed: %s", err.Error())
+	}
+	mustExecute(db, "CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT)")
+	if !fileExists(db.WALPath()) {
+		t.Fatalf("WAL file not created")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %s", err.Error())
+	}
+	if fileExists(db.WALPath()) {
+		t.Fatalf("WAL file not removed on close")
+	}
 }
 
 func Test_NewDriver(t *testing.T) {
@@ -32,5 +83,8 @@ func Test_NewDriver(t *testing.T) {
 	}
 	if len(d.Extensions()) != 2 {
 		t.Fatalf("NewDriver returned incorrect extensions: %v", d.Extensions())
+	}
+	if d.CheckpointOnCloseMode() != CnkOnCloseModeEnabled {
+		t.Fatalf("NewDriver returned incorrect checkpoint mode: %v", d.CheckpointOnCloseMode())
 	}
 }

--- a/db/state.go
+++ b/db/state.go
@@ -275,14 +275,12 @@ func EnsureDeleteMode(path string) error {
 	if IsDELETEModeEnabledSQLiteFile(path) {
 		return nil
 	}
-	rwDSN := fmt.Sprintf("file:%s", path)
-	conn, err := sql.Open(defaultDriverName, rwDSN)
+	db, err := Open(path, false, false)
 	if err != nil {
-		return fmt.Errorf("open: %s", err.Error())
+		return err
 	}
-	defer conn.Close()
-	_, err = conn.Exec("PRAGMA journal_mode=DELETE")
-	return err
+	defer db.Close()
+	return nil
 }
 
 // EnsureWALMode ensures the database at the given path is in WAL mode.
@@ -290,14 +288,12 @@ func EnsureWALMode(path string) error {
 	if IsWALModeEnabledSQLiteFile(path) {
 		return nil
 	}
-	rwDSN := fmt.Sprintf("file:%s", path)
-	conn, err := sql.Open(defaultDriverName, rwDSN)
+	db, err := Open(path, false, true)
 	if err != nil {
-		return fmt.Errorf("open: %s", err.Error())
+		return err
 	}
-	defer conn.Close()
-	_, err = conn.Exec("PRAGMA journal_mode=WAL")
-	return err
+	defer db.Close()
+	return nil
 }
 
 // CheckpointRemove checkpoints any WAL files into the database file at the given

--- a/db/state.go
+++ b/db/state.go
@@ -286,8 +286,7 @@ func EnsureWALMode(path string) error {
 }
 
 // CheckpointRemove checkpoints any WAL files into the database file at the given
-// given path. The database will be in WAL mode after the operation but no WAL-related
-// files will be present. Checkpointing a database in DELETE mode is an error.
+// given path. Checkpointing a database in DELETE mode is an error.
 func CheckpointRemove(path string) error {
 	d, err := IsDELETEModeEnabledSQLiteFile(path)
 	if err != nil {
@@ -296,10 +295,13 @@ func CheckpointRemove(path string) error {
 	if d {
 		return fmt.Errorf("cannot checkpoint database in DELETE mode")
 	}
-	if err := EnsureDeleteMode(path); err != nil {
+
+	drv := CheckpointDriver()
+	db, err := OpenWithDriver(drv, path, false, true)
+	if err != nil {
 		return err
 	}
-	return EnsureWALMode(path)
+	return db.Close()
 }
 
 // RemoveWALFiles removes the WAL and SHM files associated with the given path,

--- a/db/state.go
+++ b/db/state.go
@@ -279,8 +279,7 @@ func EnsureDeleteMode(path string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
-	return nil
+	return db.Close()
 }
 
 // EnsureWALMode ensures the database at the given path is in WAL mode.
@@ -292,12 +291,12 @@ func EnsureWALMode(path string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
-	return nil
+	return db.Close()
 }
 
 // CheckpointRemove checkpoints any WAL files into the database file at the given
-// given path. The database will be in WAL mode after the operation.
+// given path. The database will be in WAL mode after the operation, and all WAL-related
+// files will have been removed.
 func CheckpointRemove(path string) error {
 	if err := EnsureDeleteMode(path); err != nil {
 		return err

--- a/db/state.go
+++ b/db/state.go
@@ -269,13 +269,6 @@ func IsDELETEModeEnabled(b []byte) bool {
 
 // EnsureDeleteMode ensures the database at the given path is in DELETE mode.
 func EnsureDeleteMode(path string) error {
-	d, err := IsDELETEModeEnabledSQLiteFile(path)
-	if err != nil {
-		return err
-	}
-	if d {
-		return nil
-	}
 	db, err := Open(path, false, false)
 	if err != nil {
 		return err
@@ -285,13 +278,6 @@ func EnsureDeleteMode(path string) error {
 
 // EnsureWALMode ensures the database at the given path is in WAL mode.
 func EnsureWALMode(path string) error {
-	w, err := IsWALModeEnabledSQLiteFile(path)
-	if err != nil {
-		return err
-	}
-	if w {
-		return nil
-	}
 	db, err := Open(path, false, true)
 	if err != nil {
 		return err

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"compress/gzip"
 	"database/sql"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -140,6 +142,52 @@ func Test_IsValidSQLiteOnDisk(t *testing.T) {
 	}
 	if !IsValidSQLiteData(data) {
 		t.Fatalf("good SQLite data marked as invalid")
+	}
+}
+
+func Test_IsValidSQLiteCompressedOnDisk(t *testing.T) {
+	path := mustTempFile()
+	defer os.Remove(path)
+
+	dsn := fmt.Sprintf("file:%s", path)
+	db, err := sql.Open(defaultDriverName, dsn)
+	if err != nil {
+		t.Fatalf("failed to create SQLite database: %s", err.Error())
+	}
+	_, err = db.Exec("CREATE TABLE foo (name TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %s", err.Error())
+	}
+
+	// Compress the SQLite file to a second a path.
+	compressedPath := mustTempFile()
+	defer os.Remove(compressedPath)
+	mustGzip(compressedPath, path)
+	if !IsValidSQLiteFileCompressed(compressedPath) {
+		t.Fatalf("good compressed SQLite file marked as invalid")
+	}
+
+	// Ensure non-existent file is marked as invalid.
+	if IsValidSQLiteFileCompressed("non-existent") {
+		t.Fatalf("non-existent compressed SQLite file marked as valid")
+	}
+
+	// Ensure that non-compressed SQLite files are marked as invalid.
+	if IsValidSQLiteFileCompressed(path) {
+		t.Fatalf("non-compressed SQLite file marked as valid")
+	}
+
+	// Compress the already compressed file, and check that it is marked
+	// as invalid. This is to check that an valid Gzip archive, but one
+	// that is not a valid SQLite file, is marked as invalid.
+	compressedCompressedPath := mustTempFile()
+	defer os.Remove(compressedCompressedPath)
+	mustGzip(compressedCompressedPath, compressedPath)
+	if IsValidSQLiteFileCompressed(compressedCompressedPath) {
+		t.Fatalf("Gzip archive of non-SQLite file marked as valid")
 	}
 }
 
@@ -336,17 +384,6 @@ func Test_WALReplayOK(t *testing.T) {
 			}
 		}
 
-		// Check that there are no files related to WALs in the replay directory
-		// Both the copied WAL files should be gone, and there should be no
-		// "real" WAL file either.
-		walFiles, err := filepath.Glob(filepath.Join(replayDir, "*-wal*"))
-		if err != nil {
-			t.Fatalf("failed to glob replay directory: %s", err.Error())
-		}
-		if len(walFiles) != 0 {
-			t.Fatalf("replay directory contains WAL files: %s", walFiles)
-		}
-
 		replayedDB, err := Open(replayDBPath, false, true)
 		if err != nil {
 			t.Fatalf("failed to open replayed database: %s", err.Error())
@@ -529,5 +566,39 @@ func Test_WALReplayFailures(t *testing.T) {
 	err := ReplayWAL(filepath.Join(dbDir, "foo.db"), []string{filepath.Join(walDir, "foo.db-wal")}, false)
 	if err != ErrWALReplayDirectoryMismatch {
 		t.Fatalf("expected %s, got %s", ErrWALReplayDirectoryMismatch, err.Error())
+	}
+}
+
+func mustGzip(dst, src string) {
+	dstF, err := os.Create(dst)
+	if err != nil {
+		panic(err)
+	}
+	defer dstF.Close()
+
+	gw := gzip.NewWriter(dstF)
+	defer gw.Close()
+
+	srcF, err := os.Open(src)
+	if err != nil {
+		panic(err)
+	}
+	defer srcF.Close()
+
+	_, err = io.Copy(gw, srcF)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := gw.Close(); err != nil {
+		panic(err)
+	}
+
+	if err := dstF.Close(); err != nil {
+		panic(err)
+	}
+
+	if err := srcF.Close(); err != nil {
+		panic(err)
 	}
 }

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -277,7 +277,7 @@ func Test_IsWALModeEnabledOnDiskWAL(t *testing.T) {
 	}
 }
 
-func Test_EnsureDelete(t *testing.T) {
+func Test_EnsureDeleteMode(t *testing.T) {
 	path := mustTempFile()
 	defer os.Remove(path)
 
@@ -295,6 +295,27 @@ func Test_EnsureDelete(t *testing.T) {
 	}
 	if !IsDELETEModeEnabledSQLiteFile(path) {
 		t.Fatalf("database not marked as DELETE mode")
+	}
+}
+
+func Test_EnsureWALMode(t *testing.T) {
+	path := mustTempFile()
+	defer os.Remove(path)
+
+	db, err := Open(path, false, false)
+	if err != nil {
+		t.Fatalf("failed to open database in WAL mode: %s", err.Error())
+	}
+	defer db.Close()
+	if IsWALModeEnabledSQLiteFile(path) {
+		t.Fatalf("WAL file marked as WAL")
+	}
+
+	if err := EnsureWALMode(path); err != nil {
+		t.Fatalf("failed to ensure WAL mode: %s", err.Error())
+	}
+	if !IsWALModeEnabledSQLiteFile(path) {
+		t.Fatalf("database not marked as WAL mode")
 	}
 }
 

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -338,14 +338,23 @@ func Test_EnsureWALMode(t *testing.T) {
 		t.Fatalf("failed to open database in WAL mode: %s", err.Error())
 	}
 	defer db.Close()
-	if IsWALModeEnabledSQLiteFile(path) {
-		t.Fatalf("WAL file marked as WAL")
+
+	w, err := IsWALModeEnabledSQLiteFile(path)
+	if err != nil {
+		t.Fatalf("failed to check WAL mode: %s", err.Error())
+	}
+	if w {
+		t.Fatalf("DELETE mode file not marked as DELETE")
 	}
 
 	if err := EnsureWALMode(path); err != nil {
 		t.Fatalf("failed to ensure WAL mode: %s", err.Error())
 	}
-	if !IsWALModeEnabledSQLiteFile(path) {
+	w, err = IsWALModeEnabledSQLiteFile(path)
+	if err != nil {
+		t.Fatalf("failed to check WAL mode: %s", err.Error())
+	}
+	if !w {
 		t.Fatalf("database not marked as WAL mode")
 	}
 }
@@ -397,7 +406,11 @@ func Test_CheckpointRemove(t *testing.T) {
 	if err := CheckpointRemove(path); err != nil {
 		t.Fatalf("failed to checkpoint database in WAL mode: %s", err.Error())
 	}
-	if !IsWALModeEnabledSQLiteFile(path) {
+	w, err := IsWALModeEnabledSQLiteFile(path)
+	if err != nil {
+		t.Fatalf("failed to check WAL mode: %s", err.Error())
+	}
+	if !w {
 		t.Fatalf("database not marked as WAL mode")
 	}
 	if fileExists(path + "-wal") {

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -339,18 +339,15 @@ func Test_EnsureWALMode(t *testing.T) {
 	}
 	defer db.Close()
 
-	w, err := IsWALModeEnabledSQLiteFile(path)
-	if err != nil {
-		t.Fatalf("failed to check WAL mode: %s", err.Error())
-	}
-	if w {
-		t.Fatalf("DELETE mode file not marked as DELETE")
+	_, err = IsWALModeEnabledSQLiteFile(path)
+	if err == nil {
+		t.Fatalf("expect error when checking WAL mode on zero-length file")
 	}
 
 	if err := EnsureWALMode(path); err != nil {
 		t.Fatalf("failed to ensure WAL mode: %s", err.Error())
 	}
-	w, err = IsWALModeEnabledSQLiteFile(path)
+	w, err := IsWALModeEnabledSQLiteFile(path)
 	if err != nil {
 		t.Fatalf("failed to check WAL mode: %s", err.Error())
 	}

--- a/snapshot/sink.go
+++ b/snapshot/sink.go
@@ -212,8 +212,8 @@ func (s *Sink) processSnapshotData() (retErr error) {
 			if err := os.Rename(snapPrevDB, snapNewDB); err != nil {
 				return err
 			}
-			// An open-close cycle checkpoints and removes any WAL file.
-			if err := openCloseDB(snapNewDB); err != nil {
+			// Ensure any WAL files are processed and removed.
+			if err := db.CheckpointRemove(snapNewDB); err != nil {
 				return err
 			}
 		}

--- a/snapshot/sink.go
+++ b/snapshot/sink.go
@@ -214,7 +214,7 @@ func (s *Sink) processSnapshotData() (retErr error) {
 			}
 			// Ensure any WAL files are processed and removed.
 			if err := db.CheckpointRemove(snapNewDB); err != nil {
-				return err
+				return fmt.Errorf("failed to checkpoint WAL file: %s", err.Error())
 			}
 		}
 	}

--- a/snapshot/upgrader.go
+++ b/snapshot/upgrader.go
@@ -145,7 +145,7 @@ func Upgrade7To8(old, new string, logger *log.Logger) (retErr error) {
 		}
 
 		// Ensure database file exists and convert to WAL mode.
-		if err := openCloseDB(newSqlitePath); err != nil {
+		if err := db.EnsureWALMode(newSqlitePath); err != nil {
 			return fmt.Errorf("failed to convert migrated SQLite file %s to WAL mode: %s", newSqlitePath, err)
 		}
 		return nil

--- a/store/store.go
+++ b/store/store.go
@@ -2417,7 +2417,7 @@ func createOnDisk(path string, fkConstraints, wal bool, extensions []string) (*s
 	}
 	drv := db.DefaultDriver()
 	if len(extensions) > 0 {
-		drv = db.NewDriver("rqlite-sqlite3-extended", extensions)
+		drv = db.NewDriver("rqlite-sqlite3-extended", extensions, db.CnkOnCloseModeDisabled)
 	}
 	return sql.OpenSwappableWithDriver(drv, path, fkConstraints, wal)
 }


### PR DESCRIPTION
As part of the 9.0 design, rqlite must not checkpoint any database when it's closed, as that would put the primary SQLite database in an invalid state -- WAL files would be checkpointed even though a Snapshot had not occurred. This gets this change into master, reducing the changes that will arrive due to other 9.0 changes.