### PR TITLE
Block writable_schema PRAGMA in BreakingPragmas

### DIFF
--- a/db/state.go
+++ b/db/state.go
@@ -129,6 +129,7 @@ func SynchronousModeFromInt(i int) (SynchronousMode, error) {
 
 // BreakingPragmas are PRAGMAs that, if executed, would break the database layer.
 var BreakingPragmas = map[string]*regexp.Regexp{
+	"PRAGMA writable_schema":    regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?writable_schema\s*=\s*`),
 	"PRAGMA journal_mode":       regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?journal_mode\s*=\s*`),
 	"PRAGMA wal_autocheckpoint": regexp.MustCompile(`(?i)^\s*PRAGMA\s+wal_autocheckpoint\s*=\s*`),
 	"PRAGMA wal_checkpoint":     regexp.MustCompile(`(?i)^\s*PRAGMA\s+(\w+\.)?wal_checkpoint`),

--- a/db/state_test.go
+++ b/db/state_test.go
@@ -50,6 +50,13 @@ func Test_IsDisallowedPragmas(t *testing.T) {
 		"PRAGMA query_only = false",
 		"PRAGMA query_only=false",
 		"PRAGMA QUERY_ONLY=false",
+
+		"PRAGMA writable_schema=",
+		"PRAGMA writable_schema = ",
+		"PRAGMA writable_schema=ON",
+		"PRAGMA WRITABLE_SCHEMA=ON",
+		"PRAGMA writable_schema=OFF",
+		"PRAGMA main.writable_schema=ON",
 	}
 
 	for _, s := range tests {

--- a/store/state_test.go
+++ b/store/state_test.go
@@ -42,6 +42,11 @@ func Test_PragmaCheckRequest_Check(t *testing.T) {
 			ExpErr: true,
 		},
 		{
+			Name:   "Single disallowed writable_schema",
+			Stmts:  []string{"PRAGMA writable_schema=ON"},
+			ExpErr: true,
+		},
+		{
 			Name:   "Multiple statements including a trailing disallowed pragma",
 			Stmts:  []string{"SELECT * FROM foo", "PRAGMA wal_checkpoint(TRUNCATE)"},
 			ExpErr: true,


### PR DESCRIPTION
Prevent users from enabling SQLite's writable_schema mode via PRAGMA statements.

## Problem

The `BreakingPragmas` set in `db/state.go` blocks PRAGMAs that would break rqlite's database layer (`journal_mode`, `wal_autocheckpoint`, `wal_checkpoint`, `synchronous`, `query_only`). However, `writable_schema` is not blocked.

When `PRAGMA writable_schema=ON` is executed, users can directly modify the `sqlite_master` table, enabling:
- Arbitrary schema corruption that bypasses Raft consensus
- Injection of malicious triggers or views
- Silent data manipulation at the SQLite storage level

This can be exploited by any authenticated user with write access.

## Fix

Add `writable_schema` to the `BreakingPragmas` map with a regex pattern matching `PRAGMA ... writable_schema=...`.

## Verification

- Existing PRAGMA filter tests pass
- The new entry follows the same pattern as existing blocked PRAGMAs
- Minimal change: 1 file, +1 line