### PR TITLE
fix: add max-redirects limit to cluster Join

### DIFF
--- a/cluster/client.go
+++ b/cluster/client.go
@@ -513,7 +513,8 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	for {
+	const maxRedirects = 10
+	for i := 0; i < maxRedirects; i++ {
 		conn, err := c.dial(nodeAddr)
 		if err != nil {
 			return err
@@ -558,6 +559,7 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 		}
 		return nil
 	}
+	return errors.New("max redirects exceeded")
 }
 
 // BroadcastHWM performs a broadcast to all specified nodes.

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -27,6 +27,7 @@ const (
 	maxPoolCapacity   = 64
 	defaultMaxRetries = 0
 	noRetries         = 0
+	maxRedirects      = 10
 
 	protoBufferLengthSize = 8
 )
@@ -513,8 +514,10 @@ func (c *Client) Join(ctx context.Context, jr *command.JoinRequest, nodeAddr str
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	const maxRedirects = 10
 	for i := 0; i < maxRedirects; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		conn, err := c.dial(nodeAddr)
 		if err != nil {
 			return err

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -340,6 +340,163 @@ func Test_ClientJoinNode(t *testing.T) {
 	}
 }
 
+func Test_ClientJoinNode_MaxRedirectsExceeded(t *testing.T) {
+	// Simulate a cluster where every node always redirects to another node,
+	// creating an infinite redirect loop. The client should stop after
+	// maxRedirects and return an error.
+	var redirectCount int
+	var mu sync.Mutex
+
+	srv := servicetest.NewService()
+	srv.Handler = func(conn net.Conn) {
+		mu.Lock()
+		redirectCount++
+		mu.Unlock()
+
+		c := readCommand(conn)
+		if c == nil {
+			return
+		}
+		if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+			t.Fatalf("unexpected command type: %d", c.Type)
+		}
+
+		// Always respond with "not leader" and a leader address to redirect to.
+		p, err := pb.Marshal(&proto.CommandJoinResponse{
+			Error:  "not leader",
+			Leader: srv.Addr(), // redirect back to same server to simulate loop
+		})
+		if err != nil {
+			conn.Close()
+			return
+		}
+		writeBytesWithLength(conn, p)
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := NewClient(&simpleDialer{}, 0)
+	req := &command.JoinRequest{
+		Address: "test-node-addr",
+	}
+	err := c.Join(context.Background(), req, srv.Addr(), nil, time.Second)
+	if err == nil {
+		t.Fatal("expected error when max redirects exceeded")
+	}
+	if !strings.Contains(err.Error(), "max redirects exceeded") {
+		t.Fatalf("expected 'max redirects exceeded' error, got: %s", err)
+	}
+
+	mu.Lock()
+	count := redirectCount
+	mu.Unlock()
+	if count != maxRedirects {
+		t.Fatalf("expected %d redirect attempts, got %d", maxRedirects, count)
+	}
+}
+
+func Test_ClientJoinNode_ContextCanceledDuringRedirect(t *testing.T) {
+	// Simulate a redirect loop and cancel the context partway through.
+	// The context check happens at the top of each loop iteration, before
+	// dialing. Because the local test server responds instantly, we need
+	// to cancel the context before calling Join to guarantee the
+	// cancellation is observed before the loop exhausts maxRedirects.
+	srv := servicetest.NewService()
+	srv.Handler = func(conn net.Conn) {
+		c := readCommand(conn)
+		if c == nil {
+			return
+		}
+		if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+			t.Fatalf("unexpected command type: %d", c.Type)
+		}
+
+		p, err := pb.Marshal(&proto.CommandJoinResponse{
+			Error:  "not leader",
+			Leader: srv.Addr(),
+		})
+		if err != nil {
+			conn.Close()
+			return
+		}
+		writeBytesWithLength(conn, p)
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := NewClient(&simpleDialer{}, 0)
+	req := &command.JoinRequest{
+		Address: "test-node-addr",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so the first iteration sees it
+
+	err := c.Join(ctx, req, srv.Addr(), nil, time.Second)
+	if err == nil {
+		t.Fatal("expected error when context is canceled")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected context canceled error, got: %s", err)
+	}
+}
+
+func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
+	// First response redirects, second response succeeds.
+	var attempt int
+	var mu sync.Mutex
+
+	srv := servicetest.NewService()
+	srv.Handler = func(conn net.Conn) {
+		mu.Lock()
+		attempt++
+		n := attempt
+		mu.Unlock()
+
+		c := readCommand(conn)
+		if c == nil {
+			return
+		}
+		if c.Type != proto.Command_COMMAND_TYPE_JOIN {
+			t.Fatalf("unexpected command type: %d", c.Type)
+		}
+
+		var p []byte
+		var err error
+		if n == 1 {
+			p, err = pb.Marshal(&proto.CommandJoinResponse{
+				Error:  "not leader",
+				Leader: srv.Addr(),
+			})
+		} else {
+			p, err = pb.Marshal(&proto.CommandJoinResponse{})
+		}
+		if err != nil {
+			conn.Close()
+			return
+		}
+		writeBytesWithLength(conn, p)
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := NewClient(&simpleDialer{}, 0)
+	req := &command.JoinRequest{
+		Address: "test-node-addr",
+	}
+	err := c.Join(context.Background(), req, srv.Addr(), nil, time.Second)
+	if err != nil {
+		t.Fatalf("expected success after redirect, got: %s", err)
+	}
+
+	mu.Lock()
+	finalAttempt := attempt
+	mu.Unlock()
+	if finalAttempt != 2 {
+		t.Fatalf("expected 2 attempts, got %d", finalAttempt)
+	}
+}
+
 func Test_ClientRetry_SuccessFirstAttempt(t *testing.T) {
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -344,14 +345,11 @@ func Test_ClientJoinNode_MaxRedirectsExceeded(t *testing.T) {
 	// Simulate a cluster where every node always redirects to another node,
 	// creating an infinite redirect loop. The client should stop after
 	// maxRedirects and return an error.
-	var redirectCount int
-	var mu sync.Mutex
+	var redirectCount atomic.Int32
 
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
-		mu.Lock()
-		redirectCount++
-		mu.Unlock()
+		redirectCount.Add(1)
 
 		c := readCommand(conn)
 		if c == nil {
@@ -387,11 +385,8 @@ func Test_ClientJoinNode_MaxRedirectsExceeded(t *testing.T) {
 		t.Fatalf("expected 'max redirects exceeded' error, got: %s", err)
 	}
 
-	mu.Lock()
-	count := redirectCount
-	mu.Unlock()
-	if count != maxRedirects {
-		t.Fatalf("expected %d redirect attempts, got %d", maxRedirects, count)
+	if redirectCount.Load() != int32(maxRedirects) {
+		t.Fatalf("expected %d redirect attempts, got %d", maxRedirects, redirectCount.Load())
 	}
 }
 
@@ -443,15 +438,11 @@ func Test_ClientJoinNode_ContextCanceledDuringRedirect(t *testing.T) {
 
 func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 	// First response redirects, second response succeeds.
-	var numAttempts int
-	var mu sync.Mutex
+	var numAttempts atomic.Int32
 
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
-		mu.Lock()
-		numAttempts++
-		n := numAttempts
-		mu.Unlock()
+		numAttempts.Add(1)
 
 		c := readCommand(conn)
 		if c == nil {
@@ -463,7 +454,7 @@ func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 
 		var p []byte
 		var err error
-		if n == 1 {
+		if numAttempts.Load() == 1 {
 			p, err = pb.Marshal(&proto.CommandJoinResponse{
 				Error:  "not leader",
 				Leader: srv.Addr(),
@@ -489,11 +480,8 @@ func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 		t.Fatalf("expected success after redirect, got: %s", err)
 	}
 
-	mu.Lock()
-	final := numAttempts
-	mu.Unlock()
-	if final != 2 {
-		t.Fatalf("expected 2 attempts, got %d", final)
+	if numAttempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", numAttempts.Load())
 	}
 }
 

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -345,11 +344,11 @@ func Test_ClientJoinNode_MaxRedirectsExceeded(t *testing.T) {
 	// Simulate a cluster where every node always redirects to another node,
 	// creating an infinite redirect loop. The client should stop after
 	// maxRedirects and return an error.
-	var redirectCount atomic.Int32
+	redirects := make(chan struct{}, maxRedirects)
 
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
-		redirectCount.Add(1)
+		redirects <- struct{}{}
 
 		c := readCommand(conn)
 		if c == nil {
@@ -385,8 +384,13 @@ func Test_ClientJoinNode_MaxRedirectsExceeded(t *testing.T) {
 		t.Fatalf("expected 'max redirects exceeded' error, got: %s", err)
 	}
 
-	if redirectCount.Load() != int32(maxRedirects) {
-		t.Fatalf("expected %d redirect attempts, got %d", maxRedirects, redirectCount.Load())
+	close(redirects)
+	count := 0
+	for range redirects {
+		count++
+	}
+	if count != maxRedirects {
+		t.Fatalf("expected %d redirect attempts, got %d", maxRedirects, count)
 	}
 }
 
@@ -438,11 +442,11 @@ func Test_ClientJoinNode_ContextCanceledDuringRedirect(t *testing.T) {
 
 func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 	// First response redirects, second response succeeds.
-	var numAttempts atomic.Int32
+	attempts := make(chan struct{}, 2)
 
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
-		numAttempts.Add(1)
+		attempts <- struct{}{}
 
 		c := readCommand(conn)
 		if c == nil {
@@ -454,7 +458,7 @@ func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 
 		var p []byte
 		var err error
-		if numAttempts.Load() == 1 {
+		if len(attempts) == 1 {
 			p, err = pb.Marshal(&proto.CommandJoinResponse{
 				Error:  "not leader",
 				Leader: srv.Addr(),
@@ -480,8 +484,13 @@ func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 		t.Fatalf("expected success after redirect, got: %s", err)
 	}
 
-	if numAttempts.Load() != 2 {
-		t.Fatalf("expected 2 attempts, got %d", numAttempts.Load())
+	close(attempts)
+	count := 0
+	for range attempts {
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 attempts, got %d", count)
 	}
 }
 

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -443,14 +443,14 @@ func Test_ClientJoinNode_ContextCanceledDuringRedirect(t *testing.T) {
 
 func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 	// First response redirects, second response succeeds.
-	var attempt int
+	var numAttempts int
 	var mu sync.Mutex
 
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
 		mu.Lock()
-		attempt++
-		n := attempt
+		numAttempts++
+		n := numAttempts
 		mu.Unlock()
 
 		c := readCommand(conn)
@@ -490,10 +490,10 @@ func Test_ClientJoinNode_SuccessAfterRedirect(t *testing.T) {
 	}
 
 	mu.Lock()
-	finalAttempt := attempt
+	final := numAttempts
 	mu.Unlock()
-	if finalAttempt != 2 {
-		t.Fatalf("expected 2 attempts, got %d", finalAttempt)
+	if final != 2 {
+		t.Fatalf("expected 2 attempts, got %d", final)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds a maximum redirect limit to the cluster `Join` method to prevent infinite loops when nodes redirect to each other.

## Changes
- Replaced the unbounded `for {}` loop with `for i := 0; i < maxRedirects; i++` where `maxRedirects = 10`
- Added `return errors.New("max redirects exceeded")` when the limit is reached

## Problem
As described in #2616, two nodes could redirect to each other indefinitely, causing the join process to hang forever.

## Testing
- `go test ./cluster/...` passes
- `go fmt` applied

Fixes #2616