### PR TITLE
fix(snapshot): skip no-op rename in reap plan

### DIFF
--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -642,8 +642,20 @@ func (s *Store) reapInternal() (int, int, error) {
 		// 7. Rename to new snapshot name. The end result of the Reaping process
 		// will be a new full snapshot with a new ID. That ID is generated from
 		// the newest snapshot's index and term, and the current timestamp.
+		//
+		// Skip the rename if it would be a no-op. This happens when there are no
+		// incremental snapshots newer than full (so newest == full) and the
+		// millisecond-resolution timestamp component of newID happens to match the
+		// one already in full's name -- e.g. because less than a millisecond
+		// elapsed since full was named, or the wall clock stepped backwards. In
+		// that case os.Rename fails with EEXIST since source == destination, and
+		// since the rename is persisted in the plan, every future restart replays
+		// the same failing rename forever (see checker.RenameDone, which never
+		// considers a Src == Dst rename done).
 		finalDir := filepath.Join(s.dir, newID)
-		p.AddRename(full.path, finalDir)
+		if full.path != finalDir {
+			p.AddRename(full.path, finalDir)
+		}
 	}
 
 	// Persist the plan to disk for crash recovery.

--- a/snapshot/store_test.go
+++ b/snapshot/store_test.go
@@ -984,6 +984,90 @@ func Test_Store_Reap(t *testing.T) {
 
 }
 
+// Test_Store_ReapNoOpRename is a regression test for the case where the reap
+// plan's final rename is a no-op (source and destination are the same
+// directory). This happens when the newest snapshot has no incremental
+// snapshots on top of it (so it plans to rename itself to itself) and the
+// millisecond-resolution timestamp component of the recomputed name happens
+// to match the one already in its own name -- which is guaranteed here since
+// we give it an explicit ID and, within a single goroutine with no blocking
+// calls, consecutive time.Now() calls return the same instant.
+//
+// Before the fix, planning this rename unconditionally meant the persisted
+// plan always contained a Src == Dst rename. On platforms where renaming a
+// directory onto itself returns an error (observed on Linux, though not
+// reproducible with os.Rename on Windows, which is why this test asserts on
+// the planned operations rather than a platform-specific rename failure),
+// that made the reap plan permanently un-completable: Checker.RenameDone
+// never sees the source disappear, so a resumed plan fails identically on
+// every restart.
+func Test_Store_ReapNoOpRename(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("Failed to create new store: %v", err)
+	}
+	defer store.Close()
+
+	// An older snapshot for the reap to discard.
+	createSnapshotInStore(t, store, "2-1017-1704807719996", 1017, 2, 1, "testdata/db-and-wals/backup.db")
+
+	// The newest snapshot already has its own bundled, not-yet-checkpointed WAL
+	// file -- the state a node is in immediately after receiving a snapshot
+	// from the leader -- and no incremental snapshot follows it. Its ID's
+	// timestamp component is fixed to whatever time.Now() yields right now, so
+	// that the ID snapshotName() recomputes during reap collides with it.
+	now := time.Now()
+	msec := now.UnixNano() / int64(time.Millisecond)
+	fullID := fmt.Sprintf("2-1131-%d", msec)
+	createSnapshotInStore(t, store, fullID, 1131, 2, 1, "testdata/db-and-wals/backup.db", "testdata/db-and-wals/wal-00")
+
+	n, c, err := store.Reap()
+	if err != nil {
+		t.Fatalf("Failed to reap snapshots: %v", err)
+	}
+	if exp, got := 1, n; exp != got {
+		t.Fatalf("Expected %d snapshots reaped, got %d", exp, got)
+	}
+	if exp, got := 1, c; exp != got {
+		t.Fatalf("Expected %d checkpoints made, got %d", exp, got)
+	}
+
+	snaps := mustListSnapshots(t, store)
+	if exp, got := 1, len(snaps); exp != got {
+		t.Fatalf("Expected %d snapshot in destination store, got %d", exp, got)
+	}
+
+	// Confirm the persisted plan (if any is still on disk) never contains a
+	// Src == Dst rename, regardless of what the underlying OS does with one.
+	if p, err := plan.ReadFromFile(store.reapPlanPath); err == nil {
+		for _, op := range p.Ops {
+			if op.Type == plan.OpRename && op.Src == op.Dst {
+				t.Fatalf("plan contains a no-op rename: %+v", op)
+			}
+		}
+	}
+
+	// The reap must actually have completed and produced valid, queryable data,
+	// not merely returned without error.
+	_, rc, err := store.Open(snaps[0].ID)
+	if err != nil {
+		t.Fatalf("Failed to open snapshot in destination store: %v", err)
+	}
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, rc); err != nil {
+		t.Fatalf("Failed to read snapshot data from destination store: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Failed to close snapshot reader in destination store: %v", err)
+	}
+	dbPath, _ := persistStreamerData(t, buf)
+	rows := mustQueryDB(t, dbPath, "SELECT COUNT(*) FROM foo")
+	if exp, got := `[{"columns":["COUNT(*)"],"types":["integer"],"values":[[1]]}]`, rows; exp != got {
+		t.Fatalf("unexpected results for query exp: %s got: %s", exp, got)
+	}
+}
+
 func Test_Store_ReapCorruptDB(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir)


### PR DESCRIPTION
Fixes #2746.

**Disclosure:** I used a coding agent (Claude) to investigate and implement this fix, under my direction and review. The issue itself already contained an exceptionally thorough root-cause analysis and a validated Antithesis repro from the reporter — I read and understood that analysis, traced the actual code at the referenced locations to confirm it, and applied their suggested fix rather than treating their write-up as a black box.

## Understanding of the bug

`Store.reapInternal`'s compaction step always plans a final rename of the full snapshot's directory to a newly computed name (`newID`, derived from `newest`'s term/index plus the current millisecond timestamp). When there's no incremental snapshot newer than `full`, `newest == full`, so `newID` differs from `full`'s existing directory name only in its timestamp component. If that timestamp happens to collide with the one already in `full`'s name (sub-millisecond timing, or a backward clock step), the planned rename has `Src == Dst`.

`os.Rename` on some platforms (documented as reproducing on Linux) returns `EEXIST` when the destination already exists — including when it's the same path as the source. Since the rename is persisted to the on-disk plan before execution, and `Checker.RenameDone` can never see the source disappear when `Src == Dst`, a plan containing this rename can never be recognized as complete. Because the plan file is only removed after a successful execution, the failure is replayed identically on every subsequent restart, permanently preventing the node from starting.

## Fix

Skip adding the rename to the plan at all when `full.path == finalDir` (`snapshot/store.go`), matching the reporter's suggested fix.

## Testing

Added `Test_Store_ReapNoOpRename` in `snapshot/store_test.go`, which sets up the exact trigger conditions (a full snapshot carrying its own bundled, not-yet-checkpointed WAL — the state a node is in right after receiving a snapshot from the leader — with no incremental on top of it, and an older snapshot for the reap to discard) and pins the full snapshot's ID to the current millisecond so the recomputed name collides with it. The test asserts the reap completes, produces valid queryable data, and that no `Src == Dst` rename is ever left in a persisted plan.

**Caveat I want to be upfront about:** I developed and ran this on Windows, where I confirmed directly that `os.Rename(path, path)` on an existing directory returns `nil`, not an error — so I could not locally reproduce the pre-fix failure via an actual failing rename. The test therefore can't turn red on this platform even without the fix; I verified this by reverting only the `store.go` change and confirming the test still passes locally. What it does verify, on any platform: the reap completes correctly and produces valid data under the exact conditions described in the issue. I'm relying on the reporter's own Antithesis-validated confirmation (mentioned in the issue) that removing the redundant rename makes the real EEXIST failure go away on the platform where it reproduces, and expect CI here to exercise that path properly if it runs on Linux.

`go build ./...` and `go test ./snapshot/...` pass; `gofmt` and `go vet` are clean on the changed files.