### PR TITLE
Simplify tests by using t.Setenv instead of os.Setenv

### DIFF
--- a/auto/backup/config_test.go
+++ b/auto/backup/config_test.go
@@ -45,10 +45,7 @@ func Test_ReadConfigFile(t *testing.T) {
 
 	t.Run("file with environment variables", func(t *testing.T) {
 		// Set an environment variable
-		if err := os.Setenv("TEST_VAR", "test_value"); err != nil {
-			t.Fatal(err)
-		}
-		defer os.Unsetenv("TEST_VAR")
+		t.Setenv("TEST_VAR", "test_value")
 
 		// Create a temporary config file with an environment variable
 		tempFile, err := os.CreateTemp("", "upload_config")
@@ -75,10 +72,7 @@ func Test_ReadConfigFile(t *testing.T) {
 
 	t.Run("longer file with environment variables", func(t *testing.T) {
 		// Set an environment variable
-		if err := os.Setenv("TEST_VAR1", "test_value"); err != nil {
-			t.Fatal(err)
-		}
-		defer os.Unsetenv("TEST_VAR1")
+		t.Setenv("TEST_VAR1", "test_value")
 
 		// Create a temporary config file with an environment variable
 		tempFile, err := os.CreateTemp("", "upload_config")

--- a/auto/restore/config_test.go
+++ b/auto/restore/config_test.go
@@ -45,10 +45,7 @@ func Test_ReadConfigFile(t *testing.T) {
 
 	t.Run("file with environment variables", func(t *testing.T) {
 		// Set an environment variable
-		if err := os.Setenv("TEST_VAR", "test_value"); err != nil {
-			t.Fatal(err)
-		}
-		defer os.Unsetenv("TEST_VAR")
+		t.Setenv("TEST_VAR", "test_value")
 
 		// Create a temporary config file with an environment variable
 		tempFile, err := os.CreateTemp("", "upload_config")
@@ -75,10 +72,7 @@ func Test_ReadConfigFile(t *testing.T) {
 
 	t.Run("longer file with environment variables", func(t *testing.T) {
 		// Set an environment variable
-		if err := os.Setenv("TEST_VAR1", "test_value"); err != nil {
-			t.Fatal(err)
-		}
-		defer os.Unsetenv("TEST_VAR1")
+		t.Setenv("TEST_VAR1", "test_value")
 
 		// Create a temporary config file with an environment variable
 		tempFile, err := os.CreateTemp("", "upload_config")


### PR DESCRIPTION
The PR refactors tests by changing to use https://pkg.go.dev/testing#T.Setenv instead of `os.Setenv`:

> Setenv calls os.Setenv(key, value) and uses Cleanup to restore the environment variable to its original value after the test.