### PR TITLE
Explicitly snapshot after load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v9.3.6 (unreleased)
 ### Implementation changes and bug fixes
 - [PR #2404](https://github.com/rqlite/rqlite/pull/2404): Add basic end-to-end testing of the rqlite shell.
+- [PR #2406](https://github.com/rqlite/rqlite/pull/2406): Explicitly snapshot after a Load operation.
 
 ## v9.3.5 (December 7th 2025)
 ### Implementation changes and bug fixes

--- a/store/store.go
+++ b/store/store.go
@@ -1790,9 +1790,9 @@ func (s *Store) Load(lr *proto.LoadRequest) error {
 	// is regenerated. This will ensure a fast restart after a load, if one is
 	// requested. However we don't want to fail the load if the snapshot fails
 	// for any reason.
-	if err := s.Snapshot(0); err != nil {
-		s.logger.Printf("snapshot after load failed: %s", err.Error())
-	}
+if err := s.Snapshot(0); err != nil && err != ErrNothingNewToSnapshot {
+	s.logger.Printf("snapshot after load failed: %s", err.Error())
+}
 
 	stats.Add(numLoads, 1)
 	return nil

--- a/store/store.go
+++ b/store/store.go
@@ -1785,6 +1785,15 @@ func (s *Store) Load(lr *proto.LoadRequest) error {
 	if err := s.load(lr); err != nil {
 		return err
 	}
+
+	// Explicitly snapshot after load to ensure that the "clean snapshot" file
+	// is regenerated. This will ensure a fast restart after a load, if one is
+	// requested. However we don't want to fail the load if the snapshot fails
+	// for any reason.
+	if err := s.Snapshot(0); err != nil {
+		s.logger.Printf("snapshot after load failed: %s", err.Error())
+	}
+
 	stats.Add(numLoads, 1)
 	return nil
 }


### PR DESCRIPTION
This will ensure the "clean_snapshot" file is regenerated so any restart requested immediately after loading will be fast.