### PR TITLE
Limit Join leader redirects

### DIFF
--- a/cluster/client.go
+++ b/cluster/client.go
@@ -510,6 +510,36 @@ func (c *Client) Notify(ctx context.Context, nr *command.NotifyRequest, nodeAddr
 	return nil
 }
 
+
+func (c *Client) joinOnce(jr *command.JoinRequest, nodeAddr string, creds *proto.Credentials, timeout time.Duration) (*proto.CommandJoinResponse, error){
+	conn, err := c.dial(nodeAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	command := &proto.Command{
+		Type: proto.Command_COMMAND_TYPE_JOIN,
+		Request: &proto.Command_JoinRequest{
+			JoinRequest: jr,
+		},
+		Credentials: creds,
+	}
+	if err := writeCommand(conn, command, timeout); err != nil {
+		handleConnError(conn)
+		return nil, err
+	}
+	p, err := readResponse(conn, timeout)
+	if err != nil {
+		handleConnError(conn)
+		return nil, err
+	}
+	resp := &proto.CommandJoinResponse{}
+	if err := pb.Unmarshal(p, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // Join joins this node to a cluster at the remote address nodeAddr.
 // If creds is nil, then no credential information will be included in
 // the Join request to the remote node.
@@ -524,36 +554,7 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 			return err
 		}
 
-		conn, err := c.dial(nodeAddr)
-		if err != nil {
-			return err
-		}
-
-		// Create the request.
-		command := &proto.Command{
-			Type: proto.Command_COMMAND_TYPE_JOIN,
-			Request: &proto.Command_JoinRequest{
-				JoinRequest: jr,
-			},
-			Credentials: creds,
-		}
-
-		if err := writeCommand(conn, command, timeout); err != nil {
-			handleConnError(conn)
-			conn.Close()
-			return err
-		}
-
-		p, err := readResponse(conn, timeout)
-		if err != nil {
-			handleConnError(conn)
-			conn.Close()
-			return err
-		}
-		conn.Close()
-
-		a := &proto.CommandJoinResponse{}
-		err = pb.Unmarshal(p, a)
+		a, err := c.joinOnce(jr, nodeAddr, creds, timeout)
 		if err != nil {
 			return err
 		}

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -27,9 +27,13 @@ const (
 	maxPoolCapacity   = 64
 	defaultMaxRetries = 0
 	noRetries         = 0
+	maxJoinRedirects  = 8
 
 	protoBufferLengthSize = 8
 )
+
+// ErrTooManyJoinRedirects indicates that a join request was redirected too many times.
+var ErrTooManyJoinRedirects = errors.New("too many leader redirects during join")
 
 // CreateRaftDialer creates a dialer for connecting to other nodes' Raft service. If the cert and
 // key arguments are not set, then the returned dialer will not use TLS. If they are set then
@@ -513,12 +517,17 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	redirects := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		conn, err := c.dial(nodeAddr)
 		if err != nil {
 			return err
 		}
-		defer conn.Close()
 
 		// Create the request.
 		command := &proto.Command{
@@ -531,14 +540,17 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 
 		if err := writeCommand(conn, command, timeout); err != nil {
 			handleConnError(conn)
+			conn.Close()
 			return err
 		}
 
 		p, err := readResponse(conn, timeout)
 		if err != nil {
 			handleConnError(conn)
+			conn.Close()
 			return err
 		}
+		conn.Close()
 
 		a := &proto.CommandJoinResponse{}
 		err = pb.Unmarshal(p, a)
@@ -550,6 +562,10 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 			if a.Error == "not leader" {
 				if a.Leader == "" {
 					return errors.New("no leader")
+				}
+				redirects++
+				if redirects > maxJoinRedirects {
+					return ErrTooManyJoinRedirects
 				}
 				nodeAddr = a.Leader
 				continue

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -510,8 +510,7 @@ func (c *Client) Notify(ctx context.Context, nr *command.NotifyRequest, nodeAddr
 	return nil
 }
 
-
-func (c *Client) joinOnce(jr *command.JoinRequest, nodeAddr string, creds *proto.Credentials, timeout time.Duration) (*proto.CommandJoinResponse, error){
+func (c *Client) joinOnce(jr *command.JoinRequest, nodeAddr string, creds *proto.Credentials, timeout time.Duration) (*proto.CommandJoinResponse, error) {
 	conn, err := c.dial(nodeAddr)
 	if err != nil {
 		return nil, err

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -342,17 +341,59 @@ func Test_ClientJoinNode(t *testing.T) {
 }
 
 func Test_ClientJoinNodeRedirect(t *testing.T) {
-	srv2 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
-		return &proto.CommandJoinResponse{}
-	})
+	srv2 := servicetest.NewService()
+	srv2.PersistentHandler = func(conn net.Conn) {
+		defer conn.Close()
+		for {
+			c := readCommand(conn)
+			if c == nil {
+				return
+			}
+			if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+				t.Errorf("unexpected command type: %d", c.Type)
+				return
+			}
+
+			p, err := pb.Marshal(&proto.CommandJoinResponse{})
+			if err != nil {
+				t.Errorf("failed to marshal join response: %s", err)
+				return
+			}
+			if err := writeBytesWithLength(conn, p); err != nil {
+				return
+			}
+		}
+	}
+	srv2.Start()
 	defer srv2.Close()
 
-	srv1 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
-		return &proto.CommandJoinResponse{
-			Error:  "not leader",
-			Leader: srv2.Addr(),
+	srv1 := servicetest.NewService()
+	srv1.PersistentHandler = func(conn net.Conn) {
+		defer conn.Close()
+		for {
+			c := readCommand(conn)
+			if c == nil {
+				return
+			}
+			if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+				t.Errorf("unexpected command type: %d", c.Type)
+				return
+			}
+
+			p, err := pb.Marshal(&proto.CommandJoinResponse{
+				Error:  "not leader",
+				Leader: srv2.Addr(),
+			})
+			if err != nil {
+				t.Errorf("failed to marshal join response: %s", err)
+				return
+			}
+			if err := writeBytesWithLength(conn, p); err != nil {
+				return
+			}
 		}
-	})
+	}
+	srv1.Start()
 	defer srv1.Close()
 
 	c := NewClient(&simpleDialer{}, 0)
@@ -366,26 +407,65 @@ func Test_ClientJoinNodeRedirect(t *testing.T) {
 }
 
 func Test_ClientJoinNodeTooManyRedirects(t *testing.T) {
-	var srv1Addr atomic.Value
-	var srv2Addr atomic.Value
+	srv1 := servicetest.NewService()
+	srv2 := servicetest.NewService()
 
-	srv1 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
-		return &proto.CommandJoinResponse{
-			Error:  "not leader",
-			Leader: srv2Addr.Load().(string),
+	srv1.PersistentHandler = func(conn net.Conn) {
+		defer conn.Close()
+		for {
+			c := readCommand(conn)
+			if c == nil {
+				return
+			}
+			if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+				t.Errorf("unexpected command type: %d", c.Type)
+				return
+			}
+
+			p, err := pb.Marshal(&proto.CommandJoinResponse{
+				Error:  "not leader",
+				Leader: srv2.Addr(),
+			})
+			if err != nil {
+				t.Errorf("failed to marshal join response: %s", err)
+				return
+			}
+			if err := writeBytesWithLength(conn, p); err != nil {
+				return
+			}
 		}
-	})
+	}
+
+	srv2.PersistentHandler = func(conn net.Conn) {
+		defer conn.Close()
+		for {
+			c := readCommand(conn)
+			if c == nil {
+				return
+			}
+			if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+				t.Errorf("unexpected command type: %d", c.Type)
+				return
+			}
+
+			p, err := pb.Marshal(&proto.CommandJoinResponse{
+				Error:  "not leader",
+				Leader: srv1.Addr(),
+			})
+			if err != nil {
+				t.Errorf("failed to marshal join response: %s", err)
+				return
+			}
+			if err := writeBytesWithLength(conn, p); err != nil {
+				return
+			}
+		}
+	}
+
+	srv1.Start()
 	defer srv1.Close()
-	srv1Addr.Store(srv1.Addr())
-
-	srv2 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
-		return &proto.CommandJoinResponse{
-			Error:  "not leader",
-			Leader: srv1Addr.Load().(string),
-		}
-	})
+	srv2.Start()
 	defer srv2.Close()
-	srv2Addr.Store(srv2.Addr())
 
 	c := NewClient(&simpleDialer{}, 0)
 	req := &command.JoinRequest{
@@ -609,62 +689,6 @@ func (s *simpleDialer) Dial(address string, timeout time.Duration) (net.Conn, er
 		return nil, err
 	}
 	return conn, nil
-}
-
-type joinTestServer struct {
-	ln net.Listener
-}
-
-func mustNewJoinTestServer(t *testing.T, response func() *proto.CommandJoinResponse) *joinTestServer {
-	t.Helper()
-
-	ln, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %s", err)
-	}
-
-	s := &joinTestServer{ln: ln}
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-
-			go func(conn net.Conn) {
-				defer conn.Close()
-				for {
-					c := readCommand(conn)
-					if c == nil {
-						return
-					}
-					if c.Type != proto.Command_COMMAND_TYPE_JOIN {
-						t.Errorf("unexpected command type: %d", c.Type)
-						return
-					}
-
-					p, err := pb.Marshal(response())
-					if err != nil {
-						t.Errorf("failed to marshal join response: %s", err)
-						return
-					}
-					if err := writeBytesWithLength(conn, p); err != nil {
-						return
-					}
-				}
-			}(conn)
-		}
-	}()
-
-	return s
-}
-
-func (s *joinTestServer) Addr() string {
-	return s.ln.Addr().String()
-}
-
-func (s *joinTestServer) Close() error {
-	return s.ln.Close()
 }
 
 func Test_ClientBroadcast(t *testing.T) {

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -342,7 +342,8 @@ func Test_ClientJoinNode(t *testing.T) {
 
 func Test_ClientJoinNodeRedirect(t *testing.T) {
 	srv2 := servicetest.NewService()
-	srv2.PersistentHandler = func(conn net.Conn) {
+	srv2.CloseConn = false
+	srv2.Handler = func(conn net.Conn) {
 		defer conn.Close()
 		for {
 			c := readCommand(conn)
@@ -368,7 +369,8 @@ func Test_ClientJoinNodeRedirect(t *testing.T) {
 	defer srv2.Close()
 
 	srv1 := servicetest.NewService()
-	srv1.PersistentHandler = func(conn net.Conn) {
+	srv1.CloseConn = false
+	srv1.Handler = func(conn net.Conn) {
 		defer conn.Close()
 		for {
 			c := readCommand(conn)
@@ -409,8 +411,10 @@ func Test_ClientJoinNodeRedirect(t *testing.T) {
 func Test_ClientJoinNodeTooManyRedirects(t *testing.T) {
 	srv1 := servicetest.NewService()
 	srv2 := servicetest.NewService()
+	srv1.CloseConn = false
+	srv2.CloseConn = false
 
-	srv1.PersistentHandler = func(conn net.Conn) {
+	srv1.Handler = func(conn net.Conn) {
 		defer conn.Close()
 		for {
 			c := readCommand(conn)
@@ -436,7 +440,7 @@ func Test_ClientJoinNodeTooManyRedirects(t *testing.T) {
 		}
 	}
 
-	srv2.PersistentHandler = func(conn net.Conn) {
+	srv2.Handler = func(conn net.Conn) {
 		defer conn.Close()
 		for {
 			c := readCommand(conn)

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -340,6 +341,62 @@ func Test_ClientJoinNode(t *testing.T) {
 	}
 }
 
+func Test_ClientJoinNodeRedirect(t *testing.T) {
+	srv2 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
+		return &proto.CommandJoinResponse{}
+	})
+	defer srv2.Close()
+
+	srv1 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
+		return &proto.CommandJoinResponse{
+			Error:  "not leader",
+			Leader: srv2.Addr(),
+		}
+	})
+	defer srv1.Close()
+
+	c := NewClient(&simpleDialer{}, 0)
+	req := &command.JoinRequest{
+		Address: "test-node-addr",
+	}
+	err := c.Join(context.Background(), req, srv1.Addr(), nil, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_ClientJoinNodeTooManyRedirects(t *testing.T) {
+	var srv1Addr atomic.Value
+	var srv2Addr atomic.Value
+
+	srv1 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
+		return &proto.CommandJoinResponse{
+			Error:  "not leader",
+			Leader: srv2Addr.Load().(string),
+		}
+	})
+	defer srv1.Close()
+	srv1Addr.Store(srv1.Addr())
+
+	srv2 := mustNewJoinTestServer(t, func() *proto.CommandJoinResponse {
+		return &proto.CommandJoinResponse{
+			Error:  "not leader",
+			Leader: srv1Addr.Load().(string),
+		}
+	})
+	defer srv2.Close()
+	srv2Addr.Store(srv2.Addr())
+
+	c := NewClient(&simpleDialer{}, 0)
+	req := &command.JoinRequest{
+		Address: "test-node-addr",
+	}
+	err := c.Join(context.Background(), req, srv1.Addr(), nil, time.Second)
+	if err != ErrTooManyJoinRedirects {
+		t.Fatalf("expected %v, got %v", ErrTooManyJoinRedirects, err)
+	}
+}
+
 func Test_ClientRetry_SuccessFirstAttempt(t *testing.T) {
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
@@ -552,6 +609,62 @@ func (s *simpleDialer) Dial(address string, timeout time.Duration) (net.Conn, er
 		return nil, err
 	}
 	return conn, nil
+}
+
+type joinTestServer struct {
+	ln net.Listener
+}
+
+func mustNewJoinTestServer(t *testing.T, response func() *proto.CommandJoinResponse) *joinTestServer {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+
+	s := &joinTestServer{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(conn net.Conn) {
+				defer conn.Close()
+				for {
+					c := readCommand(conn)
+					if c == nil {
+						return
+					}
+					if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+						t.Errorf("unexpected command type: %d", c.Type)
+						return
+					}
+
+					p, err := pb.Marshal(response())
+					if err != nil {
+						t.Errorf("failed to marshal join response: %s", err)
+						return
+					}
+					if err := writeBytesWithLength(conn, p); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return s
+}
+
+func (s *joinTestServer) Addr() string {
+	return s.ln.Addr().String()
+}
+
+func (s *joinTestServer) Close() error {
+	return s.ln.Close()
 }
 
 func Test_ClientBroadcast(t *testing.T) {

--- a/cluster/servicetest/service.go
+++ b/cluster/servicetest/service.go
@@ -6,9 +6,10 @@ import (
 
 // Service represents a test service.
 type Service struct {
-	Listener          net.Listener
-	Handler           func(net.Conn)
-	PersistentHandler func(net.Conn)
+	Listener net.Listener
+	Handler  func(net.Conn)
+	// CloseConn controls whether the service closes a connection after Handler returns.
+	CloseConn bool
 }
 
 // NewService returns a new instance of the service that runs on
@@ -20,7 +21,8 @@ func NewService() *Service {
 		panic("service: failed to listen: " + err.Error())
 	}
 	return &Service{
-		Listener: ln,
+		Listener:  ln,
+		CloseConn: true,
 	}
 }
 
@@ -51,12 +53,10 @@ func (s *Service) serve() error {
 }
 
 func (s *Service) handleConn(conn net.Conn) {
-	if s.PersistentHandler != nil {
-		s.PersistentHandler(conn)
-		return
-	}
 	if s.Handler != nil {
 		s.Handler(conn)
 	}
-	conn.Close()
+	if s.CloseConn {
+		conn.Close()
+	}
 }

--- a/cluster/servicetest/service.go
+++ b/cluster/servicetest/service.go
@@ -6,8 +6,9 @@ import (
 
 // Service represents a test service.
 type Service struct {
-	Listener net.Listener
-	Handler  func(net.Conn)
+	Listener          net.Listener
+	Handler           func(net.Conn)
+	PersistentHandler func(net.Conn)
 }
 
 // NewService returns a new instance of the service that runs on
@@ -50,6 +51,10 @@ func (s *Service) serve() error {
 }
 
 func (s *Service) handleConn(conn net.Conn) {
+	if s.PersistentHandler != nil {
+		s.PersistentHandler(conn)
+		return
+	}
 	if s.Handler != nil {
 		s.Handler(conn)
 	}


### PR DESCRIPTION
Fixes #2616 
`cluster.Client.Join()` could follow `"not leader"` redirects indefinitely if nodes redirected to each other.                 
                                                                  
This fix adds a redirect cap, returns `ErrTooManyJoinRedirects` when exceeded, and adds tests for both normal redirect handling and redirect loops.

## Changes

- added `maxJoinRedirects` for `cluster.Client.Join()`
- return `ErrTooManyJoinRedirects` when the redirect cap is exceeded.
- kept valid single-hop leader redirects working.
- checked `ctx.Err()` on each redirect loop iteration.
- closed join connections per iteration instead of deferring inside the loop.

## Tests

Added:
- `Test_ClientJoinNodeRedirect`
- `Test_ClientJoinNodeTooManyRedirects`

Verified with:
- `go test -count=1 ./cluster -run "Test_ClientJoinNode|Test_ClientJoinNodeRedirect|Test_ClientJoinNodeTooManyRedirects"`
- `go test ./cluster`

Please go through the changes and let me know if there are any fixes or further changes to be administered in the issue.