### PR TITLE
Escape single quotes in VacuumInto path

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -847,7 +847,7 @@ func (db *DB) Vacuum() error {
 
 // VacuumInto VACUUMs the database into the file at path
 func (db *DB) VacuumInto(path string) error {
-	_, err := db.rwDB.Exec(fmt.Sprintf("VACUUM INTO '%s'", path))
+	_, err := db.rwDB.Exec(fmt.Sprintf("VACUUM INTO '%s'", strings.ReplaceAll(path, "'", "''")))
 	return err
 }
 

--- a/db/db_vacuum_test.go
+++ b/db/db_vacuum_test.go
@@ -123,6 +123,19 @@ func Test_DBVacuumInto(t *testing.T) {
 	defer vDB2.Close()
 	testQ(vDB2)
 
+	// VACUUM INTO a path containing a single quote should work.
+	tmpDir := t.TempDir()
+	tmpPath3 := tmpDir + "/it's a file.db"
+	if err := db.VacuumInto(tmpPath3); err != nil {
+		t.Fatalf("failed to vacuum into path with single quote: %s", err.Error())
+	}
+	vDB3, err := Open(tmpPath3, false, false)
+	if err != nil {
+		t.Fatalf("failed to open database at path with single quote: %s", err.Error())
+	}
+	defer vDB3.Close()
+	testQ(vDB3)
+
 	// VACUUM into a file which is an existing SQLIte database. Should fail.
 	existDB, existPath := mustCreateOnDiskDatabaseWAL()
 	defer db.Close()


### PR DESCRIPTION
## Summary
- Fix SQL injection vulnerability in `VacuumInto` by escaping single quotes in the file path (doubling `'` → `''` per SQL standard)
- SQLite does not support parameterized `VACUUM INTO`, so string escaping is the correct approach
- Added a test case that vacuums into a path containing a single quote and verifies the resulting database

Fixes #2621

## Test plan
- [x] Existing `Test_DBVacuumInto` tests pass
- [x] New test case with single-quote path passes
- [x] Full `db` package tests pass (119/119)
- [x] `go vet ./...` clean