### PR TITLE
Refactor busy timeout methods to separate read-write and read-only functionality

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -733,13 +733,30 @@ func (db *DB) SetBusyTimeout(rwMs, roMs int) (err error) {
 	return nil
 }
 
-// BusyTimeout returns the current busy timeout value.
+// RWBusyTimeout returns the current busy timeout value for the read-write
+// database connection.
+func (db *DB) RWBusyTimeout() (int, error) {
+	var ms int
+	err := db.rwDB.QueryRow("PRAGMA busy_timeout").Scan(&ms)
+	return ms, err
+}
+
+// ROBusyTimeout returns the current busy timeout value for the read-only
+// database connection.
+func (db *DB) ROBusyTimeout() (int, error) {
+	var ms int
+	err := db.roDB.QueryRow("PRAGMA busy_timeout").Scan(&ms)
+	return ms, err
+}
+
+// BusyTimeout returns the current busy timeout values for the read-write and
+// read-only database connections.
 func (db *DB) BusyTimeout() (rwMs, roMs int, err error) {
-	err = db.rwDB.QueryRow("PRAGMA busy_timeout").Scan(&rwMs)
+	rwMs, err = db.RWBusyTimeout()
 	if err != nil {
 		return 0, 0, err
 	}
-	err = db.roDB.QueryRow("PRAGMA busy_timeout").Scan(&roMs)
+	roMs, err = db.ROBusyTimeout()
 	if err != nil {
 		return 0, 0, err
 	}
@@ -771,7 +788,7 @@ func (db *DB) CheckpointTruncateWithTimeout(dur time.Duration) (err error) {
 		}
 	}()
 
-	rwBt, _, err := db.BusyTimeout()
+	rwBt, err := db.RWBusyTimeout()
 	if err != nil {
 		return fmt.Errorf("failed to get busy_timeout: %s", err.Error())
 	}
@@ -827,7 +844,7 @@ func (db *DB) CheckpointWithTimeout(mode CheckpointMode, dur time.Duration) (met
 	}()
 
 	if dur > 0 {
-		rwBt, _, err := db.BusyTimeout()
+		rwBt, err := db.RWBusyTimeout()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get busy_timeout on checkpointing connection: %s", err.Error())
 		}

--- a/db/db_common_test.go
+++ b/db/db_common_test.go
@@ -24,6 +24,22 @@ func Test_DB_BusyTimeout(t *testing.T) {
 		t.Fatalf("failed to set busy_timeout: %s", err.Error())
 	}
 
+	gotRwOnly, err := db.RWBusyTimeout()
+	if err != nil {
+		t.Fatalf("failed to get read-write busy_timeout: %s", err.Error())
+	}
+	if gotRwOnly != wantRw {
+		t.Fatalf("want read-write busy_timeout=%d, got %d", wantRw, gotRwOnly)
+	}
+
+	gotRoOnly, err := db.ROBusyTimeout()
+	if err != nil {
+		t.Fatalf("failed to get read-only busy_timeout: %s", err.Error())
+	}
+	if gotRoOnly != wantRo {
+		t.Fatalf("want read-only busy_timeout=%d, got %d", wantRo, gotRoOnly)
+	}
+
 	gotRw, gotRo, err := db.BusyTimeout()
 	if err != nil {
 		t.Fatalf("failed to get busy_timeout: %s", err.Error())


### PR DESCRIPTION

The current `BusyTimeout()` method reads the `busy_timeout` value from both the read-write and read-only database connections. However, checkpoint operations only need the read-write timeout, so querying the read-only connection introduces an unnecessary connection acquisition and PRAGMA query.

This change splits the timeout lookup into `RWBusyTimeout()` and `ROBusyTimeout()`:

- Checkpoint paths now read only the RW timeout, avoiding unnecessary RO connection access.
- The existing `BusyTimeout()` method is preserved for backward compatibility.
- Callers can now explicitly query the timeout for either the RW or RO connection.
- Existing timeout configuration, checkpoint behavior, and timeout restoration remain unchanged.
- Tests cover the RW-specific, RO-specific, and backward-compatible APIs.

This reduces unnecessary database operations during checkpointing while preserving the existing public API.