### PR TITLE
expose default prometheus metrics endpoint via golang library

### DIFF
--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/Bowery/prompt"
 	"github.com/mkideal/cli"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	clix "github.com/mkideal/cli/ext"
 	"github.com/rqlite/rqlite/v8/cmd"
 	"github.com/rqlite/rqlite/v8/cmd/rqlite/history"

--- a/cmd/rqlite/main.go
+++ b/cmd/rqlite/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Bowery/prompt"
 	"github.com/mkideal/cli"
+    "github.com/prometheus/client_golang/prometheus/promhttp"
 	clix "github.com/mkideal/cli/ext"
 	"github.com/rqlite/rqlite/v8/cmd"
 	"github.com/rqlite/rqlite/v8/cmd/rqlite/history"
@@ -80,6 +81,12 @@ func init() {
 }
 
 func main() {
+    // Expose the default metrics for Go applications via http://localhost:9090/metrics
+    http.Handle("/metrics", promhttp.Handler())
+
+    // Start the HTTP server on port 9090
+    http.ListenAndServe(":9090", nil)
+
 	cli.SetUsageStyle(cli.ManualStyle)
 	cli.Run(new(argT), func(ctx *cli.Context) error {
 		argv := ctx.Argv().(*argT)


### PR DESCRIPTION
I cannot test but I believe this might try to add a metrics endpoint and expose default values. 
- https://prometheus.io/docs/guides/go-application/#how-go-exposition-works

We should be able to expand out further with custom metrics beyond defaults.
- https://prometheus.io/docs/guides/go-application/#adding-your-own-metrics