### PR TITLE
Fix database loss on failed swap (#2103)

### DIFF
--- a/db/swappable_db.go
+++ b/db/swappable_db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sync"
 	"time"
@@ -45,6 +46,38 @@ func OpenSwappable(dbPath string, drv *Driver, fkEnabled, wal bool, maxROConns i
 	}, nil
 }
 
+// Restore the original database after a failed swap.
+func (s *SwappableDB) restoreAfterSwapFailure(dbPath, tempPath string, fkConstraints, walEnabled bool) error {
+	// Remove the failed replacement database.
+	if err := RemoveFiles(dbPath); err != nil {
+		return fmt.Errorf("failed to remove failed replacement: %s", err)
+	}
+
+	// Restore the original database files.
+	if err := restoreDatabaseFiles(dbPath, tempPath); err != nil {
+		return fmt.Errorf("failed to restore original database files: %s", err)
+	}
+
+	// Reopen the original database so SwappableDB is usable again.
+	db, err := OpenWithDriver(s.drv, dbPath, fkConstraints, walEnabled)
+	if err != nil {
+		return fmt.Errorf("failed to reopen original database: %s", err)
+	}
+
+	// Recreate the checkpoint manager because the previous DB connection
+	// was closed before the swap started.
+	mgr, err := NewCheckpointManager(db)
+	if err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to recreate checkpoint manager: %s", err)
+	}
+
+	s.db = db
+	s.checkpointMgr = mgr
+
+	return nil
+}
+
 // Swap swaps the underlying database with that at the given path. The Swap operation
 // may fail on some platforms if the file at path is open by another process. It is
 // the caller's responsibility to ensure the file at path is not in use.
@@ -55,29 +88,94 @@ func (s *SwappableDB) Swap(path string, fkConstraints, walEnabled bool) error {
 
 	s.dbMu.Lock()
 	defer s.dbMu.Unlock()
+
+	dbPath := s.db.Path()
+
 	if err := s.db.Close(); err != nil {
 		return fmt.Errorf("failed to close: %s", err)
 	}
-	if err := RemoveFiles(s.db.Path()); err != nil {
-		return fmt.Errorf("failed to remove files: %s", err)
+
+	tempPath, err := createSwapTempPath(dbPath)
+	if err != nil {
+		// No files have been moved yet; reopen the original database.
+		db, reopenErr := OpenWithDriver(s.drv, dbPath, fkConstraints, walEnabled)
+		if reopenErr != nil {
+			return fmt.Errorf(
+				"failed to create swap temporary path: %s; failed to reopen original database: %s",
+				err,
+				reopenErr,
+			)
+		}
+		mgr, mgrErr := NewCheckpointManager(db)
+		if mgrErr != nil {
+			_ = db.Close()
+			return fmt.Errorf(
+				"failed to create swap temporary path: %s; failed to recreate checkpoint manager: %s",
+				err,
+				mgrErr,
+			)
+		}
+		s.db = db
+		s.checkpointMgr = mgr
+		return fmt.Errorf("failed to create swap temporary path: %s", err)
 	}
-	if err := os.Rename(path, s.db.Path()); err != nil {
+
+	if err := renameDatabaseFiles(dbPath, tempPath); err != nil {
+		// Some files may have been partially moved; restore what we can and reopen.
+		if restoreErr := s.restoreAfterSwapFailure(dbPath, tempPath, fkConstraints, walEnabled); restoreErr != nil {
+			return fmt.Errorf("failed to rename existing database files: %s; rollback failed: %s", err, restoreErr)
+		}
+		return fmt.Errorf("failed to rename existing database files: %s", err)
+	}
+
+	if err := os.Rename(path, dbPath); err != nil {
+		// Original files are in tempPath; restore them and reopen the original database.
+		if restoreErr := s.restoreAfterSwapFailure(dbPath, tempPath, fkConstraints, walEnabled); restoreErr != nil {
+			return fmt.Errorf("failed to rename database: %s; rollback failed: %s", err, restoreErr)
+		}
 		return fmt.Errorf("failed to rename database: %s", err)
 	}
 
-	db, err := OpenWithDriver(s.drv, s.db.Path(), fkConstraints, walEnabled)
+	db, err := OpenWithDriver(s.drv, dbPath, fkConstraints, walEnabled)
 	if err != nil {
+		if restoreErr := s.restoreAfterSwapFailure(dbPath, tempPath, fkConstraints, walEnabled); restoreErr != nil {
+			return fmt.Errorf("open SQLite file failed: %s; rollback failed: %s", err, restoreErr)
+		}
+
 		return fmt.Errorf("open SQLite file failed: %s", err)
 	}
-	s.db = db
-	if err := s.checkpointMgr.Close(); err != nil {
-		return fmt.Errorf("failed to close checkpoint manager: %s", err)
-	}
-	mgr, err := NewCheckpointManager(db)
+
+	newCheckpointMgr, err := NewCheckpointManager(db)
 	if err != nil {
-		return fmt.Errorf("failed to recreate checkpoint manager: %s", err)
+		_ = db.Close()
+
+		if restoreErr := s.restoreAfterSwapFailure(dbPath, tempPath, fkConstraints, walEnabled); restoreErr != nil {
+			return fmt.Errorf("failed to create checkpoint manager: %s; rollback failed: %s", err, restoreErr)
+		}
+
+		return fmt.Errorf("failed to create checkpoint manager: %s", err)
 	}
-	s.checkpointMgr = mgr
+
+	oldCheckpointMgr := s.checkpointMgr
+
+	if err := oldCheckpointMgr.Close(); err != nil {
+		_ = newCheckpointMgr.Close()
+		_ = db.Close()
+
+		if restoreErr := s.restoreAfterSwapFailure(dbPath, tempPath, fkConstraints, walEnabled); restoreErr != nil {
+			return fmt.Errorf("failed to close old checkpoint manager: %s; rollback failed: %s", err, restoreErr)
+		}
+
+		return fmt.Errorf("failed to close old checkpoint manager: %s", err)
+	}
+
+	s.db = db
+	s.checkpointMgr = newCheckpointMgr
+
+	if err := RemoveFiles(tempPath); err != nil {
+		return fmt.Errorf("swap succeeded, but failed to remove old database files: %s", err)
+	}
+
 	return nil
 }
 
@@ -268,4 +366,75 @@ func (s *SwappableDB) Checkpoint(w io.Writer, timeout time.Duration) (*Checkpoin
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 	return s.checkpointMgr.Checkpoint(w, timeout)
+}
+
+// Move database files to temporary paths.
+func renameDatabaseFiles(path, tempPath string) error {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		src := path + suffix
+		dst := tempPath + suffix
+
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+
+		if err := os.Rename(src, dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Restore database files from temporary paths.
+func restoreDatabaseFiles(path, tempPath string) error {
+	var firstErr error
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		src := tempPath + suffix
+		dst := path + suffix
+
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		if err := os.Rename(src, dst); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// Create a unique temporary swap path.
+func createSwapTempPath(dbPath string) (string, error) {
+	dir := filepath.Dir(dbPath)
+	base := filepath.Base(dbPath)
+
+	file, err := os.CreateTemp(dir, base+"-swap-*")
+	if err != nil {
+		return "", err
+	}
+
+	tempPath := file.Name()
+
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return "", err
+	}
+
+	if err := os.Remove(tempPath); err != nil {
+		return "", err
+	}
+
+	return tempPath, nil
 }

--- a/db/swappable_db_test.go
+++ b/db/swappable_db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rqlite/rqlite/v10/internal/fsutil"
@@ -164,5 +165,237 @@ func Test_SwapInvalidSQLiteFile(t *testing.T) {
 	err = swappableDB.Swap(invalidSQLiteFilePath, false, false)
 	if err == nil {
 		t.Fatalf("expected an error when swapping with an invalid SQLite file, got nil")
+	}
+}
+
+// Test_SwapFailure_PreservesOriginalDatabase verifies that a failed swap does
+// not remove or modify the existing database.
+func Test_SwapFailure_PreservesOriginalDatabase(t *testing.T) {
+	originalPath := mustTempPath()
+	defer os.Remove(originalPath)
+
+	originalDB, err := Open(originalPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open original database: %s", err)
+	}
+
+	mustExecute(originalDB, "CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	mustExecute(originalDB, `INSERT INTO foo(name) VALUES("original")`)
+
+	if err := originalDB.Close(); err != nil {
+		t.Fatalf("failed to close original database: %s", err)
+	}
+	replacementPath := mustTempPath()
+	defer os.Remove(replacementPath)
+
+	file, err := os.Create(replacementPath)
+	if err != nil {
+		t.Fatalf("failed to create replacement database: %s", err)
+	}
+
+	if _, err := file.WriteString("SQLite format 3\x00invalid"); err != nil {
+		_ = file.Close()
+		t.Fatalf("failed to write replacement database: %s", err)
+	}
+
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close replacement database: %s", err)
+	}
+
+	swappableDB, err := OpenSwappable(originalPath, nil, false, false, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	if err := swappableDB.Swap(replacementPath, false, false); err == nil {
+		t.Fatal("expected swap to fail, got nil")
+	}
+
+	if !fsutil.FileExists(originalPath) {
+		t.Fatal("original database file was removed after failed swap")
+	}
+
+	rows, err := swappableDB.QueryStringStmt("SELECT * FROM foo")
+	if err != nil {
+		t.Fatalf("swappable database unusable after failed swap: %s", err)
+	}
+
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"original"]]}]`, asJSON(rows); exp != got {
+		t.Fatalf("unexpected data after failed swap, expected %s, got %s", exp, got)
+	}
+}
+
+// Verifies that a pre-existing stale swap temporary file is not overwritten or deleted by a subsequent swap, and that
+// the swap still uses its own isolated temporary path.
+func Test_SwapFailure_StaleTempPath(t *testing.T) {
+	// Create the original database with known data.
+	originalPath := mustTempPath()
+	defer os.Remove(originalPath)
+
+	originalDB, err := Open(originalPath, false, false)
+	if err != nil {
+		t.Fatalf("failed to open original database: %s", err)
+	}
+	mustExecute(originalDB, "CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	mustExecute(originalDB, `INSERT INTO foo(name) VALUES("stale-test")`)
+	if err := originalDB.Close(); err != nil {
+		t.Fatalf("failed to close original database: %s", err)
+	}
+
+	dir := filepath.Dir(originalPath)
+	base := filepath.Base(originalPath)
+	staleFile, err := os.CreateTemp(dir, base+"-swap-")
+	if err != nil {
+		t.Fatalf("failed to create stale swap file: %s", err)
+	}
+	stalePath := staleFile.Name()
+	if _, err := staleFile.WriteString("stale sentinel content"); err != nil {
+		_ = staleFile.Close()
+		t.Fatalf("failed to write stale swap file: %s", err)
+	}
+	if err := staleFile.Close(); err != nil {
+		t.Fatalf("failed to close stale swap file: %s", err)
+	}
+	defer os.Remove(stalePath)
+
+	replacementPath := mustTempPath()
+	defer os.Remove(replacementPath)
+	rf, err := os.Create(replacementPath)
+	if err != nil {
+		t.Fatalf("failed to create replacement file: %s", err)
+	}
+	if _, err := rf.WriteString("SQLite format 3\x00invalid"); err != nil {
+		_ = rf.Close()
+		t.Fatalf("failed to write replacement file: %s", err)
+	}
+	if err := rf.Close(); err != nil {
+		t.Fatalf("failed to close replacement file: %s", err)
+	}
+
+	swappableDB, err := OpenSwappable(originalPath, nil, false, false, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	if err := swappableDB.Swap(replacementPath, false, false); err == nil {
+		t.Fatal("expected swap to fail, got nil")
+	}
+
+	// The stale file must still exist with its original content untouched.
+	if !fsutil.FileExists(stalePath) {
+		t.Fatal("stale swap file was removed by the swap operation")
+	}
+	staleContent, err := os.ReadFile(stalePath)
+	if err != nil {
+		t.Fatalf("failed to read stale swap file: %s", err)
+	}
+	if got := string(staleContent); got != "stale sentinel content" {
+		t.Fatalf("stale swap file content changed, got %q", got)
+	}
+
+	if !fsutil.FileExists(originalPath) {
+		t.Fatal("original database file does not exist after failed swap")
+	}
+
+	// The SwappableDB must remain fully usable after rollback.
+	rows, err := swappableDB.QueryStringStmt("SELECT * FROM foo")
+	if err != nil {
+		t.Fatalf("swappable database unusable after failed swap with stale path: %s", err)
+	}
+	if exp, got := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"stale-test"]]}]`, asJSON(rows); exp != got {
+		t.Fatalf("unexpected data after failed swap, expected %s, got %s", exp, got)
+	}
+}
+
+// Verifies that WAL and SHM sidecar files belonging to the original database are preserved and restored correctly when a swap fails.
+func Test_SwapFailure_WALSidecarFilesPreserved(t *testing.T) {
+	originalPath := mustTempPath()
+	defer os.Remove(originalPath)
+	defer os.Remove(originalPath + "-wal")
+	defer os.Remove(originalPath + "-shm")
+
+	originalDB, err := Open(originalPath, false, true) // WAL mode
+	if err != nil {
+		t.Fatalf("failed to open original WAL database: %s", err)
+	}
+	mustExecute(originalDB, "CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)")
+	mustExecute(originalDB, `INSERT INTO foo(name) VALUES("wal-original")`)
+
+	if err := originalDB.Close(); err != nil {
+		t.Fatalf("failed to close original database: %s", err)
+	}
+
+	// Open the same path through SwappableDB in WAL mode.
+	swappableDB, err := OpenSwappable(originalPath, nil, false, true, 0)
+	if err != nil {
+		t.Fatalf("failed to open swappable WAL database: %s", err)
+	}
+	defer swappableDB.Close()
+
+	// Write one more row via SwappableDB so the WAL file has data.
+	mustExecute(swappableDB.db, `INSERT INTO foo(name) VALUES("via-swappable")`)
+
+	// Confirm the WAL file exists before the swap attempt.
+	if !fsutil.FileExists(originalPath + "-wal") {
+		t.Skip("WAL file not present; skipping WAL sidecar preservation test")
+	}
+
+	// Create a replacement that passes the SQLite header check but cannot be opened.
+	replacementPath := mustTempPath()
+	defer os.Remove(replacementPath)
+
+	rf, err := os.Create(replacementPath)
+	if err != nil {
+		t.Fatalf("failed to create replacement file: %s", err)
+	}
+
+	if _, err := rf.WriteString("SQLite format 3\x00invalid"); err != nil {
+		_ = rf.Close()
+		t.Fatalf("failed to write replacement file: %s", err)
+	}
+
+	if err := rf.Close(); err != nil {
+		t.Fatalf("failed to close replacement file: %s", err)
+	}
+
+	// Perform the swap — it must fail.
+	if err := swappableDB.Swap(replacementPath, false, true); err == nil {
+		t.Fatal("expected swap to fail, got nil")
+	}
+
+	// The original database file must still be present.
+	if !fsutil.FileExists(originalPath) {
+		t.Fatal("original database file missing after failed WAL swap")
+	}
+
+	// The SwappableDB must remain usable and contain the original data.
+	rows, err := swappableDB.QueryStringStmt("SELECT * FROM foo ORDER BY id")
+	if err != nil {
+		t.Fatalf("swappable WAL database unusable after failed swap: %s", err)
+	}
+
+	expected := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"wal-original"],[2,"via-swappable"]]}]`
+	if got := asJSON(rows); got != expected {
+		t.Fatalf(
+			"unexpected data after failed WAL swap, expected %s, got %s",
+			expected,
+			got,
+		)
+	}
+
+	// No temporary swap files should remain in the database directory.
+	dir := filepath.Dir(originalPath)
+	base := filepath.Base(originalPath)
+	pattern := filepath.Join(dir, base+"-swap-*")
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("failed to glob for temp swap files: %s", err)
+	}
+
+	if len(matches) != 0 {
+		t.Fatalf("leftover temp swap files found after rollback: %v", matches)
 	}
 }


### PR DESCRIPTION
Closes #2103

### Changes

- Move the existing database files to a temporary path before swapping.
- Use a unique temporary path to avoid conflicts with existing swap files.
- Restore the original database files if the swap fails.
- Reopen the original database and recreate the checkpoint manager after rollback.
- Create the new checkpoint manager before making the new database active.
- Added tests for failed swaps, stale swap files, and WAL sidecar files.

### Validation

- `go test ./db`
- `go test ./...`