### PR TITLE
Remove explicit DB-level read-only check from pure query path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Implementation changes and bug fixes
 - [PR #2706](https://github.com/rqlite/rqlite/pull/2706): Fixes for minor issues in data handling at the `db` layer.
 - [PR #2707](https://github.com/rqlite/rqlite/pull/2707): Fix minor resource lifecycle issues in the `db` layer.
+- [PR #2708](https://github.com/rqlite/rqlite/pull/2708): Remove explicit database-level read-only check from the pure Query path.
 
 ## v10.2.6 (July 4th 2026)
 ### Implementation changes and bug fixes

--- a/db/db.go
+++ b/db/db.go
@@ -1382,8 +1382,6 @@ func (db *DB) queryWithConn(ctx context.Context, req *command.Request, xTime boo
 
 		rows, err = db.queryStmtWithConn(ctx, stmt, xTime, queryer)
 		if err != nil {
-			stats.Add(numQueryErrors, 1)
-
 			// Remap errors if necessary for backwards compatibility reasons.
 			se := NewSQLiteErrorFromError(err)
 			if se != nil && se.ReadOnlyError() {

--- a/db/db.go
+++ b/db/db.go
@@ -78,6 +78,10 @@ var (
 
 	// ErrExecuteTimeout is returned when an execute times out.
 	ErrExecuteTimeout = errors.New("execute timeout")
+
+	// ErrQueryWrite is returned when an attempt to make to change the database
+	// via a query.
+	ErrQueryWrite = errors.New("attempt to change database via query operation")
 )
 
 // CheckpointMode is the mode in which a checkpoint runs. The
@@ -1376,27 +1380,15 @@ func (db *DB) queryWithConn(ctx context.Context, req *command.Request, xTime boo
 		var rows *command.QueryRows
 		var err error
 
-		readOnly, err := db.StmtReadOnlyWithConn(sql, conn)
-		if err != nil {
-			stats.Add(numQueryErrors, 1)
-			rows = &command.QueryRows{
-				Error: err.Error(),
-			}
-			allRows = append(allRows, rows)
-			continue
-		}
-		if !readOnly && !stmt.SqlExplain {
-			stats.Add(numQueryErrors, 1)
-			rows = &command.QueryRows{
-				Error: "attempt to change database via query operation",
-			}
-			allRows = append(allRows, rows)
-			continue
-		}
-
 		rows, err = db.queryStmtWithConn(ctx, stmt, xTime, queryer)
 		if err != nil {
 			stats.Add(numQueryErrors, 1)
+
+			// Remap errors if necessary for backwards compatibility reasons.
+			se := NewSQLiteErrorFromError(err)
+			if se != nil && se.ReadOnlyError() {
+				err = ErrQueryWrite
+			}
 			rows = &command.QueryRows{
 				Error: err.Error(),
 			}

--- a/db/db_common_test.go
+++ b/db/db_common_test.go
@@ -768,43 +768,48 @@ func Test_DB_ReadOnlyStatements(t *testing.T) {
 		t.Fatalf("failed to create table: %s", err.Error())
 	}
 
-	// build a table-driven test suite for StmtReadOnlyWithConn
+	// Test that statements are trapped as expected as attempts to change database on read-only
+	// connections.
+	expROResp := `[{"error":"attempt to change database via query operation"}]`
 	tests := []struct {
-		query string
-		ro    bool
+		query   string
+		expResp string
 	}{
 		{
-			query: "SELECT * FROM foo",
-			ro:    true,
+			query:   "SELECT * FROM foo",
+			expResp: `[{"columns":["id","name"],"types":["integer","text"]}]`,
 		},
 		{
-			query: "INSERT INTO foo(name) VALUES('fiona')",
-			ro:    false,
+			query:   "CREATE TABLE temp.qux (id INTEGER NOT NULL PRIMARY KEY, name TEXT)",
+			expResp: expROResp,
 		},
 		{
-			query: "INSERT INTO foo(name) VALUES('fiona') RETURNING *",
-			ro:    false,
+			query:   "INSERT INTO foo(name) VALUES('fiona')",
+			expResp: expROResp,
 		},
 		{
-			query: "UPDATE foo SET name='fiona' WHERE id=1",
-			ro:    false,
+			query:   "INSERT INTO foo(name) VALUES('fiona') RETURNING *",
+			expResp: expROResp,
 		},
 		{
-			query: "DELETE FROM foo WHERE id=1",
-			ro:    false,
+			query:   "UPDATE foo SET name='fiona' WHERE id=1",
+			expResp: expROResp,
 		},
 		{
-			query: "CREATE TABLE bar (id INTEGER NOT NULL PRIMARY KEY, name TEXT)",
-			ro:    false,
+			query:   "DELETE FROM foo WHERE id=1",
+			expResp: expROResp,
 		},
 		{
-			query: "DROP TABLE foo",
-			ro:    false,
+			query:   "CREATE TABLE bar (id INTEGER NOT NULL PRIMARY KEY, name TEXT)",
+			expResp: expROResp,
 		},
 		{
-			// Interestingly enough, this is considered read-only by SQLite.
-			query: "PRAGMA foreign_keys = ON",
-			ro:    true,
+			query:   "DROP TABLE foo",
+			expResp: expROResp,
+		},
+		{
+			query:   "PRAGMA foreign_keys = ON",
+			expResp: `[{}]`,
 		},
 	}
 
@@ -813,10 +818,8 @@ func Test_DB_ReadOnlyStatements(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to check if statement is read-only: %s", err.Error())
 		}
-		if !tt.ro {
-			if got, exp := asJSON(ro), `[{"error":"attempt to change database via query operation"}]`; got != exp {
-				t.Fatalf("unexpected results for query\nexp: %s\ngot: %s", exp, got)
-			}
+		if got, exp := asJSON(ro), tt.expResp; got != exp {
+			t.Fatalf("unexpected results for query: %s\nexp: %s\ngot: %s", tt.query, exp, got)
 		}
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -322,7 +322,7 @@ func Test_TableCreation(t *testing.T) {
 	testQ()
 }
 
-func Test_QueryReadOnly(t *testing.T) {
+func Test_Query_PragmaJournal_ReadOnly(t *testing.T) {
 	db, path := mustCreateOnDiskDatabaseWAL()
 	defer db.Close()
 	defer os.Remove(path)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -335,12 +335,25 @@ func Test_QueryReadOnly(t *testing.T) {
 		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
 	}
 
+	// A journal-mode change is not a data write, so it is not remapped to the
+	// legacy error above. Exactly how it fails -- lock contention, read-only
+	// pager, etc. -- is incidental. What matters is that it returns an error
+	// and the journal mode does not actually change. Pragma policy is enforced
+	// by the Store via PragmaCheckRequest before statements reach this layer.
 	r, err = db.QueryStringStmt("PRAGMA journal_mode=DELETE")
 	if err != nil {
 		t.Fatalf("failed to attempt to change journaling mode: %s", err.Error())
 	}
-	if exp, got := `[{"error":"attempt to change database via query operation"}]`, asJSON(r); exp != got {
-		t.Fatalf("unexpected results for query, expected %s, got %s", exp, got)
+	if len(r) != 1 || r[0].Error == "" {
+		t.Fatalf("expected error attempting to change journal mode via query, got %s", asJSON(r))
+	}
+
+	r, err = db.QueryStringStmt("PRAGMA journal_mode")
+	if err != nil {
+		t.Fatalf("failed to query journal mode: %s", err.Error())
+	}
+	if exp, got := `[{"columns":["journal_mode"],"types":["text"],"values":[["wal"]]}]`, asJSON(r); exp != got {
+		t.Fatalf("unexpected results for journal mode query, expected %s, got %s", exp, got)
 	}
 }
 

--- a/db/state.go
+++ b/db/state.go
@@ -133,6 +133,7 @@ var BreakingPragmas = map[string]*regexp.Regexp{
 	"PRAGMA wal_autocheckpoint": regexp.MustCompile(`(?i)^\s*PRAGMA\s+wal_autocheckpoint\s*=\s*`),
 	"PRAGMA wal_checkpoint":     regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?wal_checkpoint`),
 	"PRAGMA synchronous":        regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?synchronous\s*=\s*`),
+	"PRAGMA query_only":         regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?query_only\s*=\s*`),
 }
 
 // IsBreakingPragma returns true if the given statement is a breaking PRAGMA.

--- a/db/state.go
+++ b/db/state.go
@@ -43,6 +43,32 @@ var (
 	ErrWALStillExists = errors.New("WAL file still exists after checkpointing and closing the database")
 )
 
+// SQLiteError is a representation of the SQLite-level detailed error.
+type SQLiteError struct {
+	Code         int32
+	ExtendedCode int32
+	SystemErrno  int32
+}
+
+// ReadOnlyError returns true if the error is a read-only error.
+func (e *SQLiteError) ReadOnlyError() bool {
+	return e.Code == int32(sqlite3.ErrReadonly)
+}
+
+// NewSQLiteErrorFromError extracts a full structured SQLite error from an error,
+// returning nil if the error is not a SQLite error.
+func NewSQLiteErrorFromError(err error) *SQLiteError {
+	var sqErr sqlite3.Error
+	if errors.As(err, &sqErr) {
+		return &SQLiteError{
+			Code:         int32(sqErr.Code),
+			ExtendedCode: int32(sqErr.ExtendedCode),
+			SystemErrno:  int32(sqErr.SystemErrno),
+		}
+	}
+	return nil
+}
+
 // SynchronousMode is SQLite synchronous mode.
 type SynchronousMode int
 
@@ -173,6 +199,7 @@ func MakeDSN(path string, readOnly, fkEnabled, walEnabled bool) string {
 	opts := url.Values{}
 	if readOnly {
 		opts.Add("mode", "ro")
+		opts.Add("_query_only", "true")
 	}
 	opts.Add("_fk", strconv.FormatBool(fkEnabled))
 	opts.Add("_journal", "WAL")

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -214,19 +214,19 @@ func Test_MakeDSN(t *testing.T) {
 		{
 			path:     "foo.db",
 			readOnly: true,
-			want:     "file:foo.db?_fk=false&_journal=DELETE&_sync=0&mode=ro",
+			want:     "file:foo.db?_fk=false&_journal=DELETE&_query_only=true&_sync=0&mode=ro",
 		},
 		{
 			path:       "foo.db",
 			readOnly:   true,
 			walEnabled: true,
-			want:       "file:foo.db?_fk=false&_journal=WAL&_sync=0&mode=ro",
+			want:       "file:foo.db?_fk=false&_journal=WAL&_query_only=true&_sync=0&mode=ro",
 		},
 		{
 			path:      "foo.db",
 			readOnly:  true,
 			fkEnabled: true,
-			want:      "file:foo.db?_fk=true&_journal=DELETE&_sync=0&mode=ro",
+			want:      "file:foo.db?_fk=true&_journal=DELETE&_query_only=true&_sync=0&mode=ro",
 		},
 	}
 

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -39,9 +39,17 @@ func Test_IsDisallowedPragmas(t *testing.T) {
 
 		"PRAGMA synchronous=",
 		"PRAGMA synchronous = ",
+		"PRAGMA Synchronous = ",
 		"PRAGMA synchronous  =",
 		"PRAGMA  synchronous=OFF",
 		"PRAGMA main.synchronous=OFF",
+
+		"PRAGMA query_only=",
+		"PRAGMA query_only = ",
+		"PRAGMA query_only = true",
+		"PRAGMA query_only = false",
+		"PRAGMA query_only=false",
+		"PRAGMA QUERY_ONLY=false",
 	}
 
 	for _, s := range tests {


### PR DESCRIPTION
This improves query performance.