### PR TITLE
Simplify tests by using t.TempDir instead of os.MkdirTemp

### DIFF
--- a/command/chunking/chunk_dechunk_test.go
+++ b/command/chunking/chunk_dechunk_test.go
@@ -15,13 +15,7 @@ func Test_ChunkingRoundTrip(t *testing.T) {
 
 	chunker := NewChunker(bytes.NewReader(data), 1024)
 
-	dir, err := os.MkdirTemp("", "test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.Remove(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}

--- a/command/chunking/dechunker_test.go
+++ b/command/chunking/dechunker_test.go
@@ -21,13 +21,7 @@ func Test_SingleChunk(t *testing.T) {
 		Data:        mustCompressData(data),
 	}
 
-	dir, err := os.MkdirTemp("", "dechunker-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
@@ -71,13 +65,7 @@ func Test_MultiChunk(t *testing.T) {
 		Data:        mustCompressData(data2),
 	}
 
-	dir, err := os.MkdirTemp("", "dechunker-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
@@ -129,13 +117,7 @@ func Test_MultiChunkNilData(t *testing.T) {
 		Data:        nil,
 	}
 
-	dir, err := os.MkdirTemp("", "dechunker-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
@@ -183,13 +165,7 @@ func Test_UnexpectedStreamID(t *testing.T) {
 		Data:        compressedData,
 	}
 
-	dir, err := os.MkdirTemp("", "dechunker-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
@@ -227,13 +203,7 @@ func Test_ChunksOutOfOrder(t *testing.T) {
 		Data:        compressedData,
 	}
 
-	dir, err := os.MkdirTemp("", "dechunker-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	dechunker, err := NewDechunker(dir)
+	dechunker, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
@@ -255,16 +225,10 @@ func Test_ChunksOutOfOrder(t *testing.T) {
 }
 
 func Test_ReassemblyOfLargeData(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-
-	d, err := NewDechunker(dir)
+	d, err := NewDechunker(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
-	defer os.Remove(dir)
 
 	// Create a large random dataset.
 	largeData := make([]byte, 2*1024*1024) // 2 MB of data.

--- a/command/chunking/dechunker_test.go
+++ b/command/chunking/dechunker_test.go
@@ -169,6 +169,7 @@ func Test_UnexpectedStreamID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
+	defer dechunker.Close()
 
 	_, err = dechunker.WriteChunk(chunk1)
 	if err != nil {
@@ -207,6 +208,7 @@ func Test_ChunksOutOfOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create Dechunker: %v", err)
 	}
+	defer dechunker.Close()
 
 	// Write the first chunk to the Dechunker.
 	_, err = dechunker.WriteChunk(chunk1)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1444,14 +1444,6 @@ func mustTempFile() string {
 	return tmpfile.Name()
 }
 
-func mustTempDir() string {
-	tmpdir, err := os.MkdirTemp("", "rqlite-db-test")
-	if err != nil {
-		panic(err.Error())
-	}
-	return tmpdir
-}
-
 // function which copies a src file to a dst file, panics if any error
 func mustCopyFile(dst, src string) {
 	srcFile, err := os.Open(src)

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -593,8 +593,7 @@ func Test_WALReplayOK(t *testing.T) {
 		walPath := dbPath + "-wal"
 		walFile := filepath.Base(walPath)
 
-		replayDir := mustTempDir()
-		defer os.RemoveAll(replayDir)
+		replayDir := t.TempDir()
 		replayDBPath := filepath.Join(replayDir, dbFile)
 
 		// Create and copy the SQLite file and WAL #1
@@ -838,10 +837,8 @@ func Test_WALReplayOK_Complex(t *testing.T) {
 }
 
 func Test_WALReplayFailures(t *testing.T) {
-	dbDir := mustTempDir()
-	defer os.RemoveAll(dbDir)
-	walDir := mustTempDir()
-	defer os.RemoveAll(walDir)
+	dbDir := t.TempDir()
+	walDir := t.TempDir()
 
 	err := ReplayWAL(filepath.Join(dbDir, "foo.db"), []string{filepath.Join(walDir, "foo.db-wal")}, false)
 	if err != ErrWALReplayDirectoryMismatch {

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -667,6 +667,7 @@ func Test_WALReplayOK(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to open replayed database: %s", err.Error())
 		}
+		defer replayedDB.Close()
 		rows, err := replayedDB.QueryStringStmt("SELECT * FROM foo")
 		if err != nil {
 			t.Fatalf("failed to query WAL table: %s", err.Error())

--- a/rarchive/targz_test.go
+++ b/rarchive/targz_test.go
@@ -73,8 +73,7 @@ func TestUntarGzipToDir(t *testing.T) {
 	defer os.Remove(tarGzipFile)
 
 	// Create a directory to extract to
-	extractDir := "extracted_files"
-	defer os.RemoveAll(extractDir)
+	extractDir := t.TempDir()
 
 	err := UntarGzipToDir(tarGzipFile, extractDir)
 	if err != nil {

--- a/rarchive/zip_test.go
+++ b/rarchive/zip_test.go
@@ -58,11 +58,7 @@ func Test_UnzipToDir(t *testing.T) {
 	mustWriteBytesToFile(zipFileName, zipData)
 
 	// Create a temporary directory for unzipping
-	outputDir, err := os.MkdirTemp("", "unzip_test")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(outputDir)
+	outputDir := t.TempDir()
 
 	// Unzip the file to the directory
 	err = UnzipToDir(zipFileName, outputDir)
@@ -85,14 +81,10 @@ func Test_UnzipToDir(t *testing.T) {
 
 func Test_UnzipToDir_InvalidZip(t *testing.T) {
 	// Create a temporary directory for unzipping
-	outputDir, err := os.MkdirTemp("", "unzip_test")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(outputDir)
+	outputDir := t.TempDir()
 
 	// Try to unzip a non-zip file
-	err = UnzipToDir("non_existent.zip", outputDir)
+	err := UnzipToDir("non_existent.zip", outputDir)
 	if err == nil {
 		t.Fatalf("Expected error when unzipping a non-existent file, got nil")
 	}


### PR DESCRIPTION
The PR refactors tests that contain `os.MkdirTemp` with [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir):

> TempDir returns a temporary directory for the test to use. The directory is automatically removed when the test and all its subtests complete.

This PR removes 60 lines of test code without harming readability.

---
*I came to the repo after reading [this article](https://philipotoole.com/how-is-rqlite-tested/)*.