### PR TITLE
Skip systemctl daemon-reload when systemd is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### New features
 - [PR #2715](https://github.com/rqlite/rqlite/pull/2715), [PR #2716](https://github.com/rqlite/rqlite/pull/2716): Support pushing OTLP metrics to an OpenTelemetry Collector.
 
+### Implementation changes and bug fixes
+- [PR #2718](https://github.com/rqlite/rqlite/pull/2718): Skip `systemctl daemon-reload` in package scripts when systemd is not running, fixing package installation inside chroots and containers.
+
 ## v10.2.7 (July 5th 2026)
 ### Implementation changes and bug fixes
 - [PR #2714](https://github.com/rqlite/rqlite/pull/2714): `go mod` dependency updates.

--- a/tools/package/build-packages.sh
+++ b/tools/package/build-packages.sh
@@ -162,7 +162,9 @@ fi
 mkdir -p /var/lib/rqlite
 chown rqlite:rqlite /var/lib/rqlite
 chmod 750 /var/lib/rqlite
-systemctl daemon-reload
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi
 
 %preun
 if systemctl is-active --quiet rqlited 2>/dev/null; then

--- a/tools/package/build-packages.sh
+++ b/tools/package/build-packages.sh
@@ -162,7 +162,7 @@ fi
 mkdir -p /var/lib/rqlite
 chown rqlite:rqlite /var/lib/rqlite
 chmod 750 /var/lib/rqlite
-if [ -d /run/systemd/system ]; then
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload
 fi
 

--- a/tools/package/scripts/postinstall.sh
+++ b/tools/package/scripts/postinstall.sh
@@ -16,5 +16,7 @@ mkdir -p /var/lib/rqlite
 chown rqlite:rqlite /var/lib/rqlite
 chmod 750 /var/lib/rqlite
 
-# Reload systemd
-systemctl daemon-reload
+# Reload systemd, but only if systemd is running (e.g. not in a chroot or container)
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi

--- a/tools/package/scripts/postinstall.sh
+++ b/tools/package/scripts/postinstall.sh
@@ -17,6 +17,6 @@ chown rqlite:rqlite /var/lib/rqlite
 chmod 750 /var/lib/rqlite
 
 # Reload systemd, but only if systemd is running (e.g. not in a chroot or container)
-if [ -d /run/systemd/system ]; then
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
     systemctl daemon-reload
 fi


### PR DESCRIPTION
## Problem

Installing the deb package inside a chroot (e.g. during image builds) fails with:

```
System has not been booted with systemd as init system (PID 1 isn't systemd)
```

`tools/package/scripts/postinstall.sh` runs `systemctl daemon-reload` unconditionally, and since the script uses `set -e`, the failed systemctl call aborts the whole package installation. The RPM `%post` scriptlet embedded in `tools/package/build-packages.sh` has the same unguarded call.

## Fix

Guard the call with the standard `sd_booted()` check — `/run/systemd/system` only exists when systemd actually booted the system:

```sh
if [ -d /run/systemd/system ]; then
    systemctl daemon-reload
fi
```

This is the same guard Debian's `dh_installsystemd`-generated maintainer scripts use, so behavior on a normally-booted system is unchanged while chroot/container installs no longer fail.

The `systemctl` calls in `preremove.sh` are already safe — they're wrapped in `if systemctl ... 2>/dev/null` conditions, so they were left untouched.