### PR TITLE
db: add slow query logging

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -196,7 +196,8 @@ type DB struct {
 	allOptimized   bool
 	allOptimizedMu sync.Mutex
 
-	logger *log.Logger
+	logger             *log.Logger
+	slowQueryThreshold time.Duration
 }
 
 // PoolStats represents connection pool statistics
@@ -337,16 +338,17 @@ func OpenWithDriver(drv *Driver, dbPath string, fkEnabled, wal bool) (retDB *DB,
 	}
 
 	return &DB{
-		drv:       drv,
-		path:      dbPath,
-		walPath:   dbPath + "-wal",
-		fkEnabled: fkEnabled,
-		wal:       wal,
-		rwDB:      rwDB,
-		roDB:      roDB,
-		rwDSN:     rwDSN,
-		roDSN:     roDSN,
-		logger:    logger,
+		drv:                drv,
+		path:               dbPath,
+		walPath:            dbPath + "-wal",
+		fkEnabled:          fkEnabled,
+		wal:                wal,
+		rwDB:               rwDB,
+		roDB:               roDB,
+		rwDSN:              rwDSN,
+		roDSN:              roDSN,
+		logger:             logger,
+		slowQueryThreshold: defaultSlowQueryThreshold,
 	}, nil
 }
 
@@ -1257,7 +1259,9 @@ func (db *DB) executeStmtWithConn(ctx context.Context, stmt *command.Statement, 
 			Q: rows,
 		}
 	} else {
+		execStart := time.Now()
 		result, err := eq.ExecContext(ctx, stmt.Sql, parameters...)
+		db.logSlowQuery(execStart, stmt.Sql)
 		if err != nil {
 			response.Result = &command.ExecuteQueryResponse_Error{
 				Error: err.Error(),
@@ -1425,6 +1429,11 @@ func (db *DB) queryStmtWithConn(ctx context.Context, stmt *command.Statement, xT
 		rows.Error = err.Error()
 		return rows, nil
 	}
+
+	queryStart := time.Now()
+	defer func() {
+		db.logSlowQuery(queryStart, stmt.Sql)
+	}()
 
 	rs, err := q.QueryContext(ctx, stmt.Sql, parameters...)
 	if err != nil {

--- a/db/slow_query.go
+++ b/db/slow_query.go
@@ -1,0 +1,24 @@
+package db
+
+import "time"
+
+const defaultSlowQueryThreshold = 10 * time.Second
+
+// SetSlowQueryThreshold sets the duration after which a SQL statement is logged
+// as slow. A non-positive duration disables slow-query logging.
+func (db *DB) SetSlowQueryThreshold(d time.Duration) {
+	db.slowQueryThreshold = d
+}
+
+// logSlowQuery logs sql when the elapsed time since start meets or exceeds the
+// configured slow-query threshold.
+func (db *DB) logSlowQuery(start time.Time, sql string) {
+	if db.slowQueryThreshold <= 0 {
+		return
+	}
+
+	elapsed := time.Since(start)
+	if elapsed >= db.slowQueryThreshold {
+		db.logger.Printf("slow query: duration=%s sql=%s", elapsed, sql)
+	}
+}

--- a/db/slow_query_test.go
+++ b/db/slow_query_test.go
@@ -1,0 +1,113 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	command "github.com/rqlite/rqlite/v10/command/proto"
+)
+
+type slowQueryTestExecer struct {
+	delay time.Duration
+}
+
+func (e *slowQueryTestExecer) ExecContext(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+	timer := time.NewTimer(e.delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return slowQueryTestResult{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (e *slowQueryTestExecer) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errors.New("unexpected QueryContext call")
+}
+
+type slowQueryTestResult struct{}
+
+func (slowQueryTestResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (slowQueryTestResult) RowsAffected() (int64, error) {
+	return 1, nil
+}
+
+func TestSlowQueryLogging(t *testing.T) {
+	db, path := mustCreateOnDiskDatabase()
+	defer db.Close()
+	defer os.Remove(path)
+
+	if got, want := db.slowQueryThreshold, defaultSlowQueryThreshold; got != want {
+		t.Fatalf("unexpected default slow-query threshold: got %s, want %s", got, want)
+	}
+
+	var buf bytes.Buffer
+	db.logger.SetOutput(&buf)
+	db.logger.SetFlags(0)
+	db.SetSlowQueryThreshold(5 * time.Millisecond)
+
+	const executeStmt = "UPDATE foo SET name = 'bar'"
+	_, err := db.executeStmtWithConn(
+		context.Background(),
+		&command.Statement{Sql: executeStmt},
+		false,
+		&slowQueryTestExecer{delay: 20 * time.Millisecond},
+		0,
+	)
+	if err != nil {
+		t.Fatalf("execute failed: %s", err.Error())
+	}
+	if got := buf.String(); !strings.Contains(got, "slow query:") || !strings.Contains(got, executeStmt) {
+		t.Fatalf("execute did not log the full slow SQL statement: %q", got)
+	}
+
+	buf.Reset()
+	const queryStmt = "SELECT 1"
+	queryCtx, cancelQuery := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	_, _ = db.QueryWithContext(queryCtx, &command.Request{
+		Statements: []*command.Statement{
+			{
+				Sql:        queryStmt,
+				ForceStall: true,
+			},
+		},
+	}, false)
+	cancelQuery()
+	if got := buf.String(); !strings.Contains(got, "slow query:") || !strings.Contains(got, queryStmt) {
+		t.Fatalf("query did not log the full slow SQL statement: %q", got)
+	}
+
+	buf.Reset()
+	forceQueryCtx, cancelForceQuery := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	_, _ = db.ExecuteWithContext(forceQueryCtx, &command.Request{
+		Statements: []*command.Statement{
+			{
+				Sql:        queryStmt,
+				ForceQuery: true,
+				ForceStall: true,
+			},
+		},
+	}, false)
+	cancelForceQuery()
+	if got := strings.Count(buf.String(), "slow query:"); got != 1 {
+		t.Fatalf("force query logged %d times, want 1: %q", got, buf.String())
+	}
+
+	buf.Reset()
+	db.SetSlowQueryThreshold(0)
+	db.logSlowQuery(time.Now().Add(-time.Second), "SELECT 1")
+	if got := buf.String(); got != "" {
+		t.Fatalf("slow-query logging was not disabled: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #447

## Summary
- add a configurable per-DB slow-query threshold with a 10-second default
- log the full SQL statement and elapsed duration when an execute or query exceeds the threshold
- keep `ForceQuery` on the query path so it is logged only once
- allow a non-positive threshold to disable slow-query logging
- add coverage for execute, query, `ForceQuery`, the default threshold, and disabling the feature

## Testing
- `go test ./db`
- Windows slow-query regression stress test (`TestSlowQueryLogging`, 50 runs)
- `gofmt` on all changed Go files
- `git diff --check`

## Coding-agent disclosure
This change was developed with coding-agent assistance and reviewed by me before submission.