### PR TITLE
WIP: Verify mTLS peer Common Name

### DIFF
--- a/cmd/rqlited/config_flags.go
+++ b/cmd/rqlited/config_flags.go
@@ -40,6 +40,8 @@ type Config struct {
 	HTTPx509Key string
 	// Enable mutual TLS for HTTPS
 	HTTPVerifyClient bool
+	// Required Common Name on client certificates. If not set, any client cert signed by the CA is accepted
+	HTTPVerifyCN string
 	// Path to X.509 CA certificate for node-to-node encryption
 	NodeX509CACert string
 	// Path to X.509 certificate for node-to-node mutual authentication and encryption
@@ -52,6 +54,8 @@ type Config struct {
 	NodeVerifyClient bool
 	// Hostname to verify on certificate returned by a node
 	NodeVerifyServerName string
+	// Required Common Name on incoming peer certificates. If not set, any peer cert signed by the CA is accepted
+	NodeVerifyCN string
 	// Unique ID for node. If not set, set to advertised Raft address
 	NodeID string
 	// Enable compression when transferring snapshots between nodes
@@ -155,12 +159,14 @@ func Forge(arguments []string) (*flag.FlagSet, *Config, error) {
 	fs.StringVar(&config.HTTPx509Cert, "http-cert", "", "Path to HTTPS X.509 certificate")
 	fs.StringVar(&config.HTTPx509Key, "http-key", "", "Path to HTTPS X.509 private key")
 	fs.BoolVar(&config.HTTPVerifyClient, "http-verify-client", false, "Enable mutual TLS for HTTPS")
+	fs.StringVar(&config.HTTPVerifyCN, "http-verify-cn", "", "Required Common Name on client certificates. If not set, any client cert signed by the CA is accepted")
 	fs.StringVar(&config.NodeX509CACert, "node-ca-cert", "", "Path to X.509 CA certificate for node-to-node encryption")
 	fs.StringVar(&config.NodeX509Cert, "node-cert", "", "Path to X.509 certificate for node-to-node mutual authentication and encryption")
 	fs.StringVar(&config.NodeX509Key, "node-key", "", "Path to X.509 private key for node-to-node mutual authentication and encryption")
 	fs.BoolVar(&config.NoNodeVerify, "node-no-verify", false, "Skip verification of any presented certificate.")
 	fs.BoolVar(&config.NodeVerifyClient, "node-verify-client", false, "Enable mutual TLS for node-to-node communication")
 	fs.StringVar(&config.NodeVerifyServerName, "node-verify-server-name", "", "Hostname to verify on certificate returned by a node")
+	fs.StringVar(&config.NodeVerifyCN, "node-verify-cn", "", "Required Common Name on incoming peer certificates. If not set, any peer cert signed by the CA is accepted")
 	fs.StringVar(&config.NodeID, "node-id", "", "Unique ID for node. If not set, set to advertised Raft address")
 	fs.BoolVar(&config.CompressSnapTransport, "compress-snap-transport", false, "Enable compression when transferring snapshots between nodes")
 	fs.StringVar(&config.RaftAddr, "raft-addr", "localhost:4002", "Raft communication bind address")

--- a/cmd/rqlited/flags.go
+++ b/cmd/rqlited/flags.go
@@ -74,6 +74,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("either both -%s and -%s must be set, or neither", NodeX509CertFlag, NodeX509KeyFlag)
 
 	}
+	if c.HTTPVerifyCN != "" && !c.HTTPVerifyClient {
+		return errors.New("-http-verify-cn requires -http-verify-client")
+	}
+	if c.NodeVerifyCN != "" && !c.NodeVerifyClient {
+		return errors.New("-node-verify-cn requires -node-verify-client")
+	}
 
 	if c.RaftAddr == c.HTTPAddr {
 		return errors.New("HTTP and Raft addresses must differ")

--- a/cmd/rqlited/flags.toml
+++ b/cmd/rqlited/flags.toml
@@ -136,6 +136,16 @@ This allows you to control which clients can connect to the HTTPS API, as only c
 default = false
 
 [[flags]]
+name = "HTTPVerifyCN"
+cli = "http-verify-cn"
+type = "string"
+short_help = "Required Common Name on client certificates. If not set, any client cert signed by the CA is accepted"
+long_help = """
+When set, the Common Name field of the client's leaf certificate must match this string exactly. Only takes effect when -http-verify-client is also set.
+"""
+default = ""
+
+[[flags]]
 name = "NodeX509CACert"
 cli = "node-ca-cert"
 type = "string"
@@ -192,6 +202,16 @@ type = "string"
 short_help = "Hostname to verify on certificate returned by a node"
 long_help = """
 When a node verifies a certificate, it normally checks that the certificate's hostname matches the peer's hostname. This flag explicitly tells the node which hostname to expect in the certificate. It allows you to use a single certificate, with a single hostname, across all nodes. This is primarily useful when mutual TLS is enabled.
+"""
+default = ""
+
+[[flags]]
+name = "NodeVerifyCN"
+cli = "node-verify-cn"
+type = "string"
+short_help = "Required Common Name on incoming peer certificates. If not set, any peer cert signed by the CA is accepted"
+long_help = """
+When set, the Common Name field of every peer's leaf certificate must match this string exactly during the TLS handshake performed by this node's mux. Outbound connections this node makes to peers continue to be validated against -node-verify-server-name. Requires -node-verify-client.
 """
 default = ""
 

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -443,6 +443,7 @@ func startHTTPService(cfg *Config, str *store.Store, cltr *cluster.Client, credS
 	s.CertFile = cfg.HTTPx509Cert
 	s.KeyFile = cfg.HTTPx509Key
 	s.ClientVerify = cfg.HTTPVerifyClient
+	s.ClientVerifyCN = cfg.HTTPVerifyCN
 	s.DefaultQueueCap = cfg.WriteQueueCap
 	s.DefaultQueueBatchSz = cfg.WriteQueueBatchSz
 	s.DefaultQueueTimeout = cfg.WriteQueueTimeout
@@ -476,7 +477,10 @@ func startNodeMux(cfg *Config, ln net.Listener) (*tcp.Mux, error) {
 		}
 		if cfg.NodeVerifyClient {
 			b.WriteString(", mutual TLS enabled")
-			mux, err = tcp.NewMutualTLSMux(ln, adv, cfg.NodeX509Cert, cfg.NodeX509Key, cfg.NodeX509CACert)
+			if cfg.NodeVerifyCN != "" {
+				b.WriteString(fmt.Sprintf(", required peer CN %q", cfg.NodeVerifyCN))
+			}
+			mux, err = tcp.NewMutualTLSMux(ln, adv, cfg.NodeX509Cert, cfg.NodeX509Key, cfg.NodeX509CACert, cfg.NodeVerifyCN)
 		} else {
 			b.WriteString(", mutual TLS disabled")
 			mux, err = tcp.NewTLSMux(ln, adv, cfg.NodeX509Cert, cfg.NodeX509Key)

--- a/http/preflight_test.go
+++ b/http/preflight_test.go
@@ -142,7 +142,7 @@ func Test_IsServingHTTP_OpenPortTLS(t *testing.T) {
 	}
 	certFile := mustWriteTempFile(t, cert)
 	keyFile := mustWriteTempFile(t, key)
-	tlsConfig, err := rtls.CreateServerConfig(certFile, keyFile, rtls.NoCACert, rtls.MTLSStateEnabled)
+	tlsConfig, err := rtls.CreateServerConfig(certFile, keyFile, rtls.NoCACert, rtls.MTLSStateEnabled, rtls.NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create TLS config: %s", err)
 	}

--- a/http/service.go
+++ b/http/service.go
@@ -285,12 +285,13 @@ type Service struct {
 	statusMu sync.RWMutex
 	statuses map[string]StatusReporter
 
-	CACertFile   string // Path to x509 CA certificate used to verify certificates.
-	CertFile     string // Path to server's own x509 certificate.
-	KeyFile      string // Path to server's own x509 private key.
-	ClientVerify bool   // Whether client certificates should verified.
-	certReloader *rtls.CertReloader
-	tlsConfig    *tls.Config
+	CACertFile     string // Path to x509 CA certificate used to verify certificates.
+	CertFile       string // Path to server's own x509 certificate.
+	KeyFile        string // Path to server's own x509 private key.
+	ClientVerify   bool   // Whether client certificates should verified.
+	ClientVerifyCN string // If non-empty, required Common Name on client certificates.
+	certReloader   *rtls.CertReloader
+	tlsConfig      *tls.Config
 
 	aoMu        sync.RWMutex
 	allowOrigin string // Value to set for Access-Control-Allow-Origin
@@ -358,7 +359,7 @@ func (s *Service) Start() error {
 			return s.certReloader.GetCertificate()
 		}
 
-		s.tlsConfig, err = rtls.CreateServerConfigWithFunc(getCertFunc, s.CACertFile, mTLSState)
+		s.tlsConfig, err = rtls.CreateServerConfigWithFunc(getCertFunc, s.CACertFile, mTLSState, s.ClientVerifyCN)
 		if err != nil {
 			return err
 		}
@@ -373,6 +374,9 @@ func (s *Service) Start() error {
 		}
 		if s.ClientVerify {
 			b.WriteString(", mutual TLS enabled")
+			if s.ClientVerifyCN != "" {
+				b.WriteString(fmt.Sprintf(", required client CN %q", s.ClientVerifyCN))
+			}
 		} else {
 			b.WriteString(", mutual TLS disabled")
 		}

--- a/http/service_tls_test.go
+++ b/http/service_tls_test.go
@@ -259,6 +259,97 @@ func Test_TLSServiceSecureMutual(t *testing.T) {
 	}
 }
 
+func Test_TLSServiceSecureMutualVerifyCN(t *testing.T) {
+	// Generate a CA cert and key.
+	caCertPEM, caKeyPEM, err := rtls.GenerateCACert(pkix.Name{CommonName: "ca.rqlite.io"}, time.Hour, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA cert: %s", err)
+	}
+
+	caCert, _ := pem.Decode(caCertPEM)
+	if caCert == nil {
+		t.Fatal("failed to decode certificate")
+	}
+
+	caKey, _ := pem.Decode(caKeyPEM)
+	if caKey == nil {
+		t.Fatal("failed to decode key")
+	}
+
+	parsedCACert, err := x509.ParseCertificate(caCert.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedCAKey, err := x509.ParsePKCS1PrivateKey(caKey.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Server cert.
+	certServer, keyServer, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "server.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("failed to generate server cert: %s", err)
+	}
+
+	// Two client certs signed by the CA, one allowed and one not.
+	certAllowed, keyAllowed, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "allowed.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("failed to generate allowed client cert: %s", err)
+	}
+	certDenied, keyDenied, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "denied.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("failed to generate denied client cert: %s", err)
+	}
+
+	m := &MockStore{}
+	c := &mockClusterService{}
+	s := New("127.0.0.1:0", m, c, proxy.New(m, c), nil)
+	s.CertFile = mustWriteTempFile(t, certServer)
+	s.KeyFile = mustWriteTempFile(t, keyServer)
+	s.CACertFile = mustWriteTempFile(t, caCertPEM)
+	s.BuildInfo = map[string]any{
+		"version": "the version",
+	}
+	s.ClientVerify = true
+	s.ClientVerifyCN = "allowed.rqlite.io"
+	if err := s.Start(); err != nil {
+		t.Fatalf("failed to start service")
+	}
+	defer s.Close()
+
+	url := fmt.Sprintf("https://%s", s.Addr().String())
+
+	newClient := func(certPEM, keyPEM []byte) *http.Client {
+		tlsConfig := &tls.Config{InsecureSkipVerify: false}
+		tlsConfig.RootCAs = x509.NewCertPool()
+		if ok := tlsConfig.RootCAs.AppendCertsFromPEM(caCertPEM); !ok {
+			t.Fatalf("failed to parse CA certificate(s)")
+		}
+		tlsConfig.Certificates = make([]tls.Certificate, 1)
+		tlsConfig.Certificates[0], err = tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatalf("failed to set X509 key pair %s", err)
+		}
+		return &http.Client{Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}}
+	}
+
+	// Client with the required CN should succeed.
+	resp, err := newClient(certAllowed, keyAllowed).Get(url)
+	if err != nil {
+		t.Fatalf("client with matching CN failed to make HTTP request: %s", err)
+	}
+	if v := resp.Header.Get("X-RQLITE-VERSION"); v != "the version" {
+		t.Fatalf("incorrect build version present in HTTP response header, got: %s", v)
+	}
+
+	// Client with a different CN, but signed by the same CA, must be rejected.
+	if _, err := newClient(certDenied, keyDenied).Get(url); err == nil {
+		t.Fatalf("client with non-matching CN was not rejected")
+	}
+}
+
 // mustWriteTempFile writes the given bytes to a temporary file, and returns the
 // path to the file. If there is an error, it panics. The file will be automatically
 // deleted when the test ends.

--- a/internal/rtls/config.go
+++ b/internal/rtls/config.go
@@ -12,6 +12,7 @@ import (
 const (
 	NoCACert     = ""
 	NoServerName = ""
+	NoVerifyCN   = ""
 )
 
 // MTLSState indicates whether mutual TLS is enabled or disabled.
@@ -74,8 +75,9 @@ func CreateClientConfigWithFunc(certFunc func() (*tls.Certificate, error), caCer
 // authenticate the server to the client. The caCertFile parameter is the path to the CA
 // certificate file, which the server will use to verify any certificate presented by the
 // client. If mtls is MTLSStateEnabled, the server will require the client to present a
-// valid certificate.
-func CreateServerConfig(certFile, keyFile, caCertFile string, mtls MTLSState) (*tls.Config, error) {
+// valid certificate. If verifyCN is non-empty, the client certificate's Subject Common
+// Name must match it exactly.
+func CreateServerConfig(certFile, keyFile, caCertFile string, mtls MTLSState, verifyCN string) (*tls.Config, error) {
 	var err error
 
 	config := createBaseTLSConfig(NoServerName, false)
@@ -90,6 +92,9 @@ func CreateServerConfig(certFile, keyFile, caCertFile string, mtls MTLSState) (*
 		}
 	}
 	config.ClientAuth = tls.ClientAuthType(mtls)
+	if verifyCN != "" {
+		setVerifyCN(config, verifyCN)
+	}
 	return config, nil
 }
 
@@ -97,8 +102,9 @@ func CreateServerConfig(certFile, keyFile, caCertFile string, mtls MTLSState) (*
 // parameter is a function that returns the server's certificate and key. The caCertFile
 // parameter is the path to the CA certificate file, which the server will use to verify
 // any certificate presented by the client. If mtls is MTLSStateEnabled, the server will
-// require the client to present a valid certificate.
-func CreateServerConfigWithFunc(certFunc func() (*tls.Certificate, error), caCertFile string, mtls MTLSState) (*tls.Config, error) {
+// require the client to present a valid certificate. If verifyCN is non-empty, the
+// client certificate's Subject Common Name must match it exactly.
+func CreateServerConfigWithFunc(certFunc func() (*tls.Certificate, error), caCertFile string, mtls MTLSState, verifyCN string) (*tls.Config, error) {
 	config := createBaseTLSConfig(NoServerName, false)
 	config.GetCertificate = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		return certFunc()
@@ -109,7 +115,24 @@ func CreateServerConfigWithFunc(certFunc func() (*tls.Certificate, error), caCer
 		}
 	}
 	config.ClientAuth = tls.ClientAuthType(mtls)
+	if verifyCN != "" {
+		setVerifyCN(config, verifyCN)
+	}
 	return config, nil
+}
+
+// setVerifyCN installs a VerifyPeerCertificate callback that requires the
+// leaf client certificate's Subject Common Name to match verifyCN exactly.
+// If verifyCN is empty, no callback is installed.
+func setVerifyCN(config *tls.Config, verifyCN string) {
+	config.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		for _, chain := range verifiedChains {
+			if len(chain) > 0 && chain[0].Subject.CommonName == verifyCN {
+				return nil
+			}
+		}
+		return fmt.Errorf("client did not provide any valid certificate that matches CN %q", verifyCN)
+	}
 }
 
 func createBaseTLSConfig(serverName string, noverify bool) *tls.Config {

--- a/internal/rtls/config_test.go
+++ b/internal/rtls/config_test.go
@@ -19,7 +19,7 @@ func Test_CreateServerConfig(t *testing.T) {
 	keyFile := mustWriteTempFile(t, keyPEM)
 
 	// create a server config with no client verification
-	config, err := CreateServerConfig(certFile, keyFile, NoCACert, MTLSStateDisabled)
+	config, err := CreateServerConfig(certFile, keyFile, NoCACert, MTLSStateDisabled, NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create server config: %v", err)
 	}
@@ -46,7 +46,7 @@ func Test_CreateServerConfig(t *testing.T) {
 	}
 
 	// create a server config with client verification
-	config, err = CreateServerConfig(certFile, keyFile, NoCACert, MTLSStateEnabled)
+	config, err = CreateServerConfig(certFile, keyFile, NoCACert, MTLSStateEnabled, NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create server config: %v", err)
 	}
@@ -64,7 +64,7 @@ func Test_CreateServerConfigWithFunc(t *testing.T) {
 	certFile := mustWriteTempFile(t, certPEM)
 	keyFile := mustWriteTempFile(t, keyPEM)
 
-	config, err := CreateServerConfigWithFunc(mustCreateGetCertFunc(t, certFile, keyFile), NoCACert, MTLSStateDisabled)
+	config, err := CreateServerConfigWithFunc(mustCreateGetCertFunc(t, certFile, keyFile), NoCACert, MTLSStateDisabled, NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create server config: %v", err)
 	}
@@ -94,7 +94,7 @@ func Test_CreateServerConfig_CA(t *testing.T) {
 	}
 	caCertFile := mustWriteTempFile(t, caCertPEM)
 
-	config, err := CreateServerConfig(certFile, keyFile, caCertFile, MTLSStateDisabled)
+	config, err := CreateServerConfig(certFile, keyFile, caCertFile, MTLSStateDisabled, NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create server config: %v", err)
 	}
@@ -103,7 +103,7 @@ func Test_CreateServerConfig_CA(t *testing.T) {
 		t.Fatalf("expected root CA, got nil")
 	}
 
-	configF, err := CreateServerConfigWithFunc(nil, caCertFile, MTLSStateDisabled)
+	configF, err := CreateServerConfigWithFunc(nil, caCertFile, MTLSStateDisabled, NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create server config: %v", err)
 	}

--- a/tcp/dialer_test.go
+++ b/tcp/dialer_test.go
@@ -185,7 +185,7 @@ func mustNewEchoServerTLS_ExampleDotCom() (*echoServer, string, string) {
 	cert := x509.CertExampleDotComFile("")
 	key := x509.KeyExampleDotComFile("")
 
-	tlsConfig, err := rtls.CreateServerConfig(cert, key, rtls.NoCACert, rtls.MTLSStateDisabled)
+	tlsConfig, err := rtls.CreateServerConfig(cert, key, rtls.NoCACert, rtls.MTLSStateDisabled, rtls.NoVerifyCN)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create TLS config: %s", err.Error()))
 	}

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -109,18 +109,20 @@ func NewMux(ln net.Listener, adv net.Addr) (*Mux, error) {
 // using TLS. If adv is nil, then the addr of ln is used. The server will not
 // require clients to present a valid certificate since mutual TLS is not enabled.
 func NewTLSMux(ln net.Listener, adv net.Addr, cert, key string) (*Mux, error) {
-	return newTLSMux(ln, adv, cert, key, "", false)
+	return newTLSMux(ln, adv, cert, key, "", false, rtls.NoVerifyCN)
 }
 
 // NewMutualTLSMux returns a new instance of Mux for ln, and encrypts all traffic
 // using TLS. The server will also require clients to present a valid certificate.
 // If caCert is not empty, that CA certificate will be added to the pool of CAs.
-func NewMutualTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert string) (*Mux, error) {
-	return newTLSMux(ln, adv, cert, key, caCert, true)
+// If verifyCN is not empty, the connecting peer's leaf certificate must have a
+// Subject Common Name equal to verifyCN.
+func NewMutualTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert, verifyCN string) (*Mux, error) {
+	return newTLSMux(ln, adv, cert, key, caCert, true, verifyCN)
 }
 
 // newTLSMux is an internal helper to create a TLS Mux.
-func newTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert string, mutual bool) (*Mux, error) {
+func newTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert string, mutual bool, verifyCN string) (*Mux, error) {
 	mux, err := NewMux(ln, adv)
 	if err != nil {
 		return nil, err
@@ -140,7 +142,7 @@ func newTLSMux(ln net.Listener, adv net.Addr, cert, key, caCert string, mutual b
 		stats.Add(numTLSCertFetched, 1)
 		return mux.certReloader.GetCertificate()
 	}
-	mux.tlsConfig, err = rtls.CreateServerConfigWithFunc(getCertFunc, caCert, mtlsState)
+	mux.tlsConfig, err = rtls.CreateServerConfigWithFunc(getCertFunc, caCert, mtlsState, verifyCN)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create TLS config: %s", err)
 	}

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -3,6 +3,9 @@ package tcp
 import (
 	"bytes"
 	"crypto/tls"
+	cryptox509 "crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
 	"log"
 	"net"
@@ -13,6 +16,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/rqlite/rqlite/v10/internal/rtls"
 	"github.com/rqlite/rqlite/v10/testdata/x509"
 )
 
@@ -249,7 +253,7 @@ func TestMutualTLSMux(t *testing.T) {
 	caCert := x509.CertMyCAFile("")
 	defer os.Remove(caCert)
 
-	mux, err := NewMutualTLSMux(tcpListener, nil, cert, key, caCert)
+	mux, err := NewMutualTLSMux(tcpListener, nil, cert, key, caCert, rtls.NoVerifyCN)
 	if err != nil {
 		t.Fatalf("failed to create mutual TLS mux: %s", err.Error())
 	}
@@ -276,6 +280,102 @@ func TestMutualTLSMux(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "certificate required") {
 		t.Fatalf("expected error to reference missing client certificate, got %s", err.Error())
+	}
+}
+
+func TestMutualTLSMuxVerifyCN(t *testing.T) {
+	// Generate a CA and three CA-signed certs (server, allowed client, denied client).
+	caCertPEM, caKeyPEM, err := rtls.GenerateCACert(pkix.Name{CommonName: "ca.rqlite.io"}, time.Hour, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA cert: %s", err)
+	}
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	parsedCACert, err := cryptox509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %s", err)
+	}
+	parsedCAKey, err := cryptox509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA key: %s", err)
+	}
+
+	serverIP := net.ParseIP("127.0.0.1")
+	serverCertPEM, serverKeyPEM, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "server.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, serverIP)
+	if err != nil {
+		t.Fatalf("failed to generate server cert: %s", err)
+	}
+	allowedPEM, allowedKeyPEM, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "allowed.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, serverIP)
+	if err != nil {
+		t.Fatalf("failed to generate allowed client cert: %s", err)
+	}
+	deniedPEM, deniedKeyPEM, err := rtls.GenerateCertIPSAN(pkix.Name{CommonName: "denied.rqlite.io"}, time.Hour, 2048, parsedCACert, parsedCAKey, serverIP)
+	if err != nil {
+		t.Fatalf("failed to generate denied client cert: %s", err)
+	}
+
+	mustWrite := func(b []byte) string {
+		f, err := os.CreateTemp(t.TempDir(), "rqlite-mux-cn")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %s", err)
+		}
+		if _, err := f.Write(b); err != nil {
+			t.Fatalf("failed to write temp file: %s", err)
+		}
+		f.Close()
+		return f.Name()
+	}
+
+	tcpListener := mustTCPListener("127.0.0.1:0")
+	defer tcpListener.Close()
+
+	mux, err := NewMutualTLSMux(tcpListener, nil, mustWrite(serverCertPEM), mustWrite(serverKeyPEM), mustWrite(caCertPEM), "allowed.rqlite.io")
+	if err != nil {
+		t.Fatalf("failed to create mutual TLS mux: %s", err.Error())
+	}
+	defer mux.Close()
+	go mux.Serve()
+
+	rootPool := cryptox509.NewCertPool()
+	if !rootPool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatalf("failed to add CA cert to pool")
+	}
+
+	dial := func(certPEM, keyPEM []byte) (*tls.Conn, error) {
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatalf("failed to build keypair: %s", err)
+		}
+		return tls.Dial("tcp", tcpListener.Addr().String(), &tls.Config{
+			RootCAs:      rootPool,
+			Certificates: []tls.Certificate{cert},
+			ServerName:   "127.0.0.1",
+		})
+	}
+
+	// Allowed CN — handshake should succeed and the connection should be usable.
+	conn, err := dial(allowedPEM, allowedKeyPEM)
+	if err != nil {
+		t.Fatalf("expected handshake with matching CN to succeed, got error: %s", err)
+	}
+	if err := conn.Handshake(); err != nil {
+		t.Fatalf("explicit handshake with matching CN failed: %s", err)
+	}
+	conn.Close()
+
+	// Denied CN — server must reject. With TLS 1.3 the client's Dial may return
+	// nil; a subsequent Read surfaces the server's alert.
+	conn, err = dial(deniedPEM, deniedKeyPEM)
+	if err == nil {
+		var b [1]byte
+		_, err = conn.Read(b[:])
+		conn.Close()
+	}
+	if err == nil {
+		t.Fatalf("expected handshake with non-matching CN to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad certificate") && !strings.Contains(err.Error(), "did not provide any valid certificate that matches CN") {
+		t.Fatalf("expected CN mismatch error, got: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
RQLite does not currently have a way to limit what certificates signed by the CA are accepted for Mutual TLS. For simplicity on a Kubernetes cluster I'd want to have a single private CA within a namespace that will issue certificates for the application talking to RQLite as well as all the inter-node communication done by RQLite itself. However, in current state all certificates, including unrelated certificates used by the application for other purposes, would be accepted by RQLite for any purpose given they share the same CA.

For transparency, this commit has been fully generated by Claude with a bit of back-and-forth to get the desired results and some manual tweaks for coding style. Saw it easier to implement the desired feature for discussion. I have also not tested this yet so I wouldn't be comfortable merging before I verify it does what it should outside unit tests.

Additionally, if desired, the CN could either be a comma separated list or a regex to allow some flexibility.