### PR TITLE
http: allow multiple bind addresses

### DIFF
--- a/cmd/rqlited/config_flags.go
+++ b/cmd/rqlited/config_flags.go
@@ -18,7 +18,7 @@ type Config struct {
 	ShowVersion bool
 	// Unique ID for node. If not set, set to advertised Raft address
 	NodeID string
-	// HTTP server bind address. To enable HTTPS, set X.509 certificate and key
+	// Comma-delimited HTTP server bind addresses. To enable HTTPS, set X.509 certificate and key
 	HTTPAddr string
 	// Advertised HTTP address. If not set, same as HTTP server bind address
 	HTTPAdv string
@@ -161,7 +161,7 @@ func Forge(arguments []string) (*flag.FlagSet, *Config, error) {
 	}
 	fs.BoolVar(&config.ShowVersion, "version", false, "Show version information and exit")
 	fs.StringVar(&config.NodeID, "node-id", "", "Unique ID for node. If not set, set to advertised Raft address")
-	fs.StringVar(&config.HTTPAddr, "http-addr", "localhost:4001", "HTTP server bind address. To enable HTTPS, set X.509 certificate and key")
+	fs.StringVar(&config.HTTPAddr, "http-addr", "localhost:4001", "Comma-delimited HTTP server bind addresses. To enable HTTPS, set X.509 certificate and key")
 	fs.StringVar(&config.HTTPAdv, "http-adv-addr", "", "Advertised HTTP address. If not set, same as HTTP server bind address")
 	fs.StringVar(&config.HTTPAllowOrigin, "http-allow-origin", "", "Value to set for Access-Control-Allow-Origin HTTP header")
 	fs.StringVar(&config.HTTPx509Cert, "http-cert", "", "Path to HTTPS X.509 certificate")

--- a/cmd/rqlited/flags.go
+++ b/cmd/rqlited/flags.go
@@ -89,16 +89,16 @@ func (c *Config) Validate() error {
 		return errors.New("-node-verify-common-name requires -node-verify-client")
 	}
 
-	if c.RaftAddr == c.HTTPAddr {
-		return errors.New("HTTP and Raft addresses must differ")
-	}
-
 	// Enforce policies regarding addresses
 	if c.RaftAdv == "" {
 		c.RaftAdv = c.RaftAddr
 	}
+	httpAddrs := c.HTTPAddresses()
+	if len(httpAddrs) > 1 && c.HTTPAdv == "" {
+		return fmt.Errorf("multiple HTTP bind addresses require -%s", HTTPAdvAddrFlag)
+	}
 	if c.HTTPAdv == "" {
-		c.HTTPAdv = c.HTTPAddr
+		c.HTTPAdv = httpAddrs[0]
 	}
 
 	// Node ID policy
@@ -107,12 +107,19 @@ func (c *Config) Validate() error {
 	}
 
 	// Perform some address validity checks.
-	if strings.HasPrefix(strings.ToLower(c.HTTPAddr), "http") ||
-		strings.HasPrefix(strings.ToLower(c.HTTPAdv), "http") {
+	if strings.HasPrefix(strings.ToLower(c.HTTPAdv), "http") {
 		return errors.New("HTTP options should not include protocol (http:// or https://)")
 	}
-	if _, _, err := net.SplitHostPort(c.HTTPAddr); err != nil {
-		return errors.New("HTTP bind address not valid")
+	for _, httpAddr := range httpAddrs {
+		if strings.HasPrefix(strings.ToLower(httpAddr), "http") {
+			return errors.New("HTTP options should not include protocol (http:// or https://)")
+		}
+		if _, _, err := net.SplitHostPort(httpAddr); err != nil {
+			return errors.New("HTTP bind address not valid")
+		}
+		if c.RaftAddr == httpAddr {
+			return errors.New("HTTP and Raft addresses must differ")
+		}
 	}
 
 	hadv, _, err := net.SplitHostPort(c.HTTPAdv)
@@ -228,6 +235,11 @@ func (c *Config) JoinAddresses() []string {
 		return nil
 	}
 	return strings.Split(c.JoinAddrs, ",")
+}
+
+// HTTPAddresses returns the HTTP bind addresses set at the command line.
+func (c *Config) HTTPAddresses() []string {
+	return strings.Split(c.HTTPAddr, ",")
 }
 
 // HTTPURL returns the fully-formed, advertised HTTP API address for this config, including

--- a/cmd/rqlited/flags.toml
+++ b/cmd/rqlited/flags.toml
@@ -36,9 +36,9 @@ name = "HTTPAddr"
 cli = "http-addr"
 section = "HTTP API"
 type = "string"
-short_help = "HTTP server bind address. To enable HTTPS, set X.509 certificate and key"
+short_help = "Comma-delimited HTTP server bind addresses. To enable HTTPS, set X.509 certificate and key"
 long_help = """
-This is the interface rqlite will listen on for API requests. 0.0.0.0 is an acceptable address and will mean that rqlite will listen on all interfaces. However if you do use 0.0.0.0 you must then set <code>-http-adv-addr</code> to the actual network address (or hostname) the node can be reached on, as rqlite transmits its HTTP API address in certain circumstances.
+This is the interface or comma-delimited list of interfaces rqlite will listen on for API requests. 0.0.0.0 is an acceptable address and will mean that rqlite will listen on all interfaces. However if you do use 0.0.0.0, or configure multiple addresses, you must then set <code>-http-adv-addr</code> to the actual network address (or hostname) the node can be reached on, as rqlite transmits its HTTP API address in certain circumstances.
 """
 default = "localhost:4001"
 

--- a/cmd/rqlited/flags_test.go
+++ b/cmd/rqlited/flags_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigValidateHTTPAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		httpAddr string
+		httpAdv  string
+		wantErr  string
+		wantAdv  string
+	}{
+		{
+			name:     "multiple addresses with advertised address",
+			httpAddr: "127.0.0.1:4001,127.0.0.2:4001",
+			httpAdv:  "127.0.0.1:4001",
+		},
+		{
+			name:     "multiple addresses require advertised address",
+			httpAddr: "127.0.0.1:4001,127.0.0.2:4001",
+			wantErr:  "multiple HTTP bind addresses require -http-adv-addr",
+		},
+		{
+			name:     "one address still defaults advertised address",
+			httpAddr: "127.0.0.1:4001",
+			wantAdv:  "127.0.0.1:4001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				DataPath: t.TempDir(),
+				HTTPAddr: tt.httpAddr,
+				HTTPAdv:  tt.httpAdv,
+				RaftAddr: "127.0.0.1:4002",
+			}
+			err := cfg.Validate()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to validate config: %s", err)
+			}
+			if tt.wantAdv != "" && cfg.HTTPAdv != tt.wantAdv {
+				t.Fatalf("expected advertised address %q, got %q", tt.wantAdv, cfg.HTTPAdv)
+			}
+		})
+	}
+}

--- a/http/service.go
+++ b/http/service.go
@@ -263,6 +263,7 @@ type Service struct {
 	closeCh    chan struct{}
 	addr       string       // Bind address of the HTTP service.
 	ln         net.Listener // Service listener
+	lns        []net.Listener
 
 	uiHandler http.Handler
 
@@ -331,10 +332,10 @@ func (s *Service) Start() error {
 		Handler: s,
 	}
 
-	var ln net.Listener
+	var lns []net.Listener
 	var err error
 	if s.CertFile == "" || s.KeyFile == "" {
-		ln, err = net.Listen("tcp", s.addr)
+		lns, err = listenTCP(s.addr)
 		if err != nil {
 			return err
 		}
@@ -358,9 +359,12 @@ func (s *Service) Start() error {
 		if err != nil {
 			return err
 		}
-		ln, err = tls.Listen("tcp", s.addr, s.tlsConfig)
+		lns, err = listenTCP(s.addr)
 		if err != nil {
 			return err
+		}
+		for i := range lns {
+			lns[i] = tls.NewListener(lns[i], s.tlsConfig)
 		}
 		var b strings.Builder
 		b.WriteString(fmt.Sprintf("secure HTTPS server enabled with cert %s, key %s", s.CertFile, s.KeyFile))
@@ -377,7 +381,8 @@ func (s *Service) Start() error {
 		}
 		s.logger.Println(b.String())
 	}
-	s.ln = ln
+	s.ln = lns[0]
+	s.lns = lns
 
 	s.closeCh = make(chan struct{})
 	s.queueDone = make(chan struct{})
@@ -387,12 +392,14 @@ func (s *Service) Start() error {
 	s.logger.Printf("execute queue processing started with capacity %d, batch size %d, timeout %s",
 		s.DefaultQueueCap, s.DefaultQueueBatchSz, s.DefaultQueueTimeout.String())
 
-	go func() {
-		err := s.httpServer.Serve(s.ln)
-		if err != nil {
-			s.logger.Printf("HTTP service on %s stopped: %s", s.ln.Addr().String(), err.Error())
-		}
-	}()
+	for _, ln := range s.lns {
+		go func(ln net.Listener) {
+			err := s.httpServer.Serve(ln)
+			if err != nil {
+				s.logger.Printf("HTTP service on %s stopped: %s", ln.Addr().String(), err.Error())
+			}
+		}(ln)
+	}
 	s.logger.Println("service listening on", s.Addr())
 
 	return nil
@@ -404,6 +411,11 @@ func (s *Service) Close() {
 	if err := s.httpServer.Shutdown(context.Background()); err != nil {
 		s.logger.Println("HTTP service shutdown error:", err.Error())
 	}
+	for _, ln := range s.lns {
+		if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.logger.Println("HTTP service listener close error:", err.Error())
+		}
+	}
 
 	s.stmtQueue.Close()
 	select {
@@ -412,6 +424,21 @@ func (s *Service) Close() {
 		close(s.closeCh)
 	}
 	<-s.queueDone
+}
+
+func listenTCP(addrs string) ([]net.Listener, error) {
+	var lns []net.Listener
+	for _, addr := range strings.Split(addrs, ",") {
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			for _, ln := range lns {
+				ln.Close()
+			}
+			return nil, err
+		}
+		lns = append(lns, ln)
+	}
+	return lns, nil
 }
 
 // HTTPS returns whether this service is using HTTPS.

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -111,6 +111,30 @@ func Test_NewService(t *testing.T) {
 	}
 }
 
+func Test_ServiceMultipleListeners(t *testing.T) {
+	store := &MockStore{}
+	cluster := &mockClusterService{}
+	s := New("127.0.0.1:0,127.0.0.1:0", store, cluster, proxy.New(store, cluster), nil)
+	if err := s.Start(); err != nil {
+		t.Fatalf("failed to start service: %s", err)
+	}
+	defer s.Close()
+
+	if got := len(s.lns); got != 2 {
+		t.Fatalf("expected 2 listeners, got %d", got)
+	}
+	for _, ln := range s.lns {
+		resp, err := http.Get(fmt.Sprintf("http://%s/status", ln.Addr()))
+		if err != nil {
+			t.Fatalf("failed to request %s: %s", ln.Addr(), err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected HTTP 200 from %s, got %d", ln.Addr(), resp.StatusCode)
+		}
+	}
+}
+
 func Test_HasVersionHeader(t *testing.T) {
 	m := &MockStore{}
 	c := &mockClusterService{}

--- a/system_test/e2e/single_node.py
+++ b/system_test/e2e/single_node.py
@@ -11,9 +11,24 @@ import os
 import time
 import unittest
 
-from helpers import Node, Cluster, d_, deprovision_node, poll_query
+import requests
+
+from helpers import Node, Cluster, d_, deprovision_node, poll_query, random_addr
 
 RQLITED_PATH = os.environ['RQLITED_PATH']
+
+class TestMultipleHTTPAddresses(unittest.TestCase):
+  def test_listens_on_each_address(self):
+    first = random_addr()
+    second = random_addr()
+    node = Node(RQLITED_PATH, '0', api_addr=','.join([first, second]), api_adv=first)
+    try:
+      node.start()
+      node.wait_for_leader()
+      response = requests.get('http://' + second + '/readyz?noleader')
+      self.assertEqual(response.status_code, 200)
+    finally:
+      deprovision_node(node)
 
 class TestSingleNode(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
## Why

Binding `-http-addr` to `0.0.0.0` exposes every interface when a node only needs selected ones, such as Tailscale and localhost.

## Changes

- Allow `-http-addr` to take a comma-delimited list of bind addresses.
- Keep one HTTP handler and service state across those listeners.
- Require a single explicit `-http-adv-addr` when more than one bind address is configured.

## Verification

- `go build ./...`
- `go test ./...`
- `RQLITED_PATH=<rqlited> python3 -m unittest single_node.TestMultipleHTTPAddresses`

Fixes #2744
