### PR TITLE
Add logger interface to allow usage of custom loggers.

### DIFF
--- a/auto/backup/uploader.go
+++ b/auto/backup/uploader.go
@@ -5,13 +5,13 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/rqlite/rqlite/v8/db/humanize"
 	"github.com/rqlite/rqlite/v8/internal/progress"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // StorageClient is an interface for uploading data to a storage service.
@@ -77,7 +77,7 @@ type Uploader struct {
 	dataProvider  DataProvider
 	interval      time.Duration
 
-	logger             *log.Logger
+	logger             rqlog.Logger
 	lastUploadTime     time.Time
 	lastUploadDuration time.Duration
 
@@ -90,7 +90,7 @@ func NewUploader(storageClient StorageClient, dataProvider DataProvider, interva
 		storageClient: storageClient,
 		dataProvider:  dataProvider,
 		interval:      interval,
-		logger:        log.New(os.Stderr, "[uploader] ", log.LstdFlags),
+		logger:        rqlog.Default().WithName("[uploader] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/auto/restore/downloader.go
+++ b/auto/restore/downloader.go
@@ -7,9 +7,10 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"time"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // stats captures stats for the Uploader service.
@@ -88,14 +89,14 @@ type StorageClient interface {
 // Downloader is a struct that handles downloading data from a storage service.
 type Downloader struct {
 	storageClient StorageClient
-	logger        *log.Logger
+	logger        rqlog.Logger
 }
 
 // NewDownloader creates a new Downloader instance with the given StorageClient.
 func NewDownloader(storageClient StorageClient) *Downloader {
 	return &Downloader{
 		storageClient: storageClient,
-		logger:        log.New(os.Stderr, "[downloader] ", log.LstdFlags),
+		logger:        rqlog.Default().WithName("[downloader] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/cdc/service.go
+++ b/cdc/service.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"expvar"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/rqlite/rqlite/v8/command/proto"
 	"github.com/rqlite/rqlite/v8/internal/rsync"
 	"github.com/rqlite/rqlite/v8/queue"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -146,7 +146,7 @@ type Service struct {
 	wg   sync.WaitGroup
 	done chan struct{}
 
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // NewService creates a new CDC service.
@@ -179,7 +179,7 @@ func NewService(dir string, clstr Cluster, str Store, in <-chan *proto.CDCEvents
 		leaderObCh:            make(chan bool, leaderChanLen),
 		hwmObCh:               make(chan uint64, leaderChanLen),
 		done:                  make(chan struct{}),
-		logger:                log.New(os.Stdout, "[cdc-service] ", log.LstdFlags),
+		logger:                rqlog.Default().WithName("[cdc-service] ").WithOutput(os.Stdout),
 	}
 
 	fifo, err := NewQueue(filepath.Join(dir, cdcDB))

--- a/cluster/bootstrap.go
+++ b/cluster/bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/rqlite/rqlite/v8/cluster/proto"
 	command "github.com/rqlite/rqlite/v8/command/proto"
 	"github.com/rqlite/rqlite/v8/internal/random"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 var (
@@ -118,7 +118,7 @@ type Bootstrapper struct {
 	client *Client
 	creds  *proto.Credentials
 
-	logger   *log.Logger
+	logger   rqlog.Logger
 	Interval time.Duration
 
 	bootStatusMu sync.RWMutex
@@ -133,7 +133,7 @@ func NewBootstrapper(p AddressProvider, client *Client) *Bootstrapper {
 	bs := &Bootstrapper{
 		provider: p,
 		client:   client,
-		logger:   log.New(os.Stderr, "[cluster-bootstrap] ", log.LstdFlags),
+		logger:   rqlog.Default().WithName("[cluster-bootstrap] ").WithOutput(os.Stderr),
 		Interval: bootCheckInterval,
 	}
 	return bs

--- a/cluster/disco/service.go
+++ b/cluster/disco/service.go
@@ -2,12 +2,12 @@ package disco
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/rqlite/rqlite/v8/internal/random"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -73,7 +73,7 @@ type Service struct {
 	s   Store
 	suf Suffrage
 
-	logger *log.Logger
+	logger rqlog.Logger
 
 	mu          sync.Mutex
 	lastContact time.Time
@@ -87,7 +87,7 @@ func NewService(c Client, s Store, suf Suffrage) *Service {
 		suf:              suf,
 		RegisterInterval: 3 * time.Second,
 		ReportInterval:   10 * time.Second,
-		logger:           log.New(os.Stderr, "[disco] ", log.LstdFlags),
+		logger:           rqlog.Default().WithName("[disco] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/cluster/join.go
+++ b/cluster/join.go
@@ -3,12 +3,12 @@ package cluster
 import (
 	"context"
 	"errors"
-	"log"
 	"os"
 	"time"
 
 	"github.com/rqlite/rqlite/v8/cluster/proto"
 	command "github.com/rqlite/rqlite/v8/command/proto"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 var (
@@ -32,7 +32,7 @@ type Joiner struct {
 
 	client *Client
 	creds  *proto.Credentials
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // NewJoiner returns an instantiated Joiner.
@@ -41,7 +41,7 @@ func NewJoiner(client *Client, numAttempts int, attemptInterval time.Duration) *
 		client:          client,
 		numAttempts:     numAttempts,
 		attemptInterval: attemptInterval,
-		logger:          log.New(os.Stderr, "[cluster-join] ", log.LstdFlags),
+		logger:          rqlog.Default().WithName("[cluster-join] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/cluster/remove.go
+++ b/cluster/remove.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"log"
 	"os"
 	"time"
 
 	"github.com/rqlite/rqlite/v8/cluster/proto"
 	command "github.com/rqlite/rqlite/v8/command/proto"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -27,7 +27,7 @@ type Remover struct {
 	client  *Client
 	creds   *proto.Credentials
 
-	log *log.Logger
+	log rqlog.Logger
 }
 
 // / NewRemover returns an instantiated Remover.
@@ -36,7 +36,7 @@ func NewRemover(client *Client, timeout time.Duration, control Control) *Remover
 		client:  client,
 		timeout: timeout,
 		control: control,
-		log:     log.New(os.Stderr, "[cluster-remove] ", log.LstdFlags),
+		log:     rqlog.Default().WithName("[cluster-remove] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -7,7 +7,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strconv"
@@ -17,6 +16,7 @@ import (
 	"github.com/rqlite/rqlite/v8/auth"
 	"github.com/rqlite/rqlite/v8/cluster/proto"
 	command "github.com/rqlite/rqlite/v8/command/proto"
+	"github.com/rqlite/rqlite/v8/rqlog"
 	pb "google.golang.org/protobuf/proto"
 )
 
@@ -150,7 +150,7 @@ type Service struct {
 	apiAddr string // host:port this node serves the HTTP API.
 	version string // Version of software this node is running.
 
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // New returns a new instance of the cluster service
@@ -160,7 +160,7 @@ func New(ln net.Listener, db Database, m Manager, credentialStore CredentialStor
 		addr:            ln.Addr(),
 		db:              db,
 		mgr:             m,
-		logger:          log.New(os.Stderr, "[cluster] ", log.LstdFlags),
+		logger:          rqlog.Default().WithName("[cluster] ").WithOutput(os.Stderr),
 		credentialStore: credentialStore,
 	}
 }

--- a/cmd/rqlite/http/client.go
+++ b/cmd/rqlite/http/client.go
@@ -3,11 +3,12 @@ package http
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // ErrNoAvailableHost indicates that the client could not find an available host to send the request to.
@@ -47,7 +48,7 @@ type Client struct {
 
 	// creds stores the http basic authentication username and password
 	creds  string
-	logger *log.Logger
+	logger rqlog.Logger
 
 	// currentHost keeps track of the last available host
 	currentHost int
@@ -63,7 +64,7 @@ func NewClient(client *http.Client, hosts []string, configFuncs ...ConfigFunc) *
 		scheme:      "http",
 		maxRedirect: 21,
 		Prefix:      "/",
-		logger:      log.New(os.Stderr, "[client] ", log.LstdFlags),
+		logger:      rqlog.Default().WithName("[client] ").WithOutput(os.Stderr),
 	}
 
 	for _, f := range configFuncs {
@@ -89,7 +90,7 @@ func WithPrefix(prefix string) ConfigFunc {
 }
 
 // WithLogger changes the default logger to the one provided.
-func WithLogger(logger *log.Logger) ConfigFunc {
+func WithLogger(logger rqlog.Logger) ConfigFunc {
 	return func(client *Client) {
 		client.logger = logger
 	}

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -29,6 +29,7 @@ import (
 	httpd "github.com/rqlite/rqlite/v8/http"
 	"github.com/rqlite/rqlite/v8/internal/rarchive"
 	"github.com/rqlite/rqlite/v8/internal/rtls"
+	"github.com/rqlite/rqlite/v8/rqlog"
 	"github.com/rqlite/rqlite/v8/store"
 	"github.com/rqlite/rqlite/v8/tcp"
 )
@@ -55,6 +56,11 @@ func init() {
 	log.SetFlags(log.LstdFlags)
 	log.SetOutput(os.Stderr)
 	log.SetPrefix(fmt.Sprintf("[%s] ", name))
+	rqlog.SetDefault(rqlog.NewRqLogger(
+		log.Default().Writer(),
+		log.Default().Prefix(),
+		log.Default().Flags(),
+	))
 }
 
 func main() {

--- a/cmd/rqlited/profile.go
+++ b/cmd/rqlited/profile.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"log"
 	"os"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // prof stores the file locations of active profiles.
@@ -17,6 +18,7 @@ var prof struct {
 
 // startProfile starts any requested profiling.
 func startProfile(cpuprofile, memprofile, traceprofile string) {
+	log := rqlog.Default()
 	if cpuprofile != "" {
 		f, err := os.Create(cpuprofile)
 		if err != nil {
@@ -54,6 +56,7 @@ func startProfile(cpuprofile, memprofile, traceprofile string) {
 
 // stopProfile stops any active profiling.
 func stopProfile() {
+	log := rqlog.Default()
 	if prof.cpu != nil {
 		pprof.StopCPUProfile()
 		if err := prof.cpu.Close(); err != nil {

--- a/cmd/rqlited/signals.go
+++ b/cmd/rqlited/signals.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/signal"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -19,7 +20,7 @@ func HandleSignals(sigs ...os.Signal) <-chan os.Signal {
 		signal.Notify(sigCh, sigs...)
 		for {
 			sig := <-sigCh
-			log.Printf(`received signal "%s"`, sig.String())
+			rqlog.Default().Printf(`received signal "%s"`, sig.String())
 			ch <- sig
 		}
 	}()

--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ import (
 	command "github.com/rqlite/rqlite/v8/command/proto"
 	"github.com/rqlite/rqlite/v8/db/humanize"
 	"github.com/rqlite/rqlite/v8/internal/rsum"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -148,7 +149,7 @@ type DB struct {
 	allOptimized   bool
 	allOptimizedMu sync.Mutex
 
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // PoolStats represents connection pool statistics
@@ -174,7 +175,7 @@ func Open(dbPath string, fkEnabled, wal bool) (retDB *DB, retErr error) {
 // database is opened in WAL mode, the WAL files will also be created if they
 // do not exist.
 func OpenWithDriver(drv *Driver, dbPath string, fkEnabled, wal bool) (retDB *DB, retErr error) {
-	logger := log.New(log.Writer(), "[db] ", log.LstdFlags)
+	logger := rqlog.Default().WithName("[db] ").WithOutput(log.Writer())
 	startTime := time.Now()
 	defer func() {
 		if retErr != nil {

--- a/http/service.go
+++ b/http/service.go
@@ -10,7 +10,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -29,6 +28,7 @@ import (
 	"github.com/rqlite/rqlite/v8/db"
 	"github.com/rqlite/rqlite/v8/internal/rtls"
 	"github.com/rqlite/rqlite/v8/queue"
+	"github.com/rqlite/rqlite/v8/rqlog"
 	"github.com/rqlite/rqlite/v8/store"
 )
 
@@ -364,7 +364,7 @@ type Service struct {
 
 	BuildInfo map[string]any
 
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // New returns an uninitialized HTTP service. If credentials is nil, then
@@ -380,7 +380,7 @@ func New(addr string, store Store, cluster Cluster, credentials CredentialStore)
 		start:               time.Now(),
 		statuses:            make(map[string]StatusReporter),
 		credentialStore:     credentials,
-		logger:              log.New(os.Stderr, "[http] ", log.LstdFlags),
+		logger:              rqlog.Default().WithName("[http] ").WithOutput(os.Stderr),
 	}
 }
 

--- a/internal/rtls/reloader.go
+++ b/internal/rtls/reloader.go
@@ -2,10 +2,11 @@ package rtls
 
 import (
 	"crypto/tls"
-	"log"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // CertReloader is a simple TLS certificate reloader. It loads the certificate
@@ -14,7 +15,7 @@ import (
 type CertReloader struct {
 	certPath, keyPath string
 	modTime           time.Time
-	logger            *log.Logger
+	logger            rqlog.Logger
 
 	mu   sync.RWMutex
 	cert *tls.Certificate
@@ -25,7 +26,7 @@ func NewCertReloader(cert, key string) (*CertReloader, error) {
 	cr := &CertReloader{
 		certPath: cert,
 		keyPath:  key,
-		logger:   log.New(os.Stderr, "[cert-reloader] ", log.LstdFlags),
+		logger:   rqlog.Default().WithName("[cert-reloader] ").WithOutput(os.Stderr),
 	}
 	pair, err := loadKeyPair(cr.certPath, cr.keyPath)
 	if err != nil {

--- a/rqlog/rqlog.go
+++ b/rqlog/rqlog.go
@@ -1,0 +1,40 @@
+package rqlog
+
+import (
+	"io"
+	"log"
+	"sync"
+)
+
+type Logger interface {
+	Print(v ...any)
+	Printf(format string, v ...any)
+	Println(v ...any)
+	Fatal(v ...any)
+	Fatalf(format string, v ...any)
+	Fatalln(v ...any)
+	Prefix() string
+	SetPrefix(prefix string)
+
+	StandardLogger() *log.Logger
+	WithName(name string) Logger
+	WithOutput(output io.Writer) Logger
+}
+
+var (
+	syncOnce sync.Once
+	def      Logger
+)
+
+func SetDefault(logger Logger) {
+	def = logger
+}
+
+func Default() Logger {
+	syncOnce.Do(func() {
+		if def == nil {
+			def = NewRqLogger(log.Default().Writer(), log.Default().Prefix(), log.Default().Flags())
+		}
+	})
+	return def
+}

--- a/rqlog/std_log.go
+++ b/rqlog/std_log.go
@@ -1,0 +1,64 @@
+package rqlog
+
+import (
+	"io"
+	"log"
+)
+
+type RqLogger struct {
+	stdLog *log.Logger
+}
+
+func NewRqLogger(out io.Writer, prefix string, flag int) *RqLogger {
+	return &RqLogger{
+		stdLog: log.New(out, prefix, flag),
+	}
+}
+
+func (l *RqLogger) Print(v ...any) {
+	l.stdLog.Print(v...)
+}
+
+func (l *RqLogger) Printf(format string, v ...any) {
+	l.stdLog.Printf(format, v...)
+}
+
+func (l *RqLogger) Println(v ...any) {
+	l.stdLog.Println(v...)
+}
+
+func (l *RqLogger) Fatal(v ...any) {
+	l.stdLog.Fatal(v...)
+}
+
+func (l *RqLogger) Fatalf(format string, v ...any) {
+	l.stdLog.Fatalf(format, v...)
+}
+
+func (l *RqLogger) Fatalln(v ...any) {
+	l.stdLog.Fatalln(v...)
+}
+
+func (l *RqLogger) Prefix() string {
+	return l.stdLog.Prefix()
+}
+
+func (l *RqLogger) SetPrefix(prefix string) {
+	l.stdLog.SetPrefix(prefix)
+}
+
+func (l *RqLogger) StandardLogger() *log.Logger {
+	return l.stdLog
+}
+
+func (l *RqLogger) WithName(name string) Logger {
+	return &RqLogger{
+		stdLog: log.New(l.stdLog.Writer(), name, l.stdLog.Flags()),
+	}
+}
+
+func (l *RqLogger) WithOutput(output io.Writer) Logger {
+	return &RqLogger{
+		stdLog: log.New(output, l.stdLog.Prefix(), l.stdLog.Flags()),
+	}
+}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -8,19 +8,20 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/rqlite/rqlite/v8/internal/progress"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // Snapshot represents a snapshot of the database state.
 type Snapshot struct {
 	rc     io.ReadCloser
-	logger *log.Logger
+	logger rqlog.Logger
 }
 
 // NewSnapshot creates a new snapshot.
 func NewSnapshot(rc io.ReadCloser) *Snapshot {
 	return &Snapshot{
 		rc:     rc,
-		logger: log.New(log.Writer(), "[snapshot] ", log.LstdFlags),
+		logger: rqlog.Default().WithName("[snapshot] ").WithOutput(log.Writer()),
 	}
 }
 

--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -5,7 +5,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/rqlite/rqlite/v8/db"
 	"github.com/rqlite/rqlite/v8/internal/rsync"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -131,7 +131,7 @@ func (l *LockingSnapshot) Close() error {
 type Store struct {
 	dir            string
 	fullNeededPath string
-	logger         *log.Logger
+	logger         rqlog.Logger
 
 	mrsw *rsync.MultiRSW
 
@@ -148,7 +148,7 @@ func NewStore(dir string) (*Store, error) {
 	str := &Store{
 		dir:            dir,
 		fullNeededPath: filepath.Join(dir, fullNeededFile),
-		logger:         log.New(os.Stderr, "[snapshot-store] ", log.LstdFlags),
+		logger:         rqlog.Default().WithName("[snapshot-store] ").WithOutput(os.Stderr),
 		mrsw:           rsync.NewMultiRSW(),
 	}
 	str.logger.Printf("store initialized using %s", dir)

--- a/snapshot/upgrader.go
+++ b/snapshot/upgrader.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/hashicorp/raft"
 	"github.com/rqlite/rqlite/v8/db"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 // Upgrade writes a copy of the 7.x-format Snapshot directory at 'old' to a
 // 8.x-format new Snapshot directory at 'new'. If the upgrade is successful,
 // the 'old' directory is removed before the function returns.
-func Upgrade7To8(old, new string, logger *log.Logger) (retErr error) {
+func Upgrade7To8(old, new string, logger rqlog.Logger) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			stats.Add(upgradeFail, 1)

--- a/snapshot/upgrader_test.go
+++ b/snapshot/upgrader_test.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 func Test_Upgrade_NothingToDo(t *testing.T) {
-	logger := log.New(os.Stderr, "[snapshot-store-upgrader] ", 0)
+	logger := rqlog.NewRqLogger(os.Stderr, "[snapshot-store-upgrader] ", 0)
 	if err := Upgrade7To8("/does/not/exist", "/does/not/exist/either", logger); err != nil {
 		t.Fatalf("failed to upgrade nonexistent directories: %s", err)
 	}
@@ -24,7 +25,7 @@ func Test_Upgrade_NothingToDo(t *testing.T) {
 }
 
 func Test_Upgrade_OK(t *testing.T) {
-	logger := log.New(os.Stderr, "[snapshot-store-upgrader] ", 0)
+	logger := rqlog.NewRqLogger(os.Stderr, "[snapshot-store-upgrader] ", 0)
 	v7Snapshot := "testdata/upgrade/v7.20.3-snapshots"
 	v7SnapshotID := "2-18-1686659761026"
 	oldTemp := filepath.Join(t.TempDir(), "snapshots")
@@ -67,7 +68,7 @@ func Test_Upgrade_OK(t *testing.T) {
 }
 
 func Test_Upgrade_EmptyOK(t *testing.T) {
-	logger := log.New(os.Stderr, "[snapshot-store-upgrader] ", 0)
+	logger := rqlog.NewRqLogger(os.Stderr, "[snapshot-store-upgrader] ", 0)
 	v7Snapshot := "testdata/upgrade/v7.20.3-empty-snapshots"
 	v7SnapshotID := "2-18-1686659761026"
 	oldTemp := filepath.Join(t.TempDir(), "snapshots")

--- a/store/command_processor.go
+++ b/store/command_processor.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/rqlite/rqlite/v8/command/chunking"
 	"github.com/rqlite/rqlite/v8/command/proto"
 	sql "github.com/rqlite/rqlite/v8/db"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // ExecuteQueryResponses is a slice of ExecuteQueryResponse, which detects mutations.
@@ -30,12 +30,12 @@ func (e ExecuteQueryResponses) Mutation() bool {
 
 // CommandProcessor processes commands by applying them to the underlying database.
 type CommandProcessor struct {
-	logger  *log.Logger
+	logger  rqlog.Logger
 	decMgmr *chunking.DechunkerManager
 }
 
 // NewCommandProcessor returns a new instance of CommandProcessor.
-func NewCommandProcessor(logger *log.Logger, dm *chunking.DechunkerManager) *CommandProcessor {
+func NewCommandProcessor(logger rqlog.Logger, dm *chunking.DechunkerManager) *CommandProcessor {
 	return &CommandProcessor{
 		logger:  logger,
 		decMgmr: dm}

--- a/store/fsm.go
+++ b/store/fsm.go
@@ -3,10 +3,10 @@ package store
 import (
 	"expvar"
 	"io"
-	"log"
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 // FSM is a wrapper around the Store which implements raft.FSM.
@@ -42,7 +42,7 @@ type FSMSnapshot struct {
 
 	raft.FSMSnapshot
 	persistSucceeded bool
-	logger           *log.Logger
+	logger           rqlog.Logger
 }
 
 // Persist writes the snapshot to the given sink.

--- a/store/state.go
+++ b/store/state.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"github.com/rqlite/rqlite/v8/command/proto"
 	sql "github.com/rqlite/rqlite/v8/db"
 	"github.com/rqlite/rqlite/v8/internal/random"
+	"github.com/rqlite/rqlite/v8/rqlog"
 	"github.com/rqlite/rqlite/v8/snapshot"
 	rlog "github.com/rqlite/rqlite/v8/store/log"
 )
@@ -114,7 +114,7 @@ func HasData(dir string) (bool, error) {
 // RecoverNode is used to manually force a new configuration, in the event that
 // quorum cannot be restored. This borrows heavily from RecoverCluster functionality
 // of the Hashicorp Raft library, but has been customized for rqlite use.
-func RecoverNode(dataDir string, extensions []string, logger *log.Logger, logs raft.LogStore,
+func RecoverNode(dataDir string, extensions []string, logger rqlog.Logger, logs raft.LogStore,
 	stable *rlog.Log, snaps raft.SnapshotStore, tn raft.Transport, conf raft.Configuration) error {
 	logPrefix := logger.Prefix()
 	logger.SetPrefix(fmt.Sprintf("%s[recovery] ", logPrefix))

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -6,13 +6,13 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/rqlite/rqlite/v8/internal/rtls"
+	"github.com/rqlite/rqlite/v8/rqlog"
 )
 
 const (
@@ -82,7 +82,7 @@ type Mux struct {
 	Timeout time.Duration
 
 	// Out-of-band error logger
-	Logger *log.Logger
+	Logger rqlog.Logger
 
 	certReloader *rtls.CertReloader
 	tlsConfig    *tls.Config
@@ -101,7 +101,7 @@ func NewMux(ln net.Listener, adv net.Addr) (*Mux, error) {
 		addr:    addr,
 		m:       make(map[byte]*listener),
 		Timeout: DefaultTimeout,
-		Logger:  log.New(os.Stderr, "[mux] ", log.LstdFlags),
+		Logger:  rqlog.Default().WithName("[mux] ").WithOutput(os.Stderr),
 	}, nil
 }
 

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -13,6 +13,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/rqlite/rqlite/v8/rqlog"
 	"github.com/rqlite/rqlite/v8/testdata/x509"
 )
 
@@ -41,7 +42,7 @@ func TestMux(t *testing.T) {
 		defer mux.Close()
 		mux.Timeout = 200 * time.Millisecond
 		if !testing.Verbose() {
-			mux.Logger = log.New(io.Discard, "", 0)
+			mux.Logger = rqlog.NewRqLogger(io.Discard, "", 0)
 		}
 		for i := uint8(0); i < n; i++ {
 			ln := mux.Listen(i)
@@ -141,7 +142,7 @@ func TestMux_Advertise(t *testing.T) {
 	defer mux.Close()
 	mux.Timeout = 200 * time.Millisecond
 	if !testing.Verbose() {
-		mux.Logger = log.New(io.Discard, "", 0)
+		mux.Logger = rqlog.NewRqLogger(io.Discard, "", 0)
 	}
 
 	ln := mux.Listen(1)


### PR DESCRIPTION
@otoolep this was the least invasive option I could think of that would allow us to use custom logging. 
This could be also used to provide logs in json format by adding cli flag and wrapping `slog`.

closes #2163 