### PR TITLE
feat-447: integrate query logger with store

### DIFF
--- a/store/db_config.go
+++ b/store/db_config.go
@@ -1,9 +1,8 @@
 package store
 
 import (
+	"log"
 	"path/filepath"
-
-	sql "github.com/rqlite/rqlite/v10/db"
 )
 
 // DBConfig represents the configuration of the underlying SQLite database.
@@ -15,7 +14,7 @@ type DBConfig struct {
 	Extensions []string `json:"extensions,omitempty"`
 
 	// Controls query logging. If nil, query logging is disabled.
-	QueryLogConfig *sql.QueryLogConfig `json:"query_log_config,omitempty"`
+	QueryLogger *log.Logger
 }
 
 // NewDBConfig returns a new DB config instance.

--- a/store/db_config.go
+++ b/store/db_config.go
@@ -1,6 +1,10 @@
 package store
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	sql "github.com/rqlite/rqlite/v10/db"
+)
 
 // DBConfig represents the configuration of the underlying SQLite database.
 type DBConfig struct {
@@ -9,6 +13,9 @@ type DBConfig struct {
 
 	// Paths of SQLite Extensions to be loaded
 	Extensions []string `json:"extensions,omitempty"`
+
+	// Controls query logging. If nil, query logging is disabled.
+	QueryLogConfig *sql.QueryLogConfig `json:"query_log_config,omitempty"`
 }
 
 // NewDBConfig returns a new DB config instance.

--- a/store/store.go
+++ b/store/store.go
@@ -777,8 +777,8 @@ func (s *Store) Open() (retErr error) {
 	}
 
 	// If query logging is configured, use the query-log driver.
-	if s.dbConf.QueryLogConfig != nil {
-		ql := sql.NewQueryLogger(*s.dbConf.QueryLogConfig)
+	if s.dbConf.QueryLogger != nil {
+		ql := sql.NewQueryLogger(sql.QueryLogConfig{Logger: s.dbConf.QueryLogger})
 		s.dbDrv = sql.QueryLogDriver(ql)
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -776,6 +776,12 @@ func (s *Store) Open() (retErr error) {
 			s.dbConf.Extensions, sql.CnkOnCloseModeDisabled)
 	}
 
+	// If query logging is configured, use the query-log driver.
+	if s.dbConf.QueryLogConfig != nil {
+		ql := sql.NewQueryLogger(*s.dbConf.QueryLogConfig)
+		s.dbDrv = sql.QueryLogDriver(ql)
+	}
+
 	s.db, err = createDBOnDisk(s.dbPath, s.dbDrv, removeDBFiles, s.dbConf.FKConstraints, s.MaxReadOnlyConns)
 	if err != nil {
 		return fmt.Errorf("failed to create on-disk database: %s", err)

--- a/store/store_query_log_test.go
+++ b/store/store_query_log_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	dbpkg "github.com/rqlite/rqlite/v10/db"
+)
+
+// Verifies that when QueryLogConfig is nil,
+// the store opens and operates normally without any logging.
+func Test_StoreQueryLog_Disabled(t *testing.T) {
+	s, ln := mustNewStore(t)
+	defer s.Close(true)
+	defer ln.Close()
+
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to open store: %s", err)
+	}
+	if err := s.Bootstrap(NewServer(s.ID(), s.Addr(), true)); err != nil {
+		t.Fatalf("failed to bootstrap store: %s", err)
+	}
+	if _, err := s.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("failed to get leader: %s", err)
+	}
+
+	er := executeRequestFromString(`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)`, false, false)
+	if _, _, err := s.Execute(context.Background(), er); err != nil {
+		t.Fatalf("failed to execute CREATE TABLE: %s", err)
+	}
+}
+
+// Verifies that when QueryLogConfig is set,
+// SQL statements executed against the store appear in the query log.
+func Test_StoreQueryLog_Enabled(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	cfg := NewDBConfig()
+	cfg.QueryLogConfig = &dbpkg.QueryLogConfig{Logger: logger}
+
+	ly := mustMockLayer("localhost:0")
+	s := New(&Config{
+		DBConf: cfg,
+		Dir:    t.TempDir(),
+		ID:     "test-node",
+	}, ly)
+	defer s.Close(true)
+	defer ly.Close()
+
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to open store: %s", err)
+	}
+	if err := s.Bootstrap(NewServer(s.ID(), s.Addr(), true)); err != nil {
+		t.Fatalf("failed to bootstrap store: %s", err)
+	}
+	if _, err := s.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("failed to get leader: %s", err)
+	}
+
+	er := executeRequestFromString(`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)`, false, false)
+	if _, _, err := s.Execute(context.Background(), er); err != nil {
+		t.Fatalf("failed to execute CREATE TABLE: %s", err)
+	}
+
+	er = executeRequestFromString(`INSERT INTO t (name) VALUES ('alice')`, false, false)
+	if _, _, err := s.Execute(context.Background(), er); err != nil {
+		t.Fatalf("failed to execute INSERT: %s", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CREATE TABLE t") {
+		t.Fatalf("expected CREATE TABLE in query log, got:\n%s", output)
+	}
+	if !strings.Contains(output, "INSERT INTO t") {
+		t.Fatalf("expected INSERT in query log, got:\n%s", output)
+	}
+}

--- a/store/store_query_log_test.go
+++ b/store/store_query_log_test.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	dbpkg "github.com/rqlite/rqlite/v10/db"
 )
 
-// Verifies that when QueryLogConfig is nil,
+// Verifies that when QueryLogger is nil,
 // the store opens and operates normally without any logging.
 func Test_StoreQueryLog_Disabled(t *testing.T) {
 	s, ln := mustNewStore(t)
@@ -34,14 +32,14 @@ func Test_StoreQueryLog_Disabled(t *testing.T) {
 	}
 }
 
-// Verifies that when QueryLogConfig is set,
+// Verifies that when QueryLogger is set,
 // SQL statements executed against the store appear in the query log.
 func Test_StoreQueryLog_Enabled(t *testing.T) {
 	var buf bytes.Buffer
 	logger := log.New(&buf, "", 0)
 
 	cfg := NewDBConfig()
-	cfg.QueryLogConfig = &dbpkg.QueryLogConfig{Logger: logger}
+	cfg.QueryLogger = logger
 
 	ly := mustMockLayer("localhost:0")
 	s := New(&Config{


### PR DESCRIPTION
Fix: #447

Integrates the existing query logging support with the Store.

### Changes

- Add `QueryLogConfig` to `store.DBConfig`.
- Configure the Store to use `QueryLogDriver` when query logging is configured.
- Add Store-level tests covering:
  - Query logging disabled.
  - Query logging enabled and SQL statements being logged.

As discussed in #2741