### PR TITLE
Added configurable slow query logging

### DIFF
--- a/cmd/rqlited/config_flags.go
+++ b/cmd/rqlited/config_flags.go
@@ -110,6 +110,8 @@ type Config struct {
 	FKConstraints bool
 	// Maximum number of read-only connections to database
 	DBMaxReadOnlyConns int
+	// Minimum duration for logging slow SQL statements
+	SlowQueryThreshold time.Duration
 	// Period between automatic VACUUMs. If not set, not enabled
 	AutoVacInterval time.Duration
 	// Period between automatic 'PRAGMA optimize'. Set to 0h to disable
@@ -207,6 +209,7 @@ func Forge(arguments []string) (*flag.FlagSet, *Config, error) {
 	fs.DurationVar(&config.RaftReapReadOnlyNodeTimeout, "raft-reap-read-only-node-timeout", mustParseDuration("0h"), "Time after which a non-reachable read replica (non-voting) node will be reaped. If not set, no reaping takes place")
 	fs.BoolVar(&config.FKConstraints, "fk", false, "Enable SQLite foreign key constraints")
 	fs.IntVar(&config.DBMaxReadOnlyConns, "db-max-ro-conns", 256, "Maximum number of read-only connections to database")
+	fs.DurationVar(&config.SlowQueryThreshold, "slow-query-threshold", mustParseDuration("10s"), "Minimum duration for logging slow SQL statements")
 	fs.DurationVar(&config.AutoVacInterval, "auto-vacuum-int", mustParseDuration("0s"), "Period between automatic VACUUMs. If not set, not enabled")
 	fs.DurationVar(&config.AutoOptimizeInterval, "auto-optimize-int", mustParseDuration("24h"), "Period between automatic 'PRAGMA optimize'. Set to 0h to disable")
 	var tmpExtensionPaths string

--- a/cmd/rqlited/flags.toml
+++ b/cmd/rqlited/flags.toml
@@ -533,6 +533,17 @@ This places a limit on the number of read queries the node can service concurren
 default = 256
 
 [[flags]]
+name = "SlowQueryThreshold"
+cli = "slow-query-threshold"
+section = "SQLite database"
+type = "time.Duration"
+short_help = "Minimum duration for logging slow SQL statements"
+long_help = """
+SQL statements taking longer than this duration are logged as slow queries. Set to 0s to disable slow query logging.
+"""
+default = "10s"
+
+[[flags]]
 name = "AutoVacInterval"
 cli = "auto-vacuum-int"
 section = "SQLite database"

--- a/cmd/rqlited/main.go
+++ b/cmd/rqlited/main.go
@@ -432,6 +432,7 @@ func createStore(cfg *Config, ln *tcp.Layer, extensions []string) (*store.Store,
 	str.AutoOptimizeInterval = cfg.AutoOptimizeInterval
 	str.CompressSnapTransport = cfg.CompressSnapTransport
 	str.MaxReadOnlyConns = cfg.DBMaxReadOnlyConns
+	str.SlowQueryThreshold = cfg.SlowQueryThreshold
 	str.NoVerifyDB = true
 
 	if store.IsNewNode(cfg.DataPath) {

--- a/db/db.go
+++ b/db/db.go
@@ -197,6 +197,8 @@ type DB struct {
 	allOptimizedMu sync.Mutex
 
 	logger *log.Logger
+
+	slowQueryThreshold time.Duration // Minimum duration for slow SQL query logging
 }
 
 // PoolStats represents connection pool statistics
@@ -1229,6 +1231,9 @@ func (db *DB) executeStmtWithConn(ctx context.Context, stmt *command.Statement, 
 	}()
 	response := &command.ExecuteQueryResponse{}
 	start := time.Now()
+	if !stmt.ForceQuery {
+		defer db.logSlowQuery(start, stmt.Sql)
+	}
 
 	parameters, err := parametersToValues(stmt.Parameters)
 	if err != nil {
@@ -1417,6 +1422,8 @@ func (db *DB) queryStmtWithConn(ctx context.Context, stmt *command.Statement, xT
 	}()
 	rows := &command.QueryRows{}
 	start := time.Now()
+	defer db.logSlowQuery(start, stmt.Sql)
+
 	forceStall := stmt.ForceStall
 
 	parameters, err := parametersToValues(stmt.Parameters)
@@ -2223,4 +2230,22 @@ func rewriteContextTimeout(err, retErr error) error {
 		return retErr
 	}
 	return err
+}
+
+// SetSlowQueryThreshold sets the minimum duration for logging slow SQL statements. A zero or negative value disables logging.
+func (db *DB) SetSlowQueryThreshold(threshold time.Duration) {
+	db.slowQueryThreshold = threshold
+}
+
+// logSlowQuery logs the SQL statement if its execution time exceeds the
+// configured slow query threshold.
+func (db *DB) logSlowQuery(start time.Time, sql string) {
+	if db.slowQueryThreshold <= 0 {
+		return
+	}
+
+	duration := time.Since(start)
+	if duration > db.slowQueryThreshold {
+		db.logger.Printf("slow query (%s): %s", duration, sql)
+	}
 }

--- a/db/db_slow_query_test.go
+++ b/db/db_slow_query_test.go
@@ -1,0 +1,159 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	command "github.com/rqlite/rqlite/v10/command/proto"
+)
+
+type slowQueryTestExecer struct {
+	delay time.Duration
+}
+
+func (e *slowQueryTestExecer) ExecContext(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+	select {
+	case <-time.After(e.delay):
+		return slowQueryTestResult{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (e *slowQueryTestExecer) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errors.New("unexpected QueryContext call")
+}
+
+type slowQueryTestResult struct{}
+
+func (slowQueryTestResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (slowQueryTestResult) RowsAffected() (int64, error) {
+	return 1, nil
+}
+
+func Test_SlowQueryLog_Execute(t *testing.T) {
+	var buf bytes.Buffer
+	db := &DB{
+		logger: log.New(&buf, "", 0),
+	}
+	db.SetSlowQueryThreshold(10 * time.Millisecond)
+
+	const query = "UPDATE foo SET name = 'bar'"
+
+	_, err := db.executeStmtWithConn(
+		context.Background(),
+		&command.Statement{Sql: query},
+		false,
+		&slowQueryTestExecer{delay: 25 * time.Millisecond},
+		0,
+	)
+
+	if err != nil {
+		t.Fatalf("failed to execute statement: %s", err)
+	}
+
+	if !strings.Contains(buf.String(), "slow query") {
+		t.Fatalf("expected slow query log, got %q", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), query) {
+		t.Fatalf("expected SQL statement in slow query log, got %q", buf.String())
+	}
+}
+
+func Test_SlowQueryLog_Query(t *testing.T) {
+	db, path := mustCreateOnDiskDatabaseWAL()
+	defer os.Remove(path)
+	defer db.Close()
+
+	var buf bytes.Buffer
+	db.logger = log.New(&buf, "", 0)
+	db.SetSlowQueryThreshold(10 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _ = db.QueryWithContext(ctx, &command.Request{
+		Statements: []*command.Statement{
+			{
+				Sql:        "SELECT 1",
+				ForceStall: true,
+			},
+		},
+	}, false)
+
+	if count := strings.Count(buf.String(), "slow query"); count != 1 {
+		t.Fatalf("expected one slow query log, got %d: %q", count, buf.String())
+	}
+
+	if !strings.Contains(buf.String(), "SELECT 1") {
+		t.Fatalf("expected SQL statement in slow query log, got %q", buf.String())
+	}
+}
+
+func Test_SwappableDB_SlowQueryThresholdPreservedOnSwap(t *testing.T) {
+	srcPath := mustTempPath()
+	defer os.Remove(srcPath)
+
+	srcDB, err := Open(srcPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open source database: %s", err)
+	}
+
+	// Write to the database so the source file contains a valid SQLite header.
+	if _, err := srcDB.ExecuteStringStmt("CREATE TABLE foo (id INTEGER)"); err != nil {
+		t.Fatalf("failed to initialize source database: %s", err)
+	}
+
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("failed to close source database: %s", err)
+	}
+
+	swappablePath := mustTempPath()
+	defer os.Remove(swappablePath)
+
+	swappableDB, err := OpenSwappable(swappablePath, nil, false, false, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	threshold := 10 * time.Second
+	swappableDB.SetSlowQueryThreshold(threshold)
+
+	if got := swappableDB.db.slowQueryThreshold; got != threshold {
+		t.Fatalf("expected slow query threshold %s, got %s", threshold, got)
+	}
+
+	if err := swappableDB.Swap(srcPath, false, false); err != nil {
+		t.Fatalf("failed to swap database: %s", err)
+	}
+
+	if got := swappableDB.db.slowQueryThreshold; got != threshold {
+		t.Fatalf("expected slow query threshold %s after swap, got %s", threshold, got)
+	}
+}
+
+func Test_SlowQueryLog_Disabled(t *testing.T) {
+	var buf bytes.Buffer
+	db := &DB{
+		logger: log.New(&buf, "", 0),
+	}
+	db.SetSlowQueryThreshold(0)
+
+	db.logSlowQuery(time.Now().Add(-time.Minute), "SELECT 1")
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no slow query log when threshold is disabled, got %q", buf.String())
+	}
+}

--- a/db/swappable_db.go
+++ b/db/swappable_db.go
@@ -15,10 +15,11 @@ import (
 // SwappableDB is a wrapper around DB that allows the underlying database to be swapped out
 // in a thread-safe manner.
 type SwappableDB struct {
-	db            *DB
-	drv           *Driver
-	checkpointMgr *CheckpointManager
-	dbMu          sync.RWMutex
+	db                 *DB
+	drv                *Driver
+	checkpointMgr      *CheckpointManager
+	dbMu               sync.RWMutex
+	slowQueryThreshold time.Duration
 }
 
 // OpenSwappable returns a new SwappableDB instance, which opens the database at the given path,
@@ -69,6 +70,9 @@ func (s *SwappableDB) Swap(path string, fkConstraints, walEnabled bool) error {
 	if err != nil {
 		return fmt.Errorf("open SQLite file failed: %s", err)
 	}
+
+	db.SetSlowQueryThreshold(s.slowQueryThreshold)
+
 	s.db = db
 	if err := s.checkpointMgr.Close(); err != nil {
 		return fmt.Errorf("failed to close checkpoint manager: %s", err)
@@ -268,4 +272,14 @@ func (s *SwappableDB) Checkpoint(w io.Writer, timeout time.Duration) (*Checkpoin
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 	return s.checkpointMgr.Checkpoint(w, timeout)
+}
+
+// SetSlowQueryThreshold sets the minimum duration for logging slow SQL
+// statements. The setting is preserved when the underlying database is swapped.
+func (s *SwappableDB) SetSlowQueryThreshold(threshold time.Duration) {
+	s.dbMu.Lock()
+	defer s.dbMu.Unlock()
+
+	s.slowQueryThreshold = threshold
+	s.db.SetSlowQueryThreshold(threshold)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -425,6 +425,7 @@ type Store struct {
 	CompressSnapTransport    bool
 	MaxReadOnlyConns         int
 	NoVerifyDB               bool
+	SlowQueryThreshold       time.Duration
 
 	// Node-reaping configuration
 	ReapTimeout         time.Duration
@@ -780,6 +781,7 @@ func (s *Store) Open() (retErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create on-disk database: %s", err)
 	}
+	s.db.SetSlowQueryThreshold(s.SlowQueryThreshold)
 	s.checkpointer = s.db
 
 	// Clean up any files from aborted operations. This tries to catch the case where scratch files


### PR DESCRIPTION
## Summary

Closes #447

Adds slow-query logging for SQL statements that exceed a configurable execution-time threshold.

### Changes
- Added `--slow-query-threshold` configuration with a default threshold of 10s.
- Added slow-query logging for both `Execute` and `Query` paths.
- Added `SetSlowQueryThreshold()` to configure the threshold.
- Preserved the configured threshold when `SwappableDB` swaps the underlying database.
- Added tests covering slow `Execute`, slow `Query`, disabled logging, and threshold preservation across database swaps.

### Validation
- go test ./db
- go test ./...

All tests pass.