### PR TITLE
failed DB swap could delete the original database

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -243,6 +243,45 @@ func Test_RemoveFiles(t *testing.T) {
 	}
 }
 
+func Test_RenameFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	mustCreateClosedFile(fmt.Sprintf("%s/foo", srcDir))
+	mustCreateClosedFile(fmt.Sprintf("%s/foo-wal", srcDir))
+	mustCreateClosedFile(fmt.Sprintf("%s/foo-shm", srcDir))
+
+	dst := fmt.Sprintf("%s/bar", dstDir)
+	if err := RenameFiles(fmt.Sprintf("%s/foo", srcDir), dst); err != nil {
+		t.Fatalf("failed to rename files: %s", err.Error())
+	}
+
+	files, err := os.ReadDir(srcDir)
+	if err != nil {
+		t.Fatalf("failed to read directory: %s", err.Error())
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected source directory to be empty, but wasn't")
+	}
+	files, err = os.ReadDir(dstDir)
+	if err != nil {
+		t.Fatalf("failed to read directory: %s", err.Error())
+	}
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files in destination directory, got %d", len(files))
+	}
+
+	// Missing WAL and SHM files are fine.
+	mustCreateClosedFile(fmt.Sprintf("%s/baz", srcDir))
+	if err := RenameFiles(fmt.Sprintf("%s/baz", srcDir), fmt.Sprintf("%s/qux", dstDir)); err != nil {
+		t.Fatalf("failed to rename files without WAL and SHM: %s", err.Error())
+	}
+
+	// Missing source file is an error.
+	if err := RenameFiles(fmt.Sprintf("%s/nope", srcDir), fmt.Sprintf("%s/nope2", dstDir)); err == nil {
+		t.Fatalf("expected error renaming nonexistent file, got nil")
+	}
+}
+
 func Test_SetMaxReadOnlyConns(t *testing.T) {
 	path := mustTempPath()
 	defer os.Remove(path)

--- a/db/state.go
+++ b/db/state.go
@@ -428,6 +428,22 @@ func RemoveFiles(path string) error {
 	return nil
 }
 
+// RenameFiles renames the SQLite database file at src to dst, along with any
+// associated WAL and SHM files. Missing WAL and SHM files are ignored.
+func RenameFiles(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		return err
+	}
+	for _, ext := range []string{"-wal", "-shm"} {
+		if fsutil.FileExists(src + ext) {
+			if err := os.Rename(src+ext, dst+ext); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // ReplayWAL replays the given WAL files into the database at the given path,
 // in the order given by the slice. The supplied WAL files must be in the same
 // directory as the database file and are deleted as a result of the replay operation.

--- a/db/swappable_db.go
+++ b/db/swappable_db.go
@@ -48,24 +48,57 @@ func OpenSwappable(dbPath string, drv *Driver, fkEnabled, wal bool, maxROConns i
 // Swap swaps the underlying database with that at the given path. The Swap operation
 // may fail on some platforms if the file at path is open by another process. It is
 // the caller's responsibility to ensure the file at path is not in use.
-func (s *SwappableDB) Swap(path string, fkConstraints, walEnabled bool) error {
+//
+// If Swap returns an error, the original database is restored before the error
+// is returned.
+func (s *SwappableDB) Swap(path string, fkConstraints, walEnabled bool) (retErr error) {
 	if !IsValidSQLiteFile(path) {
 		return fmt.Errorf("invalid SQLite data")
 	}
 
 	s.dbMu.Lock()
 	defer s.dbMu.Unlock()
+
+	dbPath := s.db.Path()
+	backupPath := dbPath + ".swap-backup"
+	origFK, origWAL := s.db.FKEnabled(), s.db.WALEnabled()
+
 	if err := s.db.Close(); err != nil {
 		return fmt.Errorf("failed to close: %s", err)
 	}
-	if err := RemoveFiles(s.db.Path()); err != nil {
-		return fmt.Errorf("failed to remove files: %s", err)
+
+	// Move the existing database aside, so it can be restored if the swap fails.
+	RemoveFiles(backupPath)
+	if err := RenameFiles(dbPath, backupPath); err != nil {
+		return fmt.Errorf("failed to set aside existing database: %s", err)
 	}
-	if err := os.Rename(path, s.db.Path()); err != nil {
+	defer func() {
+		if retErr == nil {
+			RemoveFiles(backupPath)
+			return
+		}
+		// Swap failed, put the original database back.
+		s.db.Close()
+		RemoveFiles(dbPath)
+		if err := RenameFiles(backupPath, dbPath); err != nil {
+			return
+		}
+		db, err := OpenWithDriver(s.drv, dbPath, origFK, origWAL)
+		if err != nil {
+			return
+		}
+		s.db = db
+		s.checkpointMgr.Close()
+		if mgr, err := NewCheckpointManager(db); err == nil {
+			s.checkpointMgr = mgr
+		}
+	}()
+
+	if err := os.Rename(path, dbPath); err != nil {
 		return fmt.Errorf("failed to rename database: %s", err)
 	}
 
-	db, err := OpenWithDriver(s.drv, s.db.Path(), fkConstraints, walEnabled)
+	db, err := OpenWithDriver(s.drv, dbPath, fkConstraints, walEnabled)
 	if err != nil {
 		return fmt.Errorf("open SQLite file failed: %s", err)
 	}

--- a/db/swappable_db_test.go
+++ b/db/swappable_db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/rqlite/rqlite/v10/internal/fsutil"
@@ -164,5 +165,122 @@ func Test_SwapInvalidSQLiteFile(t *testing.T) {
 	err = swappableDB.Swap(invalidSQLiteFilePath, false, false)
 	if err == nil {
 		t.Fatalf("expected an error when swapping with an invalid SQLite file, got nil")
+	}
+}
+
+// Test_SwapSuccess_RemovesBackup tests that a successful swap removes the backup
+// copy of the original database.
+func Test_SwapSuccess_RemovesBackup(t *testing.T) {
+	srcPath := mustTempPath()
+	defer os.Remove(srcPath)
+	srcDB, err := Open(srcPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open source database: %s", err)
+	}
+	mustExecute(srcDB, "CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("failed to close source database: %s", err)
+	}
+
+	swappablePath := mustTempPath()
+	defer os.Remove(swappablePath)
+	swappableDB, err := OpenSwappable(swappablePath, nil, false, false, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	if err := swappableDB.Swap(srcPath, false, false); err != nil {
+		t.Fatalf("failed to swap database: %s", err)
+	}
+
+	for _, ext := range []string{"", "-wal", "-shm"} {
+		if fsutil.FileExists(swappablePath + ".swap-backup" + ext) {
+			t.Fatalf("backup file %s left behind after successful swap", swappablePath+".swap-backup"+ext)
+		}
+	}
+}
+
+// Test_SwapRenameFailure_RestoresOriginal tests that if a swap fails partway through,
+// the original database is restored and remains fully usable.
+func Test_SwapRenameFailure_RestoresOriginal(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("test needs a second filesystem, only guaranteed on Linux")
+	}
+	if _, err := os.Stat("/dev/shm"); err != nil {
+		t.Skip("/dev/shm not available")
+	}
+
+	// Confirm /dev/shm and the temp dir are on different filesystems, otherwise
+	// this test can't force the rename to fail.
+	probe, err := os.CreateTemp("/dev/shm", "rqlite-swap-probe")
+	if err != nil {
+		t.Fatalf("failed to create probe file: %s", err)
+	}
+	probePath := probe.Name()
+	probe.Close()
+	probeDst := mustTempPath()
+	if err := os.Rename(probePath, probeDst); err == nil {
+		os.Remove(probeDst)
+		t.Skip("/dev/shm and os.TempDir are on the same filesystem")
+	}
+	os.Remove(probePath)
+
+	// Create the original database with content.
+	origPath := mustTempPath()
+	defer os.Remove(origPath)
+	origDB, err := Open(origPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open original database: %s", err)
+	}
+	mustExecute(origDB, "CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	mustExecute(origDB, `INSERT INTO foo(name) VALUES("original")`)
+	if err := origDB.Close(); err != nil {
+		t.Fatalf("failed to close original database: %s", err)
+	}
+
+	swappableDB, err := OpenSwappable(origPath, nil, false, false, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	// Create a valid SQLite database on /dev/shm. Renaming it into place will
+	// fail with EXDEV, failing the swap after the original has been set aside.
+	srcFile, err := os.CreateTemp("/dev/shm", "rqlite-swap-test")
+	if err != nil {
+		t.Fatalf("failed to create source file: %s", err)
+	}
+	srcPath := srcFile.Name()
+	srcFile.Close()
+	os.Remove(srcPath)
+	defer os.Remove(srcPath)
+	srcDB, err := Open(srcPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open source database: %s", err)
+	}
+	mustExecute(srcDB, "CREATE TABLE bar (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("failed to close source database: %s", err)
+	}
+
+	if err := swappableDB.Swap(srcPath, false, false); err == nil {
+		t.Fatalf("expected swap to fail, but it didn't")
+	}
+
+	// The original database must be back in place and usable.
+	rows, err := swappableDB.QueryStringStmt("SELECT * FROM foo")
+	if err != nil {
+		t.Fatalf("failed to query original database after failed swap: %s", err)
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"original"]]}]`, asJSON(rows); exp != got {
+		t.Fatalf("unexpected results after failed swap, expected %s, got %s", exp, got)
+	}
+
+	// No backup files may be left behind.
+	for _, ext := range []string{"", "-wal", "-shm"} {
+		if fsutil.FileExists(origPath + ".swap-backup" + ext) {
+			t.Fatalf("backup file %s left behind after failed swap", origPath+".swap-backup"+ext)
+		}
 	}
 }


### PR DESCRIPTION
Was looking at how a node recovers from a failed /boot or load and noticed the swap path in SwappableDB is pretty unforgiving right now. Swap() deletes the existing database files up front, and only then renames the new file into place and opens it. If that rename fails, or the open right after fails, the original database is just gone. The node is left with nothing at that path, which turns a recoverable error into actual data loss.

This is the issue in #2103.

What I changed: instead of deleting the old files, Swap now moves them aside to a .swap-backup name first. If anything fails after that point, a defer puts them back and reopens the original database before returning the error, so Swap either fully succeeds or changes nothing at all. Database paths stay fixed throughout, since that's a core assumption. The cleanup uses a named return plus defer, which keeps the happy path readable.

Also added a small RenameFiles helper in state.go next to RemoveFiles, since the backup and restore steps need to move any -wal and -shm files along with the main db file.

Testing:
- new test forces the rename to fail (source file on a different filesystem, so rename returns EXDEV) and checks the original database is back in place and queryable, with no backup files left behind. I confirmed this test fails against the old code — the next query just gets "sql: database is closed" because the original files were already deleted
- test that a successful swap leaves no backup files behind
- unit test for RenameFiles
- full db package suite passes with -race, plus the store-level load/boot tests that go through Swap (Test_SingleNodeLoad*, Test_SingleNodeBoot*)

One thing I'm not 100% sure about: if the process dies mid-swap, after the old files are moved aside but before the new one is renamed in, the backup is left on disk and nothing restores it on startup. That felt out of scope here, but happy to add recovery on open if you think it's worth handling.
