### PR TITLE
Simplify random package with math/rand/v2

### DIFF
--- a/command/sql/processor.go
+++ b/command/sql/processor.go
@@ -4,7 +4,7 @@ import (
 	"expvar"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"time"
@@ -128,10 +128,8 @@ func NewRewriter() *Rewriter {
 		RewriteRand: true,
 		RewriteTime: true,
 
-		randFn: func() int64 {
-			return rand.Int63()
-		},
-		nowFn: time.Now,
+		randFn: rand.Int64,
+		nowFn:  time.Now,
 	}
 }
 

--- a/command/sql/processor_bench_test.go
+++ b/command/sql/processor_bench_test.go
@@ -5,31 +5,19 @@
 package sql
 
 import (
-	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
-)
 
-// Generate a random 100-character string
-func generateRandomString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	seed := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(seed)
-	result := make([]byte, length)
-	for i := range result {
-		result[i] = charset[r.Intn(len(charset))]
-	}
-	return string(result)
-}
+	"github.com/rqlite/rqlite/v8/random"
+)
 
 // Benchmark using strings.Contains
 func BenchmarkContains(b *testing.B) {
 	// The set of strings to search for
 	keywords := []string{"date", "time", "julianday", "unixepoch", "random", "returning"}
 	// Generate a random string
-	text := generateRandomString(100)
+	text := random.StringN(100)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -46,7 +34,7 @@ func BenchmarkRegex(b *testing.B) {
 	pattern := `(?i)date|time|julianday|unixepoch|random|returning`
 	regex := regexp.MustCompile(pattern)
 	// Generate a random string
-	text := generateRandomString(100)
+	text := random.StringN(100)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/db/db_common_test.go
+++ b/db/db_common_test.go
@@ -2,18 +2,18 @@ package db
 
 import (
 	"errors"
+	"math/rand/v2"
 	"os"
 	"strings"
 	"testing"
 
 	command "github.com/rqlite/rqlite/v8/command/proto"
-	"github.com/rqlite/rqlite/v8/random"
 	"github.com/rqlite/rqlite/v8/testdata/chinook"
 )
 
 func testBusyTimeout(t *testing.T, db *DB) {
-	wantRw := random.Intn(10000)
-	wantRo := random.Intn(10000)
+	wantRw := rand.N(10000)
+	wantRo := rand.N(10000)
 
 	err := db.SetBusyTimeout(wantRw, wantRo)
 	if err != nil {

--- a/random/random.go
+++ b/random/random.go
@@ -1,78 +1,55 @@
 package random
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"strings"
-	"sync"
 	"time"
 )
 
-var r *rand.Rand
-var mu sync.Mutex
+const srcChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-const (
-	srcChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-)
-
-func init() {
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+// String returns a random string of n characters long.
+func StringN(n int) string {
+	var output strings.Builder
+	output.Grow(n)
+	for range n {
+		random := rand.N(len(srcChars))
+		output.WriteByte(srcChars[random])
+	}
+	return output.String()
 }
 
 // String returns a random string, 20 characters long.
 func String() string {
-	mu.Lock()
-	defer mu.Unlock()
-	var output strings.Builder
-	for i := 0; i < 20; i++ {
-		random := r.Intn(len(srcChars))
-		output.WriteString(string(srcChars[random]))
-	}
-	return output.String()
+	return StringN(20)
 }
 
 // StringPattern returns a random string, with all occurrences of 'X' or 'x'
 // replaced with a random character.
 func StringPattern(s string) string {
-	mu.Lock()
-	defer mu.Unlock()
 	var output strings.Builder
+	output.Grow(len(s))
 	for _, c := range s {
 		if c == 'X' || c == 'x' {
-			random := r.Intn(len(srcChars))
-			output.WriteString(string(srcChars[random]))
+			random := rand.N(len(srcChars))
+			output.WriteByte(srcChars[random])
 		} else {
-			output.WriteString(string(c))
+			output.WriteRune(c)
 		}
 	}
 	return output.String()
 }
 
-// Float64 returns a random float64 between 0 and 1.
-func Float64() float64 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Float64()
-}
-
-// Intn returns a random int >=0 and < n.
-func Intn(n int) int {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Intn(n)
-}
-
 // Bytes returns a random slice of bytes, n bytes long.
 func Bytes(n int) []byte {
-	mu.Lock()
-	defer mu.Unlock()
 	b := make([]byte, n)
-	r.Read(b)
+	for i := range b {
+		b[i] = byte(rand.N(256))
+	}
 	return b
 }
 
 // Jitter returns a randomly-chosen duration between d and 2d.
 func Jitter(d time.Duration) time.Duration {
-	mu.Lock()
-	defer mu.Unlock()
-	return d + time.Duration(r.Float64()*float64(d))
+	return d + rand.N(d)
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -6,6 +6,26 @@ import (
 	"time"
 )
 
+func Test_StringNLength(t *testing.T) {
+	str := StringN(10)
+	if exp, got := 10, len(str); exp != got {
+		t.Errorf("String() returned a string of length %d; want %d", got, exp)
+	}
+}
+
+func Test_StringNUniqueness(t *testing.T) {
+	const numStrings = 100
+	strs := make(map[string]bool, numStrings)
+
+	for i := 0; i < numStrings; i++ {
+		str := StringN(50)
+		if strs[str] {
+			t.Errorf("StringN() returned a non-unique string: %s", str)
+		}
+		strs[str] = true
+	}
+}
+
 func Test_StringLength(t *testing.T) {
 	str := String()
 	if exp, got := 20, len(str); exp != got {
@@ -26,6 +46,19 @@ func Test_StringUniqueness(t *testing.T) {
 	}
 }
 
+func Test_StringPatternReplacement(t *testing.T) {
+	str := StringPattern("xxx-⌘-XXX-⌘")
+	if strings.Contains(str, "xxx-") {
+		t.Errorf("StringPattern() did not replace the lowercased 'x' with a random character: %q", str)
+	}
+	if strings.Contains(str, "-XXX-") {
+		t.Errorf("StringPattern() did not replace the uppercased 'XXX' with a random character: %q", str)
+	}
+	if strings.Count(str, "-⌘") != 2 {
+		t.Errorf("StringPattern() didn't work with runes: %q", str)
+	}
+}
+
 func Test_StringPatternUniqueness(t *testing.T) {
 	const numStrings = 100
 	strs := make(map[string]bool, numStrings)
@@ -42,29 +75,15 @@ func Test_StringPatternUniqueness(t *testing.T) {
 	}
 }
 
-func Test_Float64Uniqueness(t *testing.T) {
-	const numFloat64s = 100
-	floats := make(map[float64]bool, numFloat64s)
-
-	for i := 0; i < numFloat64s; i++ {
-		f := Float64()
-		if floats[f] {
-			t.Errorf("Float64() returned a non-unique float64: %f", f)
-		}
-		floats[f] = true
+func Test_BytesLength(t *testing.T) {
+	bytes := Bytes(0)
+	if exp := len(bytes); exp != 0 {
+		t.Errorf("Bytes() returned a byte slice of non-zero length %q", bytes)
 	}
-}
 
-func Test_IntnUniqueness(t *testing.T) {
-	const numIntns = 100
-	intns := make(map[int]bool, numIntns)
-
-	for i := 0; i < numIntns; i++ {
-		n := Intn(1000000000)
-		if intns[n] {
-			t.Errorf("Intn() returned a non-unique int: %d", n)
-		}
-		intns[n] = true
+	bytes = Bytes(10)
+	if exp, got := 10, len(bytes); exp != got {
+		t.Errorf("Bytes() returned a byte slice of length %q; want %d", bytes, exp)
 	}
 }
 

--- a/tcp/pool/channel_test.go
+++ b/tcp/pool/channel_test.go
@@ -2,12 +2,11 @@ package pool
 
 import (
 	"log"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/rqlite/rqlite/v8/random"
 )
 
 var (
@@ -204,7 +203,7 @@ func TestPoolConcurrent2(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			go func(i int) {
 				conn, _ := p.Get()
-				time.Sleep(time.Millisecond * time.Duration(random.Intn(100)))
+				time.Sleep(rand.N(100 * time.Millisecond))
 				conn.Close()
 				wg.Done()
 			}(i)
@@ -215,7 +214,7 @@ func TestPoolConcurrent2(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			conn, _ := p.Get()
-			time.Sleep(time.Millisecond * time.Duration(random.Intn(100)))
+			time.Sleep(rand.N(100 * time.Millisecond))
 			conn.Close()
 			wg.Done()
 		}(i)


### PR DESCRIPTION
This PR refactors code to use [`math/rand/v2`](https://go.dev/blog/randv2) instead of [`math/rand`](https://pkg.go.dev/math/rand).

Changes:

- Replace all imports `math/rand` with `math/rand/v2`.
- Simplify the `random` package implementation by removing the now unnecessary mutex and seed. See [this explanation](https://go.dev/blog/randv2#:~:text=Having%20eliminated%20repeatability,Go%201%20generator).
- Add `random.StringN`. Use it inside the `random.String` implementation and instead of `generateRandomString`.
- Replace `random.Intn` with `rand.N`.
- Remove unused `random.Float64`. It can be replaced with `rand.Float64`.
- Replace `time.Sleep(time.Millisecond * time.Duration(random.Intn(100)))` with `time.Sleep(rand.N(100 * time.Millisecond))` as the blog post [suggests](https://go.dev/blog/randv2#:~:text=d%20%3A%3D%20time.Duration(rand.Int63n(int64(5*time.Second)))).
- Extend tests for the `random` package. Now it covers runes.
