### PR TITLE
cluster: add message size limit to prevent OOM

### DIFF
--- a/cluster/client.go
+++ b/cluster/client.go
@@ -29,6 +29,12 @@ const (
 	noRetries         = 0
 
 	protoBufferLengthSize = 8
+
+	// MaxMessageSize limits the size of a single protobuf message read from
+	// a network connection. This prevents a malicious peer from sending a
+	// very large size prefix that would cause an OOM when allocating the
+	// receive buffer. 64MB should be sufficient for normal operations.
+	MaxMessageSize = 64 * 1024 * 1024
 )
 
 // CreateRaftDialer creates a dialer for connecting to other nodes' Raft service. If the cert and
@@ -875,6 +881,9 @@ func readResponse(conn net.Conn, timeout time.Duration) (buf []byte, retErr erro
 		return nil, fmt.Errorf("read protobuf length: %w", err)
 	}
 	sz := binary.LittleEndian.Uint64(b[0:])
+	if sz > MaxMessageSize {
+		return nil, fmt.Errorf("message size %d exceeds maximum allowed %d", sz, MaxMessageSize)
+	}
 
 	// Read in the actual response.
 	p := make([]byte, sz)

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -704,7 +704,7 @@ func Test_ClientBroadcast_WithError(t *testing.T) {
 	}
 }
 
-func Test_readProtoResponse_OversizedMessage(t *testing.T) {
+func Test_ClientGetNodeMeta_OversizedResponse(t *testing.T) {
 	// Create a server that sends an oversized message length prefix.
 	srv := servicetest.NewService()
 	srv.Handler = func(conn net.Conn) {
@@ -725,7 +725,7 @@ func Test_readProtoResponse_OversizedMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient(&simpleDialer{}, time.Second)
-	_, err := c.GetNodeMeta(srv.Addr(), nil, time.Second, defaultMaxRetries)
+	_, err := c.GetNodeMeta(context.Background(), srv.Addr(), defaultMaxRetries, time.Second)
 	if err == nil {
 		t.Fatal("expected error for oversized message, got nil")
 	}

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -703,3 +703,33 @@ func Test_ClientBroadcast_WithError(t *testing.T) {
 		t.Fatalf("expected 'test error', got '%s'", resp.Error)
 	}
 }
+
+func Test_readProtoResponse_OversizedMessage(t *testing.T) {
+	// Create a server that sends an oversized message length prefix.
+	srv := servicetest.NewService()
+	srv.Handler = func(conn net.Conn) {
+		// Read and discard the incoming command.
+		b := make([]byte, protoBufferLengthSize)
+		io.ReadFull(conn, b)
+		sz := binary.LittleEndian.Uint64(b[0:])
+		p := make([]byte, sz)
+		io.ReadFull(conn, p)
+
+		// Send a response with an oversized length prefix.
+		// MaxMessageSize is 64MB; claim the message is 1GB.
+		var sizePrefix [8]byte
+		binary.LittleEndian.PutUint64(sizePrefix[:], 1024*1024*1024)
+		conn.Write(sizePrefix[:])
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := NewClient(&simpleDialer{}, time.Second)
+	_, err := c.GetNodeMeta(srv.Addr(), nil, time.Second, defaultMaxRetries)
+	if err == nil {
+		t.Fatal("expected error for oversized message, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected 'exceeds maximum' error, got: %s", err.Error())
+	}
+}

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -321,6 +321,9 @@ func (s *Service) handleConn(conn net.Conn) {
 			return
 		}
 		sz := binary.LittleEndian.Uint64(b[0:])
+		if sz > MaxMessageSize {
+			return
+		}
 
 		p := make([]byte, sz)
 		if s.connTimeout > 0 {


### PR DESCRIPTION
I noticed that both the cluster client (\client.go:877\) and service (\service.go:323\) read a length prefix from the network before allocating a receive buffer. There's no upper bound check, so a malicious peer could send an extremely large size value, triggering an OOM when the allocation happens.

This patch adds a \MaxMessageSize\ constant (64MB) and validates the received size before allocating. The client now returns an error with a descriptive message; the service silently drops the connection, consistent with how it handles other read errors.

I also added a test that verifies the client properly rejects oversized messages.

Fixes #2619