### PR TITLE
auto/aws: set RequestChecksumCalculationWhenRequired for S3-compatible stores

### DIFF
--- a/auto/aws/s3.go
+++ b/auto/aws/s3.go
@@ -58,6 +58,7 @@ func NewS3Client(endpoint, region, accessKey, secretKey, bucket, key string, opt
 	// Load the default config
 	cfg, err := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion(region),
+		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SDK config, %v", err)

--- a/auto/aws/s3_test.go
+++ b/auto/aws/s3_test.go
@@ -43,6 +43,38 @@ func Test_NewS3Client(t *testing.T) {
 	}
 }
 
+func Test_S3Client_RequestChecksumCalculation(t *testing.T) {
+	// S3-compatible endpoint should use WhenRequired
+	c, err := NewS3Client("s3.custom-compatible.com", "region1", "access", "secret", "bucket2", "key3", noForcePathStyleOptions())
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
+	if c.s3.Options().RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		t.Fatalf("expected RequestChecksumCalculation to be %v, got %v",
+			aws.RequestChecksumCalculationWhenRequired, c.s3.Options().RequestChecksumCalculation)
+	}
+
+	// Native AWS endpoint should also use WhenRequired
+	c, err = NewS3Client("s3.amazonaws.com", "region1", "access", "secret", "bucket2", "key3", noForcePathStyleOptions())
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
+	if c.s3.Options().RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		t.Fatalf("expected RequestChecksumCalculation to be %v, got %v",
+			aws.RequestChecksumCalculationWhenRequired, c.s3.Options().RequestChecksumCalculation)
+	}
+
+	// nil opts should also use WhenRequired
+	c, err = NewS3Client("", "region1", "access", "secret", "bucket2", "key3", nil)
+	if err != nil {
+		t.Fatalf("error while creating aws S3 client: %v", err)
+	}
+	if c.s3.Options().RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		t.Fatalf("expected RequestChecksumCalculation to be %v, got %v",
+			aws.RequestChecksumCalculationWhenRequired, c.s3.Options().RequestChecksumCalculation)
+	}
+}
+
 func Test_S3Client_String(t *testing.T) {
 	// Test native S3 with implicit endpoint
 	c, err := NewS3Client("", "region1", "access", "secret", "bucket2", "key3", noForcePathStyleOptions())


### PR DESCRIPTION
## Problem

Since AWS SDK v2 S3 module v1.73.0 (January 2025), all `PutObject` requests automatically include a CRC32 checksum via the `x-amz-content-sha256` header. This breaks compatibility with S3-compatible storage providers (MinIO, Civo, Cloudflare R2, OVH, etc.) that don't handle this header, returning `XAmzContentSHA256Mismatch`.

## Fix

Add `config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired)` to the SDK config in `auto/aws/s3.go`. This tells the SDK to only compute checksums when the S3 operation requires one, not on every `PutObject`/`UploadPart`.

This is the same workaround adopted by Velero, Terraform Enterprise, BOSH, and others.

## Testing

Added `Test_S3Client_RequestChecksumCalculation` which verifies the setting is correctly applied for:
- S3-compatible (non-AWS) endpoints
- Native AWS endpoints
- `nil` opts

Closes #2699