### PR TITLE
Add Snap packaging for rqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ curl -G 'localhost:4001/db/query?pretty' --data-urlencode 'q=SELECT * FROM foo'
 
 [Learn how to form a multi-node cluster in seconds.](https://rqlite.io/docs/clustering/) and dive into the [_Developer Guide_](https://www.rqlite.io/docs/api).
 
+## Install with Snap
+
+On supported Linux systems, install the rqlite snap with:
+
+```bash
+sudo snap install rqlite
+```
+
+The `rqlited` service is started automatically and stores its data in the
+snap's data directory. The `rqlite` and `rqbench` applications are also
+included:
+
+```bash
+rqlite.rqlite -H localhost
+rqlite.rqbench -h
+```
+
 ## Key features
 
 **Core functionality**

--- a/snap/command-rqlited
+++ b/snap/command-rqlited
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+DATA_DIR="${SNAP_COMMON}/data"
+mkdir -p "$DATA_DIR"
+exec "$SNAP/bin/rqlited" "$@" "$DATA_DIR"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: rqlite
+version: git
+summary: A lightweight, fault-tolerant, distributed relational database
+website: https://rqlite.io
+source-code: https://github.com/rqlite/rqlite
+issues: https://github.com/rqlite/rqlite/issues
+description: |
+  rqlite is a lightweight, fault-tolerant, distributed relational database
+  built on SQLite. It uses Raft consensus to provide highly available,
+  replicated SQL storage.
+
+  The rqlited service stores its database in $SNAP_COMMON/data by default.
+  Use the rqlite and rqbench applications to connect to and benchmark a
+  running node.
+grade: stable
+confinement: strict
+base: core24
+license: MIT
+
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  rqlite:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.26/stable
+    build-packages:
+      - gcc
+    override-build: |
+      mkdir -p "$CRAFT_PART_INSTALL/bin"
+      go build -trimpath -ldflags="-s -w" -o "$CRAFT_PART_INSTALL/bin/rqlited" ./cmd/rqlited
+      go build -trimpath -ldflags="-s -w" -o "$CRAFT_PART_INSTALL/bin/rqlite" ./cmd/rqlite
+      go build -trimpath -ldflags="-s -w" -o "$CRAFT_PART_INSTALL/bin/rqbench" ./cmd/rqbench
+      install -m 0755 snap/command-rqlited "$CRAFT_PART_INSTALL/bin/command-rqlited"
+
+apps:
+  rqlited:
+    command: bin/command-rqlited
+    daemon: simple
+    restart-condition: always
+    plugs:
+      - network
+      - network-bind
+  rqlite:
+    command: bin/rqlite
+    plugs:
+      - network
+  rqbench:
+    command: bin/rqbench
+    plugs:
+      - network

--- a/snap/test-snap.sh
+++ b/snap/test-snap.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+MANIFEST="$ROOT/snap/snapcraft.yaml"
+WRAPPER="$ROOT/snap/command-rqlited"
+
+for required in \
+    'name: rqlite' \
+    'confinement: strict' \
+    'command: bin/command-rqlited' \
+    'command: bin/rqlite' \
+    'command: bin/rqbench'; do
+    if ! grep -Fq "$required" "$MANIFEST"; then
+        printf 'missing snap metadata: %s\n' "$required" >&2
+        exit 1
+    fi
+done
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/snap/bin"
+cat > "$tmpdir/snap/bin/rqlited" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" > "$SNAP/args"
+EOF
+chmod 0755 "$tmpdir/snap/bin/rqlited"
+
+SNAP="$tmpdir/snap" SNAP_COMMON="$tmpdir/common" \
+    sh "$WRAPPER" -http-addr=127.0.0.1:4001
+
+expected="$tmpdir/common/data"
+test -d "$expected"
+test "$(sed -n '1p' "$tmpdir/snap/args")" = '-http-addr=127.0.0.1:4001'
+test "$(sed -n '2p' "$tmpdir/snap/args")" = "$expected"


### PR DESCRIPTION
## Summary
- add a Snapcraft manifest for rqlite on amd64 and arm64
- package rqlited, rqlite, and rqbench
- run rqlited as a managed Snap service with data under `$SNAP_COMMON/data`
- document Snap installation and usage
- add a focused shell test for the manifest and service wrapper

## Validation
- `chmod 0755 snap/command-rqlited snap/test-snap.sh && sh snap/test-snap.sh`
- `git diff --check && git status --short`

The full Go test suite could not run because the checkout requires Go 1.26.0 while the available toolchain is Go 1.25.14. Full Snapcraft build/install validation also remains outstanding.

This change was generated with Claude (Anthropic Claude Agent SDK).

Validation observed for this change:
- `chmod 0755 snap/command-rqlited snap/test-snap.sh && sh snap/test-snap.sh`
- `git diff --check && git status --short`

Fixes #299

<!-- repo-agent-case:2027546d-1887-48d4-9baf-ddeff7498a70 -->