### PR TITLE
Implement key collection and deletion in FIFO

### DIFF
--- a/cdc/fifo.go
+++ b/cdc/fifo.go
@@ -324,9 +324,7 @@ func (q *Queue) run(highestKey uint64) {
 				// keys when iterating. See https://github.com/etcd-io/bbolt/pull/611.
 				var keysToDelete [][]byte
 				for k, _ := c.First(); k != nil && btouint64(k) <= req.idx; k, _ = c.Next() {
-					keyCopy := make([]byte, len(k))
-					copy(keyCopy, k)
-					keysToDelete = append(keysToDelete, keyCopy)
+					keysToDelete = append(keysToDelete, k)
 				}
 
 				// Now, delete the keys.

--- a/cdc/fifo.go
+++ b/cdc/fifo.go
@@ -320,10 +320,10 @@ func (q *Queue) run(highestKey uint64) {
 					deletedHead = true
 				}
 
+				// First, collect all keys that need to be deleted. It's not safe to delete
+				// keys when iterating. See https://github.com/etcd-io/bbolt/pull/611.
 				var keysToDelete [][]byte
-				// First, collect all keys that need to be deleted.
 				for k, _ := c.First(); k != nil && btouint64(k) <= req.idx; k, _ = c.Next() {
-					// The key slice `k` is only valid during the transaction. We must copy it.
 					keyCopy := make([]byte, len(k))
 					copy(keyCopy, k)
 					keysToDelete = append(keysToDelete, keyCopy)

--- a/cdc/fifo.go
+++ b/cdc/fifo.go
@@ -320,7 +320,17 @@ func (q *Queue) run(highestKey uint64) {
 					deletedHead = true
 				}
 
+				var keysToDelete [][]byte
+				// First, collect all keys that need to be deleted.
 				for k, _ := c.First(); k != nil && btouint64(k) <= req.idx; k, _ = c.Next() {
+					// The key slice `k` is only valid during the transaction. We must copy it.
+					keyCopy := make([]byte, len(k))
+					copy(keyCopy, k)
+					keysToDelete = append(keysToDelete, keyCopy)
+				}
+
+				// Now, delete the keys.
+				for _, k := range keysToDelete {
 					if derr := b.Delete(k); derr != nil {
 						return derr
 					}


### PR DESCRIPTION
Collect and delete keys that are less than or equal to the requested index. 

Removing key/values pairs in a bucket during iteration on the bucket using cursor may not work properly. Each time when removing a key/value pair, the cursor may automatically move to the next position if present. When users call c.Next() after removing a key, it may skip one key/value pair. Refer to etcd-io/bbolt#611 for more detailed info.