### PR TITLE
db: consolidate pragma and txStatus reads onto a single connection per pool

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1820,28 +1820,41 @@ func (db *DB) StmtReadOnlyWithConn(sql string, conn *sql.Conn) (bool, error) {
 }
 
 func (db *DB) pragmas() (map[string]any, error) {
-	conns := map[string]*sql.DB{
-		"rw": db.rwDB,
-		"ro": db.roDB,
+	pragmaNames := []string{
+		"synchronous",
+		"journal_mode",
+		"foreign_keys",
+		"wal_autocheckpoint",
+		"busy_timeout",
+	}
+
+	// readPragmas acquires a single connection from the given pool and reads
+	// all requested pragmas on that one connection, avoiding a separate
+	// connection acquisition per pragma.
+	readPragmas := func(sqlDB *sql.DB) (map[string]string, error) {
+		conn, err := sqlDB.Conn(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+		m := make(map[string]string, len(pragmaNames))
+		for _, p := range pragmaNames {
+			var s string
+			if err := conn.QueryRowContext(context.Background(), fmt.Sprintf("PRAGMA %s", p)).Scan(&s); err != nil {
+				return nil, err
+			}
+			m[p] = s
+		}
+		return m, nil
 	}
 
 	connsMap := make(map[string]any)
-	for k, v := range conns {
-		pragmasMap := make(map[string]string)
-		for _, p := range []string{
-			"synchronous",
-			"journal_mode",
-			"foreign_keys",
-			"wal_autocheckpoint",
-			"busy_timeout",
-		} {
-			var s string
-			if err := v.QueryRow(fmt.Sprintf("PRAGMA %s", p)).Scan(&s); err != nil {
-				return nil, err
-			}
-			pragmasMap[p] = s
+	for k, sqlDB := range map[string]*sql.DB{"rw": db.rwDB, "ro": db.roDB} {
+		m, err := readPragmas(sqlDB)
+		if err != nil {
+			return nil, err
 		}
-		connsMap[k] = pragmasMap
+		connsMap[k] = m
 	}
 	return connsMap, nil
 }
@@ -1849,29 +1862,32 @@ func (db *DB) pragmas() (map[string]any, error) {
 // txStatus returns whether there is an active transaction on each database
 // connection.
 func (db *DB) txStatus() (map[string]any, error) {
-	conns := map[string]*sql.DB{
-		"rw": db.rwDB,
-		"ro": db.roDB,
-	}
-
-	t := false
-	f := func(driverConn any) error {
-		conn := driverConn.(*sqlite3.SQLiteConn)
-		t = conn.AutoCommit()
-		return nil
+	// checkTx acquires a single connection from the given pool, checks whether
+	// it is in auto-commit mode (i.e. no active transaction), and immediately
+	// releases the connection before returning.
+	checkTx := func(sqlDB *sql.DB) (bool, error) {
+		conn, err := sqlDB.Conn(context.Background())
+		if err != nil {
+			return false, err
+		}
+		defer conn.Close()
+		var autoCommit bool
+		if err := conn.Raw(func(driverConn any) error {
+			autoCommit = driverConn.(*sqlite3.SQLiteConn).AutoCommit()
+			return nil
+		}); err != nil {
+			return false, err
+		}
+		return autoCommit, nil
 	}
 
 	txStatusMap := make(map[string]any)
-	for k, v := range conns {
-		conn, err := v.Conn(context.Background())
+	for k, sqlDB := range map[string]*sql.DB{"rw": db.rwDB, "ro": db.roDB} {
+		autoCommit, err := checkTx(sqlDB)
 		if err != nil {
 			return nil, err
 		}
-		defer conn.Close()
-		if err := conn.Raw(f); err != nil {
-			return nil, err
-		}
-		txStatusMap[k] = !t
+		txStatusMap[k] = !autoCommit
 	}
 	return txStatusMap, nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1832,6 +1832,9 @@ func (db *DB) pragmas() (map[string]any, error) {
 	// all requested pragmas on that one connection, avoiding a separate
 	// connection acquisition per pragma.
 	readPragmas := func(sqlDB *sql.DB) (map[string]string, error) {
+		if sqlDB == nil {
+			return nil, errors.New("database connection is nil")
+		}
 		conn, err := sqlDB.Conn(context.Background())
 		if err != nil {
 			return nil, err
@@ -1866,6 +1869,9 @@ func (db *DB) txStatus() (map[string]any, error) {
 	// it is in auto-commit mode (i.e. no active transaction), and immediately
 	// releases the connection before returning.
 	checkTx := func(sqlDB *sql.DB) (bool, error) {
+		if sqlDB == nil {
+			return false, errors.New("database connection is nil")
+		}
 		conn, err := sqlDB.Conn(context.Background())
 		if err != nil {
 			return false, err
@@ -1873,7 +1879,11 @@ func (db *DB) txStatus() (map[string]any, error) {
 		defer conn.Close()
 		var autoCommit bool
 		if err := conn.Raw(func(driverConn any) error {
-			autoCommit = driverConn.(*sqlite3.SQLiteConn).AutoCommit()
+			sqliteConn, ok := driverConn.(*sqlite3.SQLiteConn)
+			if !ok {
+				return fmt.Errorf("unexpected driver connection type: %T", driverConn)
+			}
+			autoCommit = sqliteConn.AutoCommit()
 			return nil
 		}); err != nil {
 			return false, err

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1649,3 +1649,61 @@ func mustFileSize(path string) int64 {
 func isAppveyor() bool {
 	return os.Getenv("APPVEYOR") != ""
 }
+
+// Test_DBStats_NoPragmaConnectionLeak verifies that calling Stats() does not
+// leave any additional connections open on the rw pool after it returns.
+// Previously, pragmas() acquired a separate connection per pragma rather than
+// batching them on a single connection, and txStatus() deferred Close() inside
+// a loop, keeping all connections alive until the function returned.
+func Test_DBStats_NoPragmaConnectionLeak(t *testing.T) {
+	db, path := mustCreateOnDiskDatabaseWAL()
+	defer db.Close()
+	defer os.Remove(path)
+
+	// Baseline: how many connections are in use before Stats() is called.
+	beforeRW := db.ConnectionPoolStats(db.rwDB).InUse
+
+	stats, err := db.Stats()
+	if err != nil {
+		t.Fatalf("Stats() returned error: %s", err)
+	}
+	if stats == nil {
+		t.Fatal("Stats() returned nil")
+	}
+
+	// After Stats() returns every transient connection must have been released.
+	afterRW := db.ConnectionPoolStats(db.rwDB).InUse
+	if afterRW != beforeRW {
+		t.Fatalf("expected %d rw connections in use after Stats(), got %d", beforeRW, afterRW)
+	}
+}
+
+// Test_DBStats_PragmaFields verifies that the pragmas map returned by Stats()
+// contains the expected keys for both the rw and ro pools.
+func Test_DBStats_PragmaFields(t *testing.T) {
+	db, path := mustCreateOnDiskDatabaseWAL()
+	defer db.Close()
+	defer os.Remove(path)
+
+	stats, err := db.Stats()
+	if err != nil {
+		t.Fatalf("Stats() returned error: %s", err)
+	}
+
+	pragmas, ok := stats["pragmas"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pragmas map, got %T", stats["pragmas"])
+	}
+
+	for _, pool := range []string{"rw", "ro"} {
+		poolPragmas, ok := pragmas[pool].(map[string]string)
+		if !ok {
+			t.Fatalf("expected pragmas[%q] to be map[string]string, got %T", pool, pragmas[pool])
+		}
+		for _, key := range []string{"synchronous", "journal_mode", "foreign_keys", "wal_autocheckpoint", "busy_timeout"} {
+			if _, exists := poolPragmas[key]; !exists {
+				t.Errorf("pragmas[%q] missing key %q", pool, key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2615.

### Problem

`pragmas()` called `v.QueryRow()` in a loop, potentially acquiring a **separate connection per pragma query** from the pool. On the `rw` pool (`MaxOpenConns=1`) this means each iteration waits for the previous connection to be returned before it can proceed.

`txStatus()` used `defer conn.Close()` **inside** a `for` loop. Go's `defer` runs when the surrounding function returns, not at the end of the loop iteration, so all connections remained open simultaneously until `txStatus()` returned.

### Fix

- **`pragmas()`** — acquire exactly one `*sql.Conn` per pool and run all `PRAGMA` reads on that connection, then close it before moving to the next pool. This mirrors the pattern already used by `memStats()`.
- **`txStatus()`** — extract the check into a `checkTx` helper that acquires one connection, inspects it, and `defer`s `Close()` correctly (scoped to the helper, not to the outer loop), so the connection is released before the next pool is checked.

### Tests

- `Test_DBStats_NoPragmaConnectionLeak` — verifies no extra rw connections remain open after `Stats()` returns.
- `Test_DBStats_PragmaFields` — verifies the pragmas map contains the expected keys for both `rw` and `ro` pools.

Full `go test ./db/` is green.