### PR TITLE
Service connection limiter

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/binary"
+	"errors"
 	"expvar"
 	"fmt"
 	"io"
@@ -19,11 +20,17 @@ import (
 	"github.com/rqlite/rqlite/v10/auth"
 	"github.com/rqlite/rqlite/v10/cluster/proto"
 	command "github.com/rqlite/rqlite/v10/command/proto"
+	"github.com/rqlite/rqlite/v10/internal/rsync"
 	pb "google.golang.org/protobuf/proto"
 )
 
-// stats captures stats for the Cluster service.
-var stats *expvar.Map
+var (
+	// stats captures stats for the Cluster service.
+	stats *expvar.Map
+
+	// ErrServiceOpen is returned when the service is already open.
+	ErrServiceOpen = errors.New("service already open")
+)
 
 const (
 	numGetNodeAPIRequest   = "num_get_node_api_req"
@@ -39,6 +46,7 @@ const (
 	numStepdownRequest     = "num_stepdown_req"
 	numBroadcastHWMRequest = "num_broadcast_hwm_req"
 	numHWMUpdateDropped    = "num_hwm_update_dropped"
+	numConnRejected        = "num_conn_rejected"
 
 	numClientRetries            = "num_client_retries"
 	numGetNodeAPIRequestRetries = "num_get_node_api_req_retries"
@@ -66,6 +74,10 @@ const (
 	// connection is closed, preventing stalled clients from holding
 	// goroutines indefinitely.
 	connReadTimeout = 30 * time.Second
+
+	// maxConcurrentConns bounds the number of connections the service handles
+	// concurrently, preventing connection floods from spawning unbounded goroutines.
+	maxConcurrentConns = 1024
 )
 
 func init() {
@@ -97,6 +109,7 @@ func ResetStats() {
 	stats.Add(numClientReadTimeouts, 0)
 	stats.Add(numClientWriteTimeouts, 0)
 	stats.Add(numClientForceNewConn, 0)
+	stats.Add(numConnRejected, 0)
 }
 
 // Dialer is the interface dialers must implement.
@@ -165,13 +178,20 @@ type Service struct {
 	credentialStore CredentialStore
 
 	mu      sync.RWMutex
-	https   bool   // Serving HTTPS?
-	apiAddr string // host:port this node serves the HTTP API.
-	version string // Version of software this node is running.
+	https   bool              // Serving HTTPS?
+	apiAddr string            // host:port this node serves the HTTP API.
+	version string            // Version of software this node is running.
+	open    *rsync.AtomicBool // Tracks whether the service is currently open.
 
 	// connTimeout is the maximum time to wait for data on a
 	// connection. Must be set before Open is called.
 	connTimeout time.Duration
+
+	// connLimit is the maximum number of concurrent service connections.
+	connLimit int
+
+	// connLimiterCh limits the number of in-service connections.
+	connLimiterCh chan struct{}
 
 	hwmMu      sync.RWMutex
 	hwmUpdateC chan<- uint64 // Channel for HWM updates
@@ -189,11 +209,20 @@ func New(ln net.Listener, db Database, m Manager, credentialStore CredentialStor
 		logger:          log.New(os.Stderr, "[cluster] ", log.LstdFlags),
 		credentialStore: credentialStore,
 		connTimeout:     connReadTimeout,
+		connLimit:       maxConcurrentConns,
+		open:            rsync.NewAtomicBool(),
 	}
 }
 
 // Open opens the Service.
 func (s *Service) Open() error {
+	if s.open.Is() {
+		return ErrServiceOpen
+	}
+
+	s.connLimiterCh = make(chan struct{}, s.connLimit)
+	s.open.Set()
+
 	go s.serve()
 	s.logger.Println("service listening on", s.addr)
 	return nil
@@ -201,8 +230,11 @@ func (s *Service) Open() error {
 
 // Close closes the service.
 func (s *Service) Close() error {
-	s.ln.Close()
-	return nil
+	err := s.ln.Close()
+	if err == nil {
+		s.open.Unset()
+	}
+	return err
 }
 
 // RegisterHWMUpdate registers a channel to receive highwater mark update requests.
@@ -275,6 +307,21 @@ func (s *Service) Stats() (map[string]any, error) {
 	return st, nil
 }
 
+// SetConnectionLimit sets the maximum number of concurrent service connections.
+// It must be called before Open. Non-positive values use the default limit.
+func (s *Service) SetConnectionLimit(n int) error {
+	if s.open.Is() {
+		return ErrServiceOpen
+	}
+
+	if n <= 0 {
+		n = maxConcurrentConns
+	}
+
+	s.connLimit = n
+	return nil
+}
+
 func (s *Service) serve() error {
 	for {
 		conn, err := s.ln.Accept()
@@ -282,7 +329,16 @@ func (s *Service) serve() error {
 			return err
 		}
 
-		go s.handleConn(conn)
+		select {
+		case s.connLimiterCh <- struct{}{}:
+			go func() {
+				defer func() { <-s.connLimiterCh }()
+				s.handleConn(conn)
+			}()
+		default:
+			_ = conn.Close()
+			stats.Add(numConnRejected, 1)
+		}
 	}
 }
 

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -536,6 +537,100 @@ func Test_ServiceClosesIdleConnection(t *testing.T) {
 	_, err = conn.Read(one)
 	if err != io.EOF {
 		t.Fatalf("expected io.EOF, got: %v", err)
+	}
+}
+
+func Test_ServiceSetConnectionLimitOpen(t *testing.T) {
+	ml := mustNewMockTransport()
+	s := New(ml, mustNewMockDatabase(), mustNewMockManager(), mustNewMockCredentialStore())
+
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to open cluster service")
+	}
+	defer s.Close()
+
+	if err := s.SetConnectionLimit(1); !errors.Is(err, ErrServiceOpen) {
+		t.Fatalf("expected ErrServiceOpen, got: %v", err)
+	}
+}
+
+func Test_ServiceConnLimiterRejectAndRelease(t *testing.T) {
+	ml := mustNewMockTransport()
+	s := New(ml, mustNewMockDatabase(), mustNewMockManager(), mustNewMockCredentialStore())
+	if err := s.SetConnectionLimit(1); err != nil {
+		t.Fatalf("failed to set connection limit: %s", err)
+	}
+
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to open cluster service")
+	}
+	defer s.Close()
+
+	md := &mockDialer{Dialer: ml}
+	t.Cleanup(md.CloseAll)
+
+	c1 := NewClient(md, 30*time.Second)
+	_, err := c1.GetNodeMeta(context.Background(), s.Addr(), noRetries, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to get node metadata on first connection: %s", err)
+	}
+
+	// The first client's pooled connection remains open and holds the limiter slot.
+	c2 := NewClient(md, 30*time.Second)
+	_, err = c2.GetNodeMeta(context.Background(), s.Addr(), noRetries, 500*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected request on rejected connection to fail")
+	}
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+		t.Fatalf("expected connection to be rejected without timing out, got: %v", err)
+	}
+
+	// Releasing the idle connection should free its limiter slot.
+	if err := md.CloseConn(0); err != nil {
+		t.Fatalf("failed to close first connection: %s", err)
+	}
+
+	// A new client request should be accepted once capacity is available again.
+	c3 := NewClient(md, 30*time.Second)
+	_, err = c3.GetNodeMeta(context.Background(), s.Addr(), noRetries, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to get node metadata after release: %s", err)
+	}
+}
+
+type mockDialer struct {
+	Dialer
+	mu    sync.Mutex
+	conns []net.Conn
+}
+
+func (d *mockDialer) Dial(address string, timeout time.Duration) (net.Conn, error) {
+	conn, err := d.Dialer.Dial(address, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	d.mu.Lock()
+	d.conns = append(d.conns, conn)
+	d.mu.Unlock()
+
+	return conn, nil
+}
+
+func (d *mockDialer) CloseConn(index int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if index < 0 || index >= len(d.conns) {
+		return fmt.Errorf("connection %d not tracked", index)
+	}
+	return d.conns[index].Close()
+}
+
+func (d *mockDialer) CloseAll() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, conn := range d.conns {
+		_ = conn.Close()
 	}
 }
 


### PR DESCRIPTION
Hi @otoolep,

I added a connection limiter to the cluster service, along with a test covering rejection when the limiter is full and accepting new connections again once a slot is released.
I set `maxConcurrentConns` to `1024` for now. My reasoning was that this should be well above normal cluster traffic, while still putting a hard cap on goroutines and per-connection resources during a flood.
Does this default look reasonable to you, or would you rather use a different value or make it configurable?

Fixes #2617