### PR TITLE
Do the faster Quick check after snapshot reap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v10.2.5 (unreleased)
+### Implementation changes and bug fixes
+- [PR #2702](https://github.com/rqlite/rqlite/pull/2702): Perform a Quick Integrity check after reaping snapshots, not Full.
+
 ## v10.2.4 (June 21st 2026)
 ### Implementation changes and bug fixes
 - [PR #2700](https://github.com/rqlite/rqlite/pull/2700): Unit test Snapshot Store `Verify`.

--- a/db/db.go
+++ b/db/db.go
@@ -949,14 +949,14 @@ func (db *DB) IntegrityCheck(mode IntegrityCheckMode, maxIssues int) (IntegrityR
 	return IntegrityResult{OK: false, Issues: issues}, nil
 }
 
-// VerifyIntegrity runs a full PRAGMA integrity_check that stops after the
-// first problem. It is shorthand for IntegrityCheck(IntegrityCheckFull, 1)
-// for callers that only need a yes/no answer.
+// VerifyIntegrity runs a PRAGMA quick_check that stops after the first problem.
+// It is shorthand for IntegrityCheck(IntegrityCheckQuick, 1) for callers that only
+// need a yes/no answer.
 //
 // If IntegrityResult.OK is false and err is nil this function guarantees
 // that res.Issues will contain exactly 1 issue.
 func (db *DB) VerifyIntegrity() (IntegrityResult, error) {
-	res, err := db.IntegrityCheck(IntegrityCheckFull, 1)
+	res, err := db.IntegrityCheck(IntegrityCheckQuick, 1)
 	if err != nil {
 		return IntegrityResult{}, err
 	}


### PR DESCRIPTION
For continual automated checking let's go with the quicker version. Users can always run a full check if they wish.