### PR TITLE
Read Term from Raft level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v8.32.0 (unreleased)
 ### New features
-- [PR #1930](https://github.com/rqlite/rqlite/pull/1930), [PR #1935](https://github.com/rqlite/rqlite/pull/1935), [PR #1936](https://github.com/rqlite/rqlite/pull/1936): Add Linearizable reads. Thanks @lalalalatt, @peterxcli
+- [PR #1930](https://github.com/rqlite/rqlite/pull/1930), [PR #1935](https://github.com/rqlite/rqlite/pull/1935), [PR #1936](https://github.com/rqlite/rqlite/pull/1936), [PR #1937](https://github.com/rqlite/rqlite/pull/1937): Add Linearizable reads. Thanks @lalalalatt, @peterxcli
 
 ### Implementation changes and bug fixes
 - [PR #1933](https://github.com/rqlite/rqlite/pull/1933), [PR #1934](https://github.com/rqlite/rqlite/pull/1934): Add `CloseOrTimeout` utility to rsync module.


### PR DESCRIPTION
The Term could be updated by log entries that are never passed to the FSM layer.