### PR TITLE
Verify local database in /readyz handler (issue #2633)

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -66,6 +66,11 @@ type Store interface {
 	// Stats returns stats on the Store.
 	Stats() (map[string]any, error)
 
+	// Query executes queries that return rows, and do not modify the
+	// database. The /readyz handler uses this to verify that the local
+	// database is reachable.
+	Query(ctx context.Context, qr *proto.QueryRequest) ([]*proto.QueryRows, proto.ConsistencyLevel, uint64, error)
+
 	// Snapshot triggers a Raft Snapshot and Log Truncation.
 	Snapshot(n uint64) error
 
@@ -1187,17 +1192,52 @@ func (s *Service) handleReadyz(w http.ResponseWriter, r *http.Request, qp QueryP
 		return
 	}
 
-	okMsg := "[+]node ok\n[+]leader ok\n[+]store ok"
+	if err := s.databaseReady(r.Context()); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write(fmt.Appendf(nil, "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database %s", err.Error()))
+		return
+	}
+
+	okMsg := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database ok"
 	if qp.Sync() {
 		if _, err := s.store.Committed(qp.Timeout(defaultTimeout)); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write(fmt.Appendf(nil, "[+]node ok\n[+]leader ok\n[+]store ok\n[+]sync %s", err.Error()))
+			w.Write(fmt.Appendf(nil, "%s\n[+]sync %s", okMsg, err.Error()))
 			return
 		}
 		okMsg += "\n[+]sync ok"
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(okMsg))
+}
+
+// databaseReady verifies the local database is reachable by issuing a
+// `SELECT 1` with NONE read consistency. It returns nil if the database
+// answers `1`, or an error describing the failure.
+func (s *Service) databaseReady(ctx context.Context) error {
+	qr := &proto.QueryRequest{
+		Request: &proto.Request{
+			Statements: []*proto.Statement{{Sql: "SELECT 1"}},
+		},
+		Level: proto.ConsistencyLevel_NONE,
+	}
+	rows, _, _, err := s.store.Query(ctx, qr)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("no rows returned")
+	}
+	if rows[0].Error != "" {
+		return errors.New(rows[0].Error)
+	}
+	if len(rows[0].Values) == 0 || len(rows[0].Values[0].Parameters) == 0 {
+		return fmt.Errorf("no rows returned")
+	}
+	if v := rows[0].Values[0].Parameters[0].GetI(); v != 1 {
+		return fmt.Errorf("unexpected value %d", v)
+	}
+	return nil
 }
 
 // handleLicenses serves the license information.

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -1252,7 +1252,7 @@ func Test_Readyz(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("failed to get expected StatusOK for node, got %d", resp.StatusCode)
 	}
-	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok", mustReadBody(t, resp); exp != got {
+	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database ok", mustReadBody(t, resp); exp != got {
 		t.Fatalf("incorrect response body, exp: %s, got: %s", exp, got)
 	}
 
@@ -1299,7 +1299,7 @@ func Test_Readyz(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("failed to get expected StatusServiceUnavailable, got %d", resp.StatusCode)
 	}
-	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]sync timeout", mustReadBody(t, resp); exp != got {
+	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database ok\n[+]sync timeout", mustReadBody(t, resp); exp != got {
 		t.Fatalf("incorrect response body, exp: %s, got: %s", exp, got)
 	}
 	if cnt.Load() != 1 {
@@ -1318,11 +1318,42 @@ func Test_Readyz(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("failed to get expected StatusOK, got %d", resp.StatusCode)
 	}
-	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]sync ok", mustReadBody(t, resp); exp != got {
+	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database ok\n[+]sync ok", mustReadBody(t, resp); exp != got {
 		t.Fatalf("incorrect response body, exp: %s, got: %s", exp, got)
 	}
 	if cnt.Load() != 2 {
 		t.Fatalf("failed to call committedFn")
+	}
+}
+
+func Test_Readyz_DatabaseError(t *testing.T) {
+	m := &MockStore{
+		leaderAddr: "foo:1234",
+		queryFn: func(qr *command.QueryRequest) ([]*command.QueryRows, uint64, error) {
+			return nil, 0, fmt.Errorf("disk full")
+		},
+	}
+	c := &mockClusterService{
+		apiAddr: "https://bar:5678",
+	}
+	s := New("127.0.0.1:0", m, c, proxy.New(m, c), nil)
+	if err := s.Start(); err != nil {
+		t.Fatalf("failed to start service")
+	}
+	defer s.Close()
+
+	client := &http.Client{}
+	host := fmt.Sprintf("http://%s", s.Addr().String())
+	resp, err := client.Get(host + "/readyz")
+	if err != nil {
+		t.Fatalf("failed to make readyz request")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when database query fails, got %d", resp.StatusCode)
+	}
+	if exp, got := "[+]node ok\n[+]leader ok\n[+]store ok\n[+]database disk full", mustReadBody(t, resp); exp != got {
+		t.Fatalf("incorrect response body, exp: %s, got: %s", exp, got)
 	}
 }
 
@@ -2536,7 +2567,14 @@ func (m *MockStore) Query(ctx context.Context, qr *command.QueryRequest) ([]*com
 		rows, idx, err := m.queryFn(qr)
 		return rows, command.ConsistencyLevel_NONE, idx, err
 	}
-	return nil, command.ConsistencyLevel_NONE, 0, nil
+	rows := []*command.QueryRows{{
+		Columns: []string{"1"},
+		Types:   []string{"integer"},
+		Values: []*command.Values{{
+			Parameters: []*command.Parameter{{Value: &command.Parameter_I{I: 1}}},
+		}},
+	}}
+	return rows, command.ConsistencyLevel_NONE, 0, nil
 }
 
 func (m *MockStore) Request(ctx context.Context, eqr *command.ExecuteQueryRequest) ([]*command.ExecuteQueryResponse, uint64, uint64, error) {


### PR DESCRIPTION
Closes #2633.

Adds a `SELECT 1` check at the database layer (NONE read consistency, so it stays local) to the existing `/readyz` handler. The successful response now reads:

\`\`\`
$ curl localhost:4001/readyz
[+]node ok
[+]leader ok
[+]store ok
[+]database ok
\`\`\`

If the local database query fails or returns an unexpected value, the handler returns 503 with `[+]database <reason>` appended.

## Changes

- `http/service.go`: added `Query` to the `Store` interface (the real `*store.Store` already satisfies it; only the mock needed to grow); added a small `databaseReady` helper and wired it into `handleReadyz` between the existing `[+]store ok` and `[+]sync` checks.
- `http/service_test.go`: existing `Test_Readyz` assertions updated to expect the new line; new `Test_Readyz_DatabaseError` covers the failure path. The mock's `Query` default now returns a single `1` row so other tests don't have to opt in.

## Verification

- `go vet ./...` clean
- `gofmt -l http/service.go http/service_test.go` clean
- `go test ./http/... -count=1` -- 186/186 pass

The `?sync` and `?noleader` paths still behave as before; `?noleader` still skips the database check (it's intentionally a node-only response).