### PR TITLE
Add table row preview action to Console schema page

### DIFF
--- a/http/console/static/css/style.css
+++ b/http/console/static/css/style.css
@@ -616,6 +616,44 @@ footer a:hover {
     color: var(--text);
 }
 
+.schema-table-heading {
+    display: inline-flex;
+    align-items: center;
+}
+
+.schema-view-rows {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-left: 0.375rem;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.schema-view-rows:hover,
+.schema-view-rows:focus-visible {
+    border-color: var(--border);
+    background: var(--surface-alt);
+    color: var(--accent);
+}
+
+.schema-view-rows svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.75;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+}
+
 .schema-drop-table,
 .schema-drop-index {
     background: transparent;

--- a/http/console/static/js/app.js
+++ b/http/console/static/js/app.js
@@ -125,10 +125,7 @@
     tabs.forEach(function (tab) {
         tab.addEventListener("click", function () {
             var target = tab.getAttribute("data-tab");
-            tabs.forEach(function (t) { t.classList.remove("active"); });
-            tabContents.forEach(function (tc) { tc.classList.remove("active"); });
-            tab.classList.add("active");
-            document.getElementById(target).classList.add("active");
+            showTab(target);
             if (target === "schema") {
                 loadSchema();
             } else if (target === "restore") {
@@ -137,6 +134,15 @@
             }
         });
     });
+
+    function showTab(target) {
+        tabs.forEach(function (t) {
+            t.classList.toggle("active", t.getAttribute("data-tab") === target);
+        });
+        tabContents.forEach(function (tc) {
+            tc.classList.toggle("active", tc.id === target);
+        });
+    }
 
     // --- Query Tab ---
 
@@ -1262,7 +1268,7 @@
             var anchor = "schema-table-" + slugify(tableName);
             html += '<div class="detail-section schema-section' + openClass(anchor, true) + '" id="' + escapeHTML(anchor) + '">';
             html += '<div class="detail-section-header">';
-            html += '<span><span class="schema-kind">table</span> ' + escapeHTML(tableName);
+            html += '<span class="schema-table-heading"><span><span class="schema-kind">table</span> ' + escapeHTML(tableName);
             var columnsStr = t.columns.length + ' column' + (t.columns.length === 1 ? '' : 's');
             html += ' <span class="schema-count">(' + escapeHTML(columnsStr);
             if (Object.prototype.hasOwnProperty.call(rowCounts, tableName)) {
@@ -1271,6 +1277,10 @@
                 html += ', <span class="schema-rowcount-text" title="Row count read with &#39;none&#39; consistency &mdash; may be slightly stale">' + escapeHTML(rowsStr) + '</span>';
             }
             html += ')</span></span>';
+            html += '<button class="schema-view-rows" type="button" data-table-name="' + escapeHTML(tableName) + '"';
+            html += ' aria-label="Preview first 100 rows from ' + escapeHTML(tableName) + '" title="Preview first 100 rows">';
+            html += '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"></path><circle cx="12" cy="12" r="2.5"></circle></svg>';
+            html += '</button></span>';
             html += '<span class="arrow">&#9654;</span>';
             html += '</div>';
             html += '<div class="detail-section-body">';
@@ -1363,6 +1373,13 @@
         return '"' + String(name).replace(/"/g, '""') + '"';
     }
 
+    function viewFirstRows(tableName) {
+        showTab("query");
+        sqlInput.value = "SELECT *\nFROM " + sqlQuoteIdent(tableName) + "\nLIMIT 100;";
+        autoGrow();
+        executeQuery();
+    }
+
     function dropTable(tableName, btn) {
         btn.disabled = true;
         var sql = "DROP TABLE " + sqlQuoteIdent(tableName);
@@ -1412,14 +1429,21 @@
     });
 
     schemaContent.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest("button");
+        if (btn && btn.classList.contains("schema-view-rows")) {
+            var browseTableName = btn.getAttribute("data-table-name");
+            if (!browseTableName) return;
+            viewFirstRows(browseTableName);
+            return;
+        }
+
         var header = e.target.closest && e.target.closest(".detail-section-header");
         if (header && schemaContent.contains(header)) {
             header.parentElement.classList.toggle("open");
             return;
         }
 
-        var btn = e.target;
-        if (!btn.classList) return;
+        if (!btn || !schemaContent.contains(btn)) return;
 
         if (btn.classList.contains("schema-sql-toggle")) {
             var block = btn.closest(".schema-sql-block");

--- a/http/console/static/js/app.js
+++ b/http/console/static/js/app.js
@@ -1378,6 +1378,7 @@
         sqlInput.value = "SELECT *\nFROM " + sqlQuoteIdent(tableName) + "\nLIMIT 100;";
         autoGrow();
         executeQuery();
+        window.scrollTo(0, 0);
     }
 
     function dropTable(tableName, btn) {


### PR DESCRIPTION
## Summary
- add a compact preview action beside each table on the Schema page
- open the Query page with a quoted SELECT query limited to 100 rows
- execute the generated query automatically and render its results
- support table names containing spaces, quotes, reserved words, and special characters

<img width="986" height="120" alt="Screenshot 2026-07-22 at 12 05 13 AM" src="https://github.com/user-attachments/assets/7afa878f-24fb-4d51-a042-cde805d4e50e" />

## Validation
- go test ./http/...
- node --check http/console/static/js/app.js
- browser-tested with a table named order "items"

Refs https://github.com/rqlite/rqlite/issues/2725