### PR TITLE
WIP: Record snapshot index and term in clean-snapshot fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [PR #2741](https://github.com/rqlite/rqlite/pull/2741), [PR #2745](https://github.com/rqlite/rqlite/pull/2745): Add query logging at database level. Thanks @karangupta982
 - [PR #2751](https://github.com/rqlite/rqlite/pull/2751): Add _CopyDir_ functionality to file utils.
 - [PR #2752](https://github.com/rqlite/rqlite/pull/2752): Add ability to clone Snapshots, primarily for testing purposes.
+- [PR #2753](https://github.com/rqlite/rqlite/pull/2753): The clean-snapshot marker now records the Raft index and term of the Snapshot the SQLite database corresponds to. A node therefore no longer fast-restarts with a database which does not match the newest Snapshot in its Snapshot Store, which could previously result in the node hiding committed rows. Each node performs a single full restore from its Snapshot Store on its first start after upgrading. Fixes issue [#2747](https://github.com/rqlite/rqlite/issues/2747). Thanks @rohanpadhye
 
 ## v10.2.7 (July 5th 2026)
 ### Implementation changes and bug fixes

--- a/snapshot/sink.go
+++ b/snapshot/sink.go
@@ -26,6 +26,26 @@ type snapshotTypeController interface {
 	SetDueNext(Type) error
 }
 
+// IndexTermer is implemented by a snapshot sink which knows the Raft index and
+// term of the snapshot it is capturing. Sink implements it.
+type IndexTermer interface {
+	Index() uint64
+	Term() uint64
+}
+
+// SinkIndexTerm returns the Raft index and term of the snapshot the given sink is
+// capturing. Raft's SnapshotSink interface exposes only the snapshot ID, so the
+// index and term must be recovered from the sink itself. Every sink Raft holds
+// comes from Store.Create in this package, so a sink which cannot supply them is
+// a programming error and is reported as such.
+func SinkIndexTerm(sink raft.SnapshotSink) (uint64, uint64, error) {
+	it, ok := sink.(IndexTermer)
+	if !ok {
+		return 0, 0, fmt.Errorf("snapshot sink of type %T does not know its index and term", sink)
+	}
+	return it.Index(), it.Term(), nil
+}
+
 // Sink is a sink for writing snapshot data to a Snapshot store.
 //
 // This sink is adaptive. It can handle multiple types of snapshot data,

--- a/snapshot/sink_test.go
+++ b/snapshot/sink_test.go
@@ -423,3 +423,31 @@ func asJSON(v any) string {
 	}
 	return string(b)
 }
+
+func Test_SinkIndexTerm(t *testing.T) {
+	sink := NewSink(t.TempDir(), makeRaftMeta("test-index-term", 100, 3, 1), nil, nil)
+	index, term, err := SinkIndexTerm(sink)
+	if err != nil {
+		t.Fatalf("unexpected error getting index and term of sink: %s", err.Error())
+	}
+	if exp, got := uint64(100), index; exp != got {
+		t.Fatalf("wrong index, exp %d, got %d", exp, got)
+	}
+	if exp, got := uint64(3), term; exp != got {
+		t.Fatalf("wrong term, exp %d, got %d", exp, got)
+	}
+}
+
+func Test_SinkIndexTerm_NotIndexTermer(t *testing.T) {
+	if _, _, err := SinkIndexTerm(&testSnapshotSink{}); err == nil {
+		t.Fatalf("expected error from sink which does not know its index and term")
+	}
+}
+
+// testSnapshotSink implements raft.SnapshotSink and nothing more.
+type testSnapshotSink struct{}
+
+func (t *testSnapshotSink) Write(p []byte) (int, error) { return len(p), nil }
+func (t *testSnapshotSink) Close() error                { return nil }
+func (t *testSnapshotSink) ID() string                  { return "test" }
+func (t *testSnapshotSink) Cancel() error               { return nil }

--- a/store/DESIGN.md
+++ b/store/DESIGN.md
@@ -77,12 +77,19 @@ The clean-snapshot fingerprint is the optimization that makes this skip safe. Af
 - The SQLite file's modification time
 - Its size
 - Its CRC32
+- The Raft index and term of the snapshot the file corresponds to
 
-On `Open`, the Store checks for this file. If it exists, the SQLite file's mtime and size still match, and the snapshot store has at least one snapshot, the Store sets `raftConfig.NoSnapshotRestoreOnStart = true` — telling Raft to bring up the FSM without re-restoring from the snapshot. The local SQLite file is reused as-is.
+On `Open`, the Store checks for this file. If it exists, the SQLite file's mtime and size still match, and the recorded index and term are those of the newest snapshot in the snapshot store, the Store sets `raftConfig.NoSnapshotRestoreOnStart = true` — telling Raft to bring up the FSM without re-restoring from the snapshot. The local SQLite file is reused as-is.
+
+The index and term matter as much as the state of the file itself. Raft's `InstallSnapshot` makes a received snapshot durable and visible — `sink.Close()` — *before* handing it to the FSM to be restored, so a crash or a failed restore in that window leaves the snapshot store ahead of the SQLite file, with the fingerprint still describing that file perfectly. Recording only the file's own state, the node would take the fast path and adopt an index its database has never seen, hiding every row committed at or below it; since `NoSnapshotRestoreOnStart` also stops Raft replaying the log below that index, nothing would ever repair it. The drift runs the other way too: a snapshot which is fingerprinted but never becomes visible in the store leaves the SQLite file *ahead* of the store, and Raft would replay entries the database has already applied. Requiring an exact match on index and term declines the fast path in both cases, at the cost of one restore. See [issue #2747](https://github.com/rqlite/rqlite/issues/2747).
+
+The fingerprint is written by the `FSMSnapshot` finalizer, which Raft invokes at the end of `Persist` — before `sink.Close()`, and therefore before the new snapshot is visible in the snapshot store. The index and term cannot be looked up there, so they are taken from the sink Raft passed to `Persist`, via `snapshot.SinkIndexTerm`. On the restore path `fsmRestore` uses the index and term it is itself adopting.
 
 The CRC32 check is more expensive (it has to read the whole file), so it runs asynchronously in a goroutine after `Open` returns. While that goroutine is running, snapshotting is blocked by `snapshotCAS` so the file is not modified mid-CRC. If the CRC mismatches, the process logs a fatal error and exits — the node is in an unrecoverable state and the cluster's redundancy is supposed to provide the fault tolerance.
 
 Any code path that invalidates the SQLite file relative to the snapshot store — `fsmRestore`, `RecoverNode`, `Load`, manual swap — removes the fingerprint file before swapping. On the next restart, the absence of the fingerprint forces a normal snapshot-restore. The optimization is opt-in by design: only a *clean* shutdown after a successful snapshot enables the fast path.
+
+A fingerprint written by a version which did not record the index and term has both set to zero, so it never matches. Every node therefore performs one full restore on its first startup after upgrading to a version which records them.
 
 ## State and Locks
 

--- a/store/file_fingerprint.go
+++ b/store/file_fingerprint.go
@@ -2,17 +2,27 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 )
 
-// FileFingerprint stores a file's modification time and size.
-// It can be written to or read from disk as JSON. Older versions
-// may not have the CRC32 field, so it is optional in comparisons.
+// FileFingerprint describes a file, and the snapshot that file corresponds to,
+// at the moment the file was fingerprinted. It can be written to or read from
+// disk as JSON. Fingerprints written by older versions may not have the CRC32,
+// Index and Term fields, so they are optional.
 type FileFingerprint struct {
 	ModTime time.Time `json:"mod_time"`
 	Size    int64     `json:"size"`
 	CRC32   uint32    `json:"crc32,omitempty"`
+	Index   uint64    `json:"index,omitempty"`
+	Term    uint64    `json:"term,omitempty"`
+}
+
+// String implements the Stringer interface.
+func (f *FileFingerprint) String() string {
+	return fmt.Sprintf("FileFingerprint{mod time: %s, size: %d, CRC32: %d, index: %d, term: %d}",
+		f.ModTime, f.Size, f.CRC32, f.Index, f.Term)
 }
 
 // WriteToFile saves the fingerprint to a file and fsyncs it to disk.
@@ -49,9 +59,24 @@ func (f *FileFingerprint) ReadFromFile(path string) error {
 	return json.Unmarshal(data, f)
 }
 
-// Compare checks if the given modification time and size match the fingerprint.
-// If the CRC32 in the fingerprint is zero, it is ignored in the comparison to
-// allow for backward compatibility.
-func (f *FileFingerprint) Compare(mt time.Time, sz int64, crc uint32) bool {
-	return f.ModTime.Equal(mt) && f.Size == sz && (f.CRC32 == crc || f.CRC32 == 0)
+// ValidFor returns whether the file described by this fingerprint can be used
+// as-is at startup, given that the newest snapshot in the Snapshot Store is at
+// the given index and term. Two things must hold: the file must be unchanged
+// since it was fingerprinted, and it must be the file which corresponds to that
+// snapshot.
+//
+// If the two have parted company then a snapshot reached the Snapshot Store
+// without being restored into the FSM, or a snapshot was fingerprinted but never
+// became visible in the Store. Either way the file and the Store describe
+// different states, and only a restore from the Store can resolve it. See
+// https://github.com/rqlite/rqlite/issues/2747.
+//
+// A fingerprint written before the index and term were recorded has both set to
+// zero and so is never valid while any snapshot exists. Such a node performs one
+// full restore on its first startup after upgrading.
+//
+// The CRC32 is deliberately not checked here: calculating it means reading the
+// whole file, so that check is made separately.
+func (f *FileFingerprint) ValidFor(mt time.Time, sz int64, index, term uint64) bool {
+	return f.ModTime.Equal(mt) && f.Size == sz && f.Index == index && f.Term == term
 }

--- a/store/file_fingerprint_test.go
+++ b/store/file_fingerprint_test.go
@@ -15,6 +15,8 @@ func Test_FileFingerprint_WriteAndRead(t *testing.T) {
 		ModTime: time.Now().UTC().Truncate(time.Second),
 		Size:    123456,
 		CRC32:   78901234,
+		Index:   10,
+		Term:    2,
 	}
 
 	// Write fingerprint
@@ -44,27 +46,38 @@ func Test_FileFingerprint_WriteAndRead(t *testing.T) {
 	if loaded.Size != original.Size {
 		t.Fatalf("Size mismatch: got %d, want %d", loaded.Size, original.Size)
 	}
+	if loaded.CRC32 != original.CRC32 {
+		t.Fatalf("CRC32 mismatch: got %d, want %d", loaded.CRC32, original.CRC32)
+	}
+	if loaded.Index != original.Index {
+		t.Fatalf("Index mismatch: got %d, want %d", loaded.Index, original.Index)
+	}
+	if loaded.Term != original.Term {
+		t.Fatalf("Term mismatch: got %d, want %d", loaded.Term, original.Term)
+	}
+}
 
-	if !loaded.Compare(original.ModTime, original.Size, original.CRC32) {
-		t.Fatalf("Compare returned false for matching values")
+// Test_FileFingerprint_WriteAndRead_Legacy checks that a fingerprint written
+// before the index and term were recorded is still readable, and reads back with
+// both set to zero.
+func Test_FileFingerprint_WriteAndRead_Legacy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fp.json")
+	if err := os.WriteFile(path, []byte(`{"mod_time":"2026-08-30T09:00:00Z","size":123456,"crc32":78901234}`), 0644); err != nil {
+		t.Fatalf("failed to write legacy fingerprint: %v", err)
 	}
 
-	if loaded.Compare(original.ModTime, original.Size+1, original.CRC32) {
-		t.Fatalf("Compare returned true for non-matching size")
+	var fp FileFingerprint
+	if err := fp.ReadFromFile(path); err != nil {
+		t.Fatalf("ReadFromFile failed: %v", err)
 	}
-
-	if loaded.Compare(original.ModTime.Add(time.Second), original.Size, original.CRC32) {
-		t.Fatalf("Compare returned true for non-matching mod time")
+	if exp, got := int64(123456), fp.Size; exp != got {
+		t.Fatalf("Size mismatch: got %d, want %d", got, exp)
 	}
-
-	if loaded.Compare(original.ModTime, original.Size, original.CRC32+1) {
-		t.Fatalf("Compare returned true for non-matching CRC32")
+	if exp, got := uint32(78901234), fp.CRC32; exp != got {
+		t.Fatalf("CRC32 mismatch: got %d, want %d", got, exp)
 	}
-
-	// Test backward compatibility with zero CRC32
-	loaded.CRC32 = 0
-	if !loaded.Compare(original.ModTime, original.Size, original.CRC32+1) {
-		t.Fatalf("Compare returned false for zero CRC32")
+	if fp.Index != 0 || fp.Term != 0 {
+		t.Fatalf("expected zero index and term, got %d and %d", fp.Index, fp.Term)
 	}
 }
 
@@ -73,5 +86,87 @@ func Test_FileFingerprint_ReadFromMissingFile(t *testing.T) {
 	err := fp.ReadFromFile("nonexistent.json")
 	if err == nil {
 		t.Fatalf("expected error reading nonexistent file")
+	}
+}
+
+// Test_FileFingerprint_ValidFor tests the rule which decides whether the SQLite
+// file a node finds on disk at startup can be used as-is, or whether the node
+// must restore from the Snapshot Store instead.
+func Test_FileFingerprint_ValidFor(t *testing.T) {
+	mt := time.Now().UTC().Truncate(time.Second)
+	fp := FileFingerprint{
+		ModTime: mt,
+		Size:    123456,
+		CRC32:   78901234,
+		Index:   10,
+		Term:    2,
+	}
+	legacy := FileFingerprint{
+		ModTime: mt,
+		Size:    fp.Size,
+	}
+
+	tests := []struct {
+		name  string
+		fp    FileFingerprint
+		mt    time.Time
+		sz    int64
+		index uint64
+		term  uint64
+		exp   bool
+	}{
+		{
+			name: "Match",
+			fp:   fp, mt: mt, sz: fp.Size, index: fp.Index, term: fp.Term, exp: true,
+		},
+		{
+			name: "ModTimeChanged",
+			fp:   fp, mt: mt.Add(time.Second), sz: fp.Size, index: fp.Index, term: fp.Term, exp: false,
+		},
+		{
+			name: "SizeChanged",
+			fp:   fp, mt: mt, sz: fp.Size + 1, index: fp.Index, term: fp.Term, exp: false,
+		},
+		{
+			// The Snapshot Store has moved past the file, which means a snapshot
+			// reached the Store but was never restored into the FSM. Using the file
+			// as-is would mean adopting an index it has never seen.
+			// See https://github.com/rqlite/rqlite/issues/2747.
+			name: "SnapshotStoreAhead",
+			fp:   fp, mt: mt, sz: fp.Size, index: fp.Index + 1, term: fp.Term, exp: false,
+		},
+		{
+			// The file was fingerprinted for a snapshot which never became visible
+			// in the Snapshot Store. The file holds state the Store does not, and
+			// Raft would replay logs the file has already seen.
+			name: "SnapshotStoreBehind",
+			fp:   fp, mt: mt, sz: fp.Size, index: fp.Index - 1, term: fp.Term, exp: false,
+		},
+		{
+			name: "TermChanged",
+			fp:   fp, mt: mt, sz: fp.Size, index: fp.Index, term: fp.Term + 1, exp: false,
+		},
+		{
+			// A fingerprint written before the index and term were recorded cannot be
+			// shown to correspond to the newest snapshot, so a full restore is needed.
+			// This costs an upgrading node one restore on its first startup.
+			name: "LegacyFingerprint",
+			fp:   legacy, mt: mt, sz: legacy.Size, index: 10, term: 2, exp: false,
+		},
+		{
+			// A legacy fingerprint whose file has also changed is invalid for both
+			// reasons.
+			name: "LegacyFingerprintSizeChanged",
+			fp:   legacy, mt: mt, sz: legacy.Size + 1, index: 10, term: 2, exp: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fp.ValidFor(tt.mt, tt.sz, tt.index, tt.term); got != tt.exp {
+				t.Fatalf("ValidFor(%s, %d, %d, %d) returned %v, expected %v",
+					tt.mt, tt.sz, tt.index, tt.term, got, tt.exp)
+			}
+		})
 	}
 }

--- a/store/fsm.go
+++ b/store/fsm.go
@@ -41,8 +41,11 @@ func (f *FSM) Restore(rc io.ReadCloser) error {
 // FSMSnapshot is a wrapper around raft.FSMSnapshot which adds an optional
 // Finalizer, instrumentation, and logging.
 type FSMSnapshot struct {
-	Type      snapshot.Type
-	Finalizer func() error
+	Type snapshot.Type
+	// Finalizer, if set, is called once the snapshot has been persisted to the
+	// sink. It is passed the sink so that any record it makes of the snapshot
+	// can be tied to the index and term the snapshot was captured at.
+	Finalizer func(sink raft.SnapshotSink) error
 	OnRelease func(invoked, succeeded bool)
 
 	raft.FSMSnapshot
@@ -74,7 +77,7 @@ func (f *FSMSnapshot) Persist(sink raft.SnapshotSink) (retError error) {
 		return err
 	}
 	if f.Finalizer != nil {
-		return f.Finalizer()
+		return f.Finalizer(sink)
 	}
 	return nil
 }

--- a/store/fsm_test.go
+++ b/store/fsm_test.go
@@ -8,21 +8,25 @@ import (
 )
 
 func Test_FSMSnapshot_Finalizer(t *testing.T) {
-	finalizerCalled := false
+	var finalizerSink raft.SnapshotSink
+	sink := &mockSnapshotSink{}
 	f := FSMSnapshot{
-		Finalizer: func() error {
-			finalizerCalled = true
+		Finalizer: func(s raft.SnapshotSink) error {
+			finalizerSink = s
 			return nil
 		},
 		FSMSnapshot: &mockRaftSnapshot{},
 		logger:      nil,
 	}
 
-	if err := f.Persist(&mockSnapshotSink{}); err != nil {
+	if err := f.Persist(sink); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !finalizerCalled {
+	if finalizerSink == nil {
 		t.Fatalf("finalizer was not called")
+	}
+	if finalizerSink != raft.SnapshotSink(sink) {
+		t.Fatalf("finalizer was not passed the sink given to Persist")
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -647,9 +647,24 @@ func (s *Store) Open() (retErr error) {
 			s.logger.Printf("failed to read mod time from clean snapshot (%s), performing full restore", err)
 			return nil
 		}
+		li, tm, err := snapshotStore.LatestIndexTerm()
+		if err != nil {
+			s.logger.Printf("failed to retrieve latest snapshot index/term (%s), performing full restore", err)
+			return nil
+		}
 
-		if !mt.Equal(fp.ModTime) || sz != fp.Size {
-			s.logger.Printf("clean snapshot failed mod time and size check, full restore needed")
+		// The SQLite file must be unchanged since it was fingerprinted, and must be the
+		// file which corresponds to the newest snapshot in the Snapshot Store. If the
+		// Store has moved on without the SQLite file moving with it, then a snapshot
+		// reached the Store but was never restored into the FSM, and taking the fast
+		// path would mean coming up at an index this database has never seen.
+		if fp.Index == 0 && fp.Term == 0 {
+			s.logger.Printf("clean snapshot predates recording of snapshot index and term, full restore needed")
+			return nil
+		}
+		if !fp.ValidFor(mt, sz, li, tm) {
+			s.logger.Printf("clean snapshot check failed, full restore needed (%s, database file mod time: %s, size: %d, newest snapshot index: %d, term: %d)",
+				fp, mt, sz, li, tm)
 			return nil
 		}
 
@@ -703,10 +718,6 @@ func (s *Store) Open() (retErr error) {
 		s.logger.Printf("detected successful prior snapshot operation, skipping restore")
 		raftConfig.NoSnapshotRestoreOnStart = true
 		removeDBFiles = false
-		li, tm, err := snapshotStore.LatestIndexTerm()
-		if err != nil {
-			return fmt.Errorf("failed to retrieve latest snapshot index/term: %s", err)
-		}
 		s.fsmIdx.Store(li)
 		s.fsmTerm.Store(tm)
 		s.dbAppliedIdx.Store(li)
@@ -2635,7 +2646,17 @@ func (s *Store) fsmSnapshot() (fSnap raft.FSMSnapshot, retErr error) {
 	}()
 
 	var fsmSnapshot raft.FSMSnapshot
-	finalizer := s.createSnapshotFingerprint
+	// The fingerprint must record the index and term of the snapshot now being
+	// created, so that a restart can tell whether the SQLite file on disk is the
+	// one this snapshot was made from. Raft passes the sink to Persist, and the
+	// sink knows what it is capturing.
+	finalizer := func(sink raft.SnapshotSink) error {
+		index, term, err := snapshot.SinkIndexTerm(sink)
+		if err != nil {
+			return fmt.Errorf("failed to determine index and term of snapshot: %w", err)
+		}
+		return s.createSnapshotFingerprint(index, term)
+	}
 	if dueNext.IsFull() {
 		// We need to start the snapshoting process over again, starting with a full copy of the SQLite
 		// database. This happens when a node is snapshotting for the very first time, or in certain
@@ -2803,10 +2824,6 @@ func (s *Store) fsmRestore(rc io.ReadCloser) (retErr error) {
 		return fmt.Errorf("error swapping database file: %v", err)
 	}
 	s.logger.Printf("successfully opened database at %s due to restore", s.db.Path())
-	// Installed SQLite database is safe for fast restarts again.
-	if err := s.createSnapshotFingerprint(); err != nil {
-		return fmt.Errorf("failed to create snapshot fingerprint post restore: %s", err)
-	}
 
 	// Take conservative approach and assume that everything has changed, so update
 	// the indexes. It is possible that dbAppliedIdx is now ahead of some other nodes'
@@ -2817,6 +2834,14 @@ func (s *Store) fsmRestore(rc io.ReadCloser) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to get latest snapshot index post restore: %s", err)
 	}
+
+	// Installed SQLite database is safe for fast restarts again. It is fingerprinted
+	// against the very index and term the node is adopting here, so that a restart
+	// can tell that the two still correspond to one another.
+	if err := s.createSnapshotFingerprint(li, tm); err != nil {
+		return fmt.Errorf("failed to create snapshot fingerprint post restore: %s", err)
+	}
+
 	s.fsmIdx.Store(li)
 	s.fsmTarget.Signal(li)
 	s.fsmTerm.Store(tm)
@@ -3058,7 +3083,11 @@ func (s *Store) selfLeaderChange(leader bool) {
 	}
 }
 
-func (s *Store) createSnapshotFingerprint() error {
+// createSnapshotFingerprint writes the clean-snapshot marker file, recording the
+// state of the SQLite file on disk along with the index and term of the snapshot
+// that file corresponds to. On restart the marker tells the node whether it can
+// use the SQLite file as-is -- see FileFingerprint.ValidFor.
+func (s *Store) createSnapshotFingerprint(index, term uint64) error {
 	tmpFP := s.cleanSnapshotPath + ".tmp"
 	defer os.Remove(tmpFP)
 	mt, err := s.db.DBLastModified()
@@ -3080,6 +3109,8 @@ func (s *Store) createSnapshotFingerprint() error {
 		ModTime: mt,
 		Size:    sz,
 		CRC32:   sum,
+		Index:   index,
+		Term:    term,
 	}
 	if err := fp.WriteToFile(tmpFP); err != nil {
 		return fmt.Errorf("failed to write snapshot fingerprint to temp file: %s", err)

--- a/store/store_restart_test.go
+++ b/store/store_restart_test.go
@@ -391,6 +391,37 @@ func Test_Store_RestoreNoCleanSnapshot(t *testing.T) {
 			},
 		},
 		{
+			// A fingerprint written before the snapshot index and term were recorded
+			// cannot be tied to any snapshot, so a full restore is needed. This is the
+			// state of every node on its first startup after upgrading.
+			name: "CleanSnapshotNoIndexTerm",
+			tamperFn: func(t *testing.T, s *Store) {
+				fp := mustReadFingerprint(t, s.cleanSnapshotPath)
+				fp.Index, fp.Term = 0, 0
+				mustWriteFingerprint(t, s.cleanSnapshotPath, fp)
+			},
+		},
+		{
+			// The fingerprint does not describe the newest snapshot in the Snapshot
+			// Store, so the SQLite file cannot be shown to correspond to it.
+			// See https://github.com/rqlite/rqlite/issues/2747.
+			name: "CleanSnapshotIndexMismatch",
+			tamperFn: func(t *testing.T, s *Store) {
+				fp := mustReadFingerprint(t, s.cleanSnapshotPath)
+				fp.Index++
+				mustWriteFingerprint(t, s.cleanSnapshotPath, fp)
+			},
+		},
+		{
+			// As above, but for the term.
+			name: "CleanSnapshotTermMismatch",
+			tamperFn: func(t *testing.T, s *Store) {
+				fp := mustReadFingerprint(t, s.cleanSnapshotPath)
+				fp.Term++
+				mustWriteFingerprint(t, s.cleanSnapshotPath, fp)
+			},
+		},
+		{
 			name: "SQLiteModTime",
 			tamperFn: func(t *testing.T, s *Store) {
 				now := time.Now().Add(1 * time.Hour)
@@ -686,5 +717,149 @@ func Test_Store_Restore_NoSnapshotOnClose_Snapshot(t *testing.T) {
 	}
 	if s.numSnapshotsSkipped.Load() != 1 {
 		t.Fatalf("expected snapshot skipped count to be 1")
+	}
+}
+
+// Test_Store_RestoreSnapshotAheadOfDB tests that a node does not fast-restart
+// with a SQLite file which is older than the newest snapshot in the Snapshot
+// Store. See https://github.com/rqlite/rqlite/issues/2747.
+//
+// Raft's InstallSnapshot makes a received snapshot durable and visible -- by
+// calling sink.Close() -- before handing it to the FSM to be restored. If that
+// restore never happens, because the node dies in that window or because opening
+// the snapshot fails, the Snapshot Store is left ahead of the SQLite file. The
+// clean-snapshot fingerprint records the state of the SQLite file, so it still
+// matches, and unless the fingerprint also records the snapshot that file
+// corresponds to, the node takes the fast-restart path and adopts the index and
+// term of the newest snapshot in the Snapshot Store -- an index its database has
+// never seen. Every row committed at or below that index is then invisible and,
+// because Raft comes up with lastApplied already at that index, is never replayed.
+func Test_Store_RestoreSnapshotAheadOfDB(t *testing.T) {
+	// A node holding a row the node under test will never receive. Its FSM
+	// snapshot stands in for the snapshot a Leader would install.
+	src, srcLn := mustNewStore(t)
+	defer srcLn.Close()
+	src.NoSnapshotOnClose = true
+	if err := src.Open(); err != nil {
+		t.Fatalf("failed to open source store: %s", err.Error())
+	}
+	defer src.Close(true)
+	if err := src.Bootstrap(NewServer(src.ID(), src.Addr(), true)); err != nil {
+		t.Fatalf("failed to bootstrap source store: %s", err.Error())
+	}
+	if _, err := src.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("Error waiting for leader on source store: %s", err)
+	}
+	mustExecute(t, src, []string{
+		`CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)`,
+		`INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+		`INSERT INTO foo(id, name) VALUES(2, "declan")`,
+	})
+
+	s, ln := mustNewStore(t)
+	defer ln.Close()
+	s.NoSnapshotOnClose = true
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to open single-node store: %s", err.Error())
+	}
+	if err := s.Bootstrap(NewServer(s.ID(), s.Addr(), true)); err != nil {
+		t.Fatalf("failed to bootstrap single-node store: %s", err.Error())
+	}
+	if _, err := s.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("Error waiting for leader: %s", err)
+	}
+	mustExecute(t, s, []string{
+		`CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY, name TEXT)`,
+		`INSERT INTO foo(id, name) VALUES(1, "fiona")`,
+	})
+
+	// Snapshot the node, which writes its clean-snapshot fingerprint. The SQLite
+	// file and the newest snapshot in the Snapshot Store now agree with one another.
+	if err := s.Snapshot(0); err != nil {
+		t.Fatalf("failed to snapshot single-node store: %s", err.Error())
+	}
+	metas, err := s.snapshotStore.List()
+	if err != nil {
+		t.Fatalf("failed to list snapshots: %s", err.Error())
+	}
+	if len(metas) != 1 {
+		t.Fatalf("expected 1 snapshot in store, got %d", len(metas))
+	}
+	latest := metas[0]
+
+	// Install a newer snapshot into the Snapshot Store, without restoring it into
+	// the FSM. This leaves behind exactly what Raft's installSnapshot leaves behind
+	// when sink.Close() returns but the FSM restore which should follow it does not
+	// happen.
+	installIdx := latest.Index + 100
+	sink, err := s.snapshotStore.Create(latest.Version, installIdx, latest.Term,
+		latest.Configuration, latest.ConfigurationIndex, nil)
+	if err != nil {
+		t.Fatalf("failed to create snapshot sink: %s", err.Error())
+	}
+	installSnap, err := NewFSM(src).Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot source node: %s", err.Error())
+	}
+	if err := installSnap.Persist(sink); err != nil {
+		t.Fatalf("failed to persist installed snapshot: %s", err.Error())
+	}
+	installSnap.Release()
+	if err := sink.Close(); err != nil {
+		t.Fatalf("failed to close snapshot sink: %s", err.Error())
+	}
+
+	// Restart the node.
+	if err := s.Close(true); err != nil {
+		t.Fatalf("failed to close single-node store: %s", err.Error())
+	}
+	if err := s.Open(); err != nil {
+		t.Fatalf("failed to reopen single-node store: %s", err.Error())
+	}
+	defer s.Close(true)
+	if _, err := s.WaitForLeader(10 * time.Second); err != nil {
+		t.Fatalf("Error waiting for leader: %s", err)
+	}
+
+	// The node adopts installIdx as its FSM and database applied index, so every
+	// row in the snapshot at that index must actually be in its database.
+	if got, exp := s.DBAppliedIndex(), installIdx; got < exp {
+		t.Fatalf("wrong DB applied index after restart, got: %d, exp at least %d", got, exp)
+	}
+	qr := queryRequestFromString("SELECT * FROM foo", false, false, false)
+	qr.Level = command.ConsistencyLevel_STRONG
+	r, _, _, err := s.Query(context.Background(), qr)
+	if err != nil {
+		t.Fatalf("failed to query single node: %s", err.Error())
+	}
+	exp := `[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"declan"]]}]`
+	if got := asJSON(r); exp != got {
+		t.Fatalf("node is hiding rows committed at or below its own applied index of %d\nexp: %s\ngot: %s",
+			installIdx, exp, got)
+	}
+
+	// The snapshot was never restored into the FSM, so the fast-restart path must
+	// have been declined and a full restore performed instead.
+	if exp, got := uint64(1), s.numSnapshotsStart.Load(); exp != got {
+		t.Fatalf("expected snapshot start count to be %d, got %d", exp, got)
+	}
+	if exp, got := uint64(0), s.numSnapshotsSkipped.Load(); exp != got {
+		t.Fatalf("expected snapshot skipped count to be %d, got %d", exp, got)
+	}
+}
+
+func mustReadFingerprint(t *testing.T, path string) *FileFingerprint {
+	t.Helper()
+	fp := &FileFingerprint{}
+	if err := fp.ReadFromFile(path); err != nil {
+		t.Fatalf("failed to read clean snapshot fingerprint: %s", err.Error())
+	}
+	return fp
+}
+
+func mustWriteFingerprint(t *testing.T, path string, fp *FileFingerprint) {
+	t.Helper()
+	if err := fp.WriteToFile(path); err != nil {
+		t.Fatalf("failed to write clean snapshot fingerprint: %s", err.Error())
 	}
 }

--- a/store/store_snapshot_test.go
+++ b/store/store_snapshot_test.go
@@ -873,6 +873,14 @@ func (m *mockSnapshotSink) ID() string {
 	return "1"
 }
 
+func (m *mockSnapshotSink) Index() uint64 {
+	return 1
+}
+
+func (m *mockSnapshotSink) Term() uint64 {
+	return 1
+}
+
 func (m *mockSnapshotSink) Cancel() error {
 	return nil
 }

--- a/system_test/cluster_test.go
+++ b/system_test/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/rqlite/rqlite/v10/db"
 	"github.com/rqlite/rqlite/v10/http"
 	"github.com/rqlite/rqlite/v10/queue"
+	"github.com/rqlite/rqlite/v10/snapshot"
 	"github.com/rqlite/rqlite/v10/store"
 	"github.com/rqlite/rqlite/v10/tcp"
 )
@@ -2375,4 +2377,157 @@ func Test_ClusterLeader_Stepdown(t *testing.T) {
 		}
 		return ldrNode.Addr != node.Addr, nil
 	}, time.Second, 10*time.Second)
+}
+
+// Test_MultiNodeCluster_SnapshotAheadOfDB tests that a node which restarts with a
+// snapshot in its Snapshot Store that was never restored into its FSM does not come
+// back up serving reads from a database which predates that snapshot.
+// See https://github.com/rqlite/rqlite/issues/2747.
+//
+// Raft's InstallSnapshot makes a received snapshot durable and visible -- by calling
+// sink.Close() -- before handing it to the FSM to be restored. If the node dies in
+// that window, or the restore fails, the Snapshot Store is left ahead of the SQLite
+// file, which is the state set up here. The clean-snapshot fingerprint still matches
+// the SQLite file, so unless it also records the snapshot that file corresponds to,
+// the node takes the fast-restart path and adopts the index of a snapshot it never
+// restored. Rows committed at or below that index are missing from its database and,
+// since Raft comes up with lastApplied already at that index, are never replayed, so
+// reads served locally silently return incomplete results.
+func Test_MultiNodeCluster_SnapshotAheadOfDB(t *testing.T) {
+	raftDialer := tcp.NewDialer(cluster.MuxRaftHeader, nil)
+	clstrDialer := tcp.NewDialer(cluster.MuxClusterHeader, nil)
+
+	leader := mustNewLeaderNode("leader")
+	defer leader.Deprovision()
+
+	// The victim follower gets its own mux so it can later be restarted on the
+	// same Raft address.
+	mux2, ln2 := mustNewOpenMux("")
+	node2 := mustNodeEncrypted("node2", mustTempDir("node2"), false, false, mux2, raftDialer, clstrDialer)
+	if err := node2.Join(leader); err != nil {
+		t.Fatalf("node failed to join leader: %s", err.Error())
+	}
+	if _, err := node2.WaitForLeader(); err != nil {
+		t.Fatalf("failed waiting for leader: %s", err.Error())
+	}
+
+	// A third voter, so that the cluster keeps quorum while the victim is down.
+	node3 := mustNewNode("node3", false)
+	defer node3.Deprovision()
+	if err := node3.Join(leader); err != nil {
+		t.Fatalf("node failed to join leader: %s", err.Error())
+	}
+	if _, err := node3.WaitForLeader(); err != nil {
+		t.Fatalf("failed waiting for leader: %s", err.Error())
+	}
+
+	if _, err := leader.Execute(`CREATE TABLE foo (id integer not null primary key, name text)`); err != nil {
+		t.Fatalf("failed to create table: %s", err.Error())
+	}
+	if _, err := leader.Execute(`INSERT INTO foo(id, name) VALUES(1, "fiona")`); err != nil {
+		t.Fatalf("failed to insert record: %s", err.Error())
+	}
+	testPoll(t, func() (bool, error) {
+		r, err := node2.QueryNoneConsistency(`SELECT COUNT(*) FROM foo`)
+		if err != nil {
+			return false, err
+		}
+		return r == `{"results":[{"columns":["COUNT(*)"],"types":["integer"],"values":[[1]]}]}`, nil
+	}, 50*time.Millisecond, 10*time.Second)
+
+	// Shut the follower down cleanly, which snapshots it and writes its clean-snapshot
+	// fingerprint. Its SQLite file and the newest snapshot in its Snapshot Store now
+	// agree with one another.
+	followerDir, followerRaftAddr := node2.Dir, node2.RaftAddr
+	if err := node2.Close(true); err != nil {
+		t.Fatalf("failed to close follower: %s", err.Error())
+	}
+	ln2.Close()
+
+	// The cluster commits another row while the follower is down.
+	if _, err := leader.Execute(`INSERT INTO foo(id, name) VALUES(2, "declan")`); err != nil {
+		t.Fatalf("failed to insert record: %s", err.Error())
+	}
+
+	// Install the Leader's state into the follower's Snapshot Store, at the index the
+	// Leader has actually reached, but without restoring it into the follower's FSM.
+	leaderDB := mustTempFile()
+	defer os.Remove(leaderDB)
+	if err := leader.Backup(leaderDB, false, ""); err != nil {
+		t.Fatalf("failed to back up leader: %s", err.Error())
+	}
+	installIdx := leader.Store.DBAppliedIndex()
+	// "wsnapshots" is the Snapshot Store directory name used by the store package.
+	mustInstallSnapshotUnrestored(t, filepath.Join(followerDir, "wsnapshots"), leaderDB, installIdx)
+
+	// Restart the follower.
+	mux4, ln4 := mustNewOpenMux(followerRaftAddr)
+	defer ln4.Close()
+	node4 := mustNodeEncrypted("node2", followerDir, false, false, mux4, raftDialer, clstrDialer)
+	defer node4.Deprovision()
+	if _, err := node4.WaitForLeader(); err != nil {
+		t.Fatalf("failed waiting for leader after restart: %s", err.Error())
+	}
+
+	// The restarted node reports having applied installIdx, so a read served from its
+	// own database must return every row committed at or below that index.
+	if got, exp := node4.Store.DBAppliedIndex(), installIdx; got < exp {
+		t.Fatalf("restarted node has DB applied index of %d, expected at least %d", got, exp)
+	}
+	r, err := node4.QueryNoneConsistency(`SELECT * FROM foo`)
+	if err != nil {
+		t.Fatalf("failed to query restarted node: %s", err.Error())
+	}
+	exp := `{"results":[{"columns":["id","name"],"types":["integer","text"],"values":[[1,"fiona"],[2,"declan"]]}]}`
+	if exp != r {
+		t.Fatalf("restarted node is hiding rows committed at or below its own applied index of %d\nexp: %s\ngot: %s",
+			installIdx, exp, r)
+	}
+}
+
+// mustInstallSnapshotUnrestored writes the SQLite file at dbPath into the Snapshot
+// Store at snapDir, as a full snapshot at the given index. This is what Raft's
+// installSnapshot does, up to and including making the snapshot durable and visible,
+// but with no FSM restore following it.
+func mustInstallSnapshotUnrestored(t *testing.T, snapDir, dbPath string, index uint64) {
+	t.Helper()
+	str, err := snapshot.NewStore(snapDir)
+	if err != nil {
+		t.Fatalf("failed to open snapshot store: %s", err.Error())
+	}
+	defer str.Close()
+
+	metas, err := str.List()
+	if err != nil {
+		t.Fatalf("failed to list snapshots: %s", err.Error())
+	}
+	if len(metas) != 1 {
+		t.Fatalf("expected 1 snapshot in store, got %d", len(metas))
+	}
+	latest := metas[0]
+	if index <= latest.Index {
+		t.Fatalf("install index %d is not ahead of newest snapshot index %d", index, latest.Index)
+	}
+
+	sink, err := str.Create(latest.Version, index, latest.Term, latest.Configuration,
+		latest.ConfigurationIndex, nil)
+	if err != nil {
+		t.Fatalf("failed to create snapshot sink: %s", err.Error())
+	}
+	streamer, err := snapshot.NewSnapshotStreamer(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create snapshot streamer: %s", err.Error())
+	}
+	if err := streamer.Open(); err != nil {
+		t.Fatalf("failed to open snapshot streamer: %s", err.Error())
+	}
+	if _, err := io.Copy(sink, streamer); err != nil {
+		t.Fatalf("failed to write installed snapshot to sink: %s", err.Error())
+	}
+	if err := streamer.Close(); err != nil {
+		t.Fatalf("failed to close snapshot streamer: %s", err.Error())
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("failed to close snapshot sink: %s", err.Error())
+	}
 }


### PR DESCRIPTION
Store.Open's fast-restart path was entered on the strength of the clean-snapshot fingerprint, which recorded only the SQLite file's mod time, size and CRC32. It then adopted the index and term of the newest snapshot in the Snapshot Store. Nothing tied those two things together.

Raft's InstallSnapshot makes a received snapshot durable and visible -- sink.Close() -- before handing it to the FSM to be restored. If that restore never happens, because the node dies in that window or because opening the snapshot fails, the Snapshot Store is left ahead of the SQLite file while the fingerprint still matches it. The node then restarts claiming an index its database has never seen, and since NoSnapshotRestoreOnStart also stops Raft replaying the log below that index, every row committed at or below it is hidden for good.

The fingerprint now also records the index and term of the snapshot the SQLite file corresponds to, and the fast path is taken only when those match the newest snapshot in the Store. The match is exact, so the fast path is also declined when the file is ahead of the Store -- a snapshot which was fingerprinted but never became visible -- where Raft would otherwise replay entries the database has already applied.

The index and term come from the sink Raft passes to Persist, since the finalizer which writes the fingerprint runs before sink.Close() and so cannot find the new snapshot in the Store. FSMSnapshot.Finalizer takes the sink for that reason, and snapshot.SinkIndexTerm extracts the pair.

Fingerprints written by earlier versions have a zero index and term, so each node performs one full restore on its first start after upgrading.

Fixes #2747


Claude-Session: https://claude.ai/code/session_01HiEHxeN5Si9Lf1sj5W6i6J