### PR TITLE
Rename snapshot Store List() to ListAll()

### DIFF
--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -222,9 +222,9 @@ func (s *Store) Create(version raft.SnapshotVersion, index, term uint64, configu
 	return NewLockingSink(sink, s), nil
 }
 
-// List returns the list of available snapshots in the Store,
+// ListAll returns the list of all available snapshots in the Store,
 // ordered from newest to oldest.
-func (s *Store) List() ([]*raft.SnapshotMeta, error) {
+func (s *Store) ListAll() ([]*raft.SnapshotMeta, error) {
 	if err := s.mrsw.BeginRead(); err != nil {
 		return nil, err
 	}
@@ -240,6 +240,19 @@ func (s *Store) List() ([]*raft.SnapshotMeta, error) {
 		metas[i], metas[j] = metas[j], metas[i]
 	}
 	return metas, nil
+}
+
+// List returns the most recent snapshot in the Store, if any exist.
+// It satisfies the raft.SnapshotStore interface.
+func (s *Store) List() ([]*raft.SnapshotMeta, error) {
+	metas, err := s.ListAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(metas) == 0 {
+		return metas, nil
+	}
+	return metas[:1], nil
 }
 
 // Len returns the number of snapshots in the Store.

--- a/snapshot/upgrader_test.go
+++ b/snapshot/upgrader_test.go
@@ -53,7 +53,7 @@ func Test_Upgrade_OK(t *testing.T) {
 		t.Fatalf("failed to create new snapshot store: %s", err)
 	}
 
-	snapshots, err := store.List()
+	snapshots, err := store.ListAll()
 	if err != nil {
 		t.Fatalf("failed to list snapshots: %s", err)
 	}
@@ -101,7 +101,7 @@ func Test_Upgrade_EmptyOK(t *testing.T) {
 		t.Fatalf("failed to create new snapshot store: %s", err)
 	}
 
-	snapshots, err := store.List()
+	snapshots, err := store.ListAll()
 	if err != nil {
 		t.Fatalf("failed to list snapshots: %s", err)
 	}
@@ -252,7 +252,7 @@ func Test_Upgrade8To10_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create store: %s", err)
 	}
-	snaps, err := store.List()
+	snaps, err := store.ListAll()
 	if err != nil {
 		t.Fatalf("failed to list snapshots: %s", err)
 	}


### PR DESCRIPTION
ListAll() preserves the original behavior of returning all snapshots. The new List() satisfies the raft.SnapshotStore interface and returns only the most recent snapshot, which is all Raft needs for restoration.