### PR TITLE
Remove Query Transaction mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [PR #1917](https://github.com/rqlite/rqlite/pull/1917): Update "DB last modified time" on Restore.
 - [PR #1918](https://github.com/rqlite/rqlite/pull/1918): Store snapshotted WAL data in a file, not in memory.
 - [PR #1920](https://github.com/rqlite/rqlite/pull/1920): _AutoVac_ should just `VACUUM`, not `VACUUM INTO`. Fixes issue [#1914](https://github.com/rqlite/rqlite/issues/1914).
+- [PR #1921](https://github.com/rqlite/rqlite/pull/1921): Remove unneeded Query Transaction mutex.
 
 ## v8.31.1 (September 27th 2024)
 ### Implementation changes and bug fixes


### PR DESCRIPTION
This mutex has not been needed since rqlite moved to WAL-based snapshotting.