### PR TITLE
Vendor BoltDB raft store into internal/raftdb with faster MsgPack codec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.44
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-msgpack/v2 v2.1.5
 	github.com/hashicorp/raft v1.7.3
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-sqlite3 v1.14.50
 	github.com/mkideal/cli v0.2.7
 	github.com/mkideal/pkg v0.1.3
 	github.com/peterh/liner v1.2.2
-	github.com/rqlite/raft-boltdb/v2 v2.0.0-20230523104317-c08e70f4de48
 	github.com/rqlite/rqlite-disco-clients v0.0.0-20250205044118-8ada2b350099
 	github.com/rqlite/sql v0.0.0-20260224021119-1b2524a41372
 	go.etcd.io/bbolt v1.5.0
@@ -31,7 +31,7 @@ require (
 )
 
 require (
-	github.com/armon/go-metrics v0.6.1 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.38 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38 // indirect
@@ -63,8 +63,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.6.1 // indirect
-	github.com/hashicorp/go-msgpack v1.1.5 // indirect
-	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,7 +44,6 @@ github.com/aws/smithy-go v1.27.10/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCq
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -106,7 +105,6 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -116,9 +114,6 @@ github.com/hashicorp/go-metrics v0.5.1 h1:rfPwUqFU6uZXNvGl4hzjY8LEBsqFVU4si1H9/H
 github.com/hashicorp/go-metrics v0.5.1/go.mod h1:KEjodfebIOuBYSAe/bHTm+HChmKSxAOXPBieMLYozDE=
 github.com/hashicorp/go-metrics v0.6.1 h1:V7j9cgHTXl4OebnX3y0l6ZSoO5dTp0VI0K8Y7JfRsS4=
 github.com/hashicorp/go-metrics v0.6.1/go.mod h1:XOozbQKeJz12GG8cCcQb/E5vNVeTdJt0aHbM+uHnL1M=
-github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
-github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=
 github.com/hashicorp/go-msgpack/v2 v2.1.5 h1:Ue879bPnutj/hXfmUk6s/jtIK90XxgiUIcXRl656T44=
 github.com/hashicorp/go-msgpack/v2 v2.1.5/go.mod h1:bjCsRXpZ7NsJdk45PoCQnzRGDaK8TKm5ZnDI/9y3J4M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
@@ -138,10 +133,8 @@ github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iP
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/memberlist v0.6.0 h1:hhVDLQUzWkLaitLLSrxLLqSD2l2+qiOz1DMr5zb9EQQ=
 github.com/hashicorp/memberlist v0.6.0/go.mod h1:a2lqh8KICpm8JibWOmuld7DaA+9QU1YcUtTTTMAtt/M=
-github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft v1.7.3 h1:DxpEqZJysHN0wK+fviai5mFcSYsCkNpFUl1xpAW8Rbo=
 github.com/hashicorp/raft v1.7.3/go.mod h1:DfvCGFxpAUPE0L4Uc8JLlTPtc3GzSbdH0MTJCLgnmJQ=
-github.com/hashicorp/raft-boltdb v0.0.0-20210409134258-03c10cc3d4ea/go.mod h1:qRd6nFJYYS6Iqnc/8HcUmko2/2Gw8qTFEmxDLii6W5I=
 github.com/hashicorp/serf v0.10.4 h1:TCQOrJXHZ1Xf80c4WBhMM9OwUFgDaIP0R+YvoQUKadI=
 github.com/hashicorp/serf v0.10.4/go.mod h1:l+s5Q1OSPWU6b9l9m7ODJzTp7mLevSaVzAI03Nka2F0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -212,8 +205,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rqlite/go-sqlite3 v1.51.0 h1:9b2AeiirIRLRyxxT9245yaKuNlQ/xEjhTXIjW91Jstk=
 github.com/rqlite/go-sqlite3 v1.51.0/go.mod h1:XIq9SQymduohsJwPy++jWepF9QJ5gT/S3SkUivYSVZ0=
-github.com/rqlite/raft-boltdb/v2 v2.0.0-20230523104317-c08e70f4de48 h1:NZ62M+kT0JqhyFUMc8I4SMmfmD4NGJxhb2ePJQXjryc=
-github.com/rqlite/raft-boltdb/v2 v2.0.0-20230523104317-c08e70f4de48/go.mod h1:CRnsxgy5G8fAf5J+AM0yrsSdxXHKkIYOaq2sm+Q4DYc=
 github.com/rqlite/rqlite-disco-clients v0.0.0-20250205044118-8ada2b350099 h1:5cqkVLdl6sGJSY3kiF2dqaA3bD+8OS5FUdZqO0BxXLU=
 github.com/rqlite/rqlite-disco-clients v0.0.0-20250205044118-8ada2b350099/go.mod h1:6SVI8KegsW9Fyu2UQ+uvw0JI5CAILRYRyiQ/OFSJPrs=
 github.com/rqlite/sql v0.0.0-20260224021119-1b2524a41372 h1:2V0y6mzmPj7vQKad76nTL7sZ/lFLj5VKvNjpa6IRxYE=
@@ -235,7 +226,6 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
 go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 go.etcd.io/etcd/api/v3 v3.7.1 h1:KJG0/DcWGfe3Y1otDf/fsBf0TSSgpxZ5RO/L8SFt73E=
@@ -283,7 +273,6 @@ golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa/go.mod h1:zeBbvyFKDaLwa7CH/z
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
 golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -291,7 +280,6 @@ golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
@@ -305,7 +293,6 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -320,7 +307,6 @@ golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
 golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
-golang.org/x/tools v0.0.0-20190424220101-1e8e1cfdf96b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
 golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/raftdb/bench_test.go
+++ b/internal/raftdb/bench_test.go
@@ -1,0 +1,86 @@
+package raftdb
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/raft"
+)
+
+// The benchmarks below isolate the MsgPack encode/decode layer, comparing
+// this package's optimized implementation against the upstream raft-boltdb
+// implementation (new Handle + bytes.Buffer + io.Writer per call).
+
+func benchLog() *raft.Log {
+	return &raft.Log{
+		Index:      12345,
+		Term:       67,
+		Type:       raft.LogCommand,
+		Data:       bytes.Repeat([]byte("x"), 256),
+		Extensions: nil,
+		AppendedAt: time.Unix(1700000000, 123456789).UTC(),
+	}
+}
+
+// BenchmarkEncodeOptimized measures this package's encodeMsgPack.
+func BenchmarkEncodeOptimized(b *testing.B) {
+	log := benchLog()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := encodeMsgPack(log); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEncodeUpstream measures the upstream-style encoding.
+func BenchmarkEncodeUpstream(b *testing.B) {
+	log := benchLog()
+	b.ReportAllocs()
+	for b.Loop() {
+		buf := bytes.NewBuffer(nil)
+		hd := codec.MsgpackHandle{}
+		enc := codec.NewEncoder(buf, &hd)
+		if err := enc.Encode(log); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDecodeOptimized measures this package's decodeMsgPack.
+func BenchmarkDecodeOptimized(b *testing.B) {
+	log := benchLog()
+	buf, err := encodeMsgPack(log)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		var out raft.Log
+		if err := decodeMsgPack(buf, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDecodeUpstream measures the upstream-style decoding.
+func BenchmarkDecodeUpstream(b *testing.B) {
+	log := benchLog()
+	var buf bytes.Buffer
+	hd := codec.MsgpackHandle{}
+	if err := codec.NewEncoder(&buf, &hd).Encode(log); err != nil {
+		b.Fatal(err)
+	}
+	enc := buf.Bytes()
+	b.ReportAllocs()
+	for b.Loop() {
+		r := bytes.NewBuffer(enc)
+		hd := codec.MsgpackHandle{}
+		var out raft.Log
+		if err := codec.NewDecoder(r, &hd).Decode(&out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/raftdb/bolt_store.go
+++ b/internal/raftdb/bolt_store.go
@@ -1,0 +1,283 @@
+// Package raftdb provides a BoltDB-backed Raft log and stable store.
+//
+// This package is derived from github.com/rqlite/raft-boltdb/v2, vendored
+// into rqlite so that its internals (notably the MsgPack encode/decode hot
+// paths) can be optimized. It retains full on-disk compatibility with the
+// upstream package: databases written by either implementation are readable
+// by the other.
+//
+// Source: github.com/rqlite/raft-boltdb/v2 v2.0.0-20230523104317-c08e70f4de48
+// License: Mozilla Public License, version 2.0. Copyright (c) 2015 HashiCorp, Inc.
+package raftdb
+
+import (
+	"errors"
+
+	"github.com/hashicorp/raft"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	// Permissions to use on the db file. This is only used if the
+	// database file does not exist and needs to be created.
+	dbFileMode = 0600
+)
+
+var (
+	// Bucket names we perform transactions in
+	dbLogs = []byte("logs")
+	dbConf = []byte("conf")
+
+	// An error indicating a given key does not exist
+	ErrKeyNotFound = errors.New("not found")
+)
+
+// BoltStore provides access to Bbolt for Raft to store and retrieve
+// log entries. It also provides key/value storage, and can be used as
+// a LogStore and StableStore.
+type BoltStore struct {
+	// conn is the underlying handle to the db.
+	conn *bbolt.DB
+
+	// The path to the Bolt database file
+	path string
+}
+
+// Options contains all the configuration used to open the Bbolt
+type Options struct {
+	// Path is the file path to the Bbolt to use
+	Path string
+
+	// BoltOptions contains any specific Bbolt options you might
+	// want to specify [e.g. open timeout]
+	BoltOptions *bbolt.Options
+
+	// NoSync causes the database to skip fsync calls after each
+	// write to the log. This is unsafe, so it should be used
+	// with caution.
+	NoSync bool
+}
+
+// readOnly returns true if the contained bolt options say to open
+// the DB in readOnly mode [this can be useful to tools that want
+// to examine the log]
+func (o *Options) readOnly() bool {
+	return o != nil && o.BoltOptions != nil && o.BoltOptions.ReadOnly
+}
+
+// NewBoltStore takes a file path and returns a connected Raft backend.
+func NewBoltStore(path string) (*BoltStore, error) {
+	return New(Options{Path: path})
+}
+
+// New uses the supplied options to open the Bbolt and prepare it for use as a raft backend.
+func New(options Options) (*BoltStore, error) {
+	// Try to connect
+	handle, err := bbolt.Open(options.Path, dbFileMode, options.BoltOptions)
+	if err != nil {
+		return nil, err
+	}
+	handle.NoSync = options.NoSync
+
+	// Create the new store
+	store := &BoltStore{
+		conn: handle,
+		path: options.Path,
+	}
+
+	// If the store was opened read-only, don't try and create buckets
+	if !options.readOnly() {
+		// Set up our buckets
+		if err := store.initialize(); err != nil {
+			store.Close()
+			return nil, err
+		}
+	}
+	return store, nil
+}
+
+// initialize is used to set up all of the buckets.
+func (b *BoltStore) initialize() error {
+	tx, err := b.conn.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Create all the buckets
+	if _, err := tx.CreateBucketIfNotExists(dbLogs); err != nil {
+		return err
+	}
+	if _, err := tx.CreateBucketIfNotExists(dbConf); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (b *BoltStore) Stats() bbolt.Stats {
+	return b.conn.Stats()
+}
+
+// Close is used to gracefully close the DB connection.
+func (b *BoltStore) Close() error {
+	return b.conn.Close()
+}
+
+// FirstIndex returns the first known index from the Raft log.
+func (b *BoltStore) FirstIndex() (uint64, error) {
+	tx, err := b.conn.Begin(false)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	curs := tx.Bucket(dbLogs).Cursor()
+	if first, _ := curs.First(); first == nil {
+		return 0, nil
+	} else {
+		return bytesToUint64(first), nil
+	}
+}
+
+// LastIndex returns the last known index from the Raft log.
+func (b *BoltStore) LastIndex() (uint64, error) {
+	tx, err := b.conn.Begin(false)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	curs := tx.Bucket(dbLogs).Cursor()
+	if last, _ := curs.Last(); last == nil {
+		return 0, nil
+	} else {
+		return bytesToUint64(last), nil
+	}
+}
+
+// GetLog is used to retrieve a log from Bbolt at a given index.
+func (b *BoltStore) GetLog(idx uint64, log *raft.Log) error {
+	tx, err := b.conn.Begin(false)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	bucket := tx.Bucket(dbLogs)
+	val := bucket.Get(uint64ToBytes(idx))
+
+	if val == nil {
+		return raft.ErrLogNotFound
+	}
+	return decodeMsgPack(val, log)
+}
+
+// StoreLog is used to store a single raft log
+func (b *BoltStore) StoreLog(log *raft.Log) error {
+	return b.StoreLogs([]*raft.Log{log})
+}
+
+// StoreLogs is used to store a set of raft logs
+func (b *BoltStore) StoreLogs(logs []*raft.Log) error {
+	tx, err := b.conn.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	bucket := tx.Bucket(dbLogs)
+	for _, log := range logs {
+		key := uint64ToBytes(log.Index)
+		val, err := encodeMsgPack(log)
+		if err != nil {
+			return err
+		}
+
+		if err := bucket.Put(key, val); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// DeleteRange is used to delete logs within a given range inclusively.
+func (b *BoltStore) DeleteRange(min, max uint64) error {
+	minKey := uint64ToBytes(min)
+
+	tx, err := b.conn.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	curs := tx.Bucket(dbLogs).Cursor()
+	for k, _ := curs.Seek(minKey); k != nil; k, _ = curs.Next() {
+		// Handle out-of-range log index
+		if bytesToUint64(k) > max {
+			break
+		}
+
+		// Delete in-range log index
+		if err := curs.Delete(); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// Set is used to set a key/value set outside of the raft log
+func (b *BoltStore) Set(k, v []byte) error {
+	tx, err := b.conn.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	bucket := tx.Bucket(dbConf)
+	if err := bucket.Put(k, v); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// Get is used to retrieve a value from the k/v store by key
+func (b *BoltStore) Get(k []byte) ([]byte, error) {
+	tx, err := b.conn.Begin(false)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	bucket := tx.Bucket(dbConf)
+	val := bucket.Get(k)
+
+	if val == nil {
+		return nil, ErrKeyNotFound
+	}
+	return append([]byte(nil), val...), nil
+}
+
+// SetUint64 is like Set, but handles uint64 values
+func (b *BoltStore) SetUint64(key []byte, val uint64) error {
+	return b.Set(key, uint64ToBytes(val))
+}
+
+// GetUint64 is like Get, but handles uint64 values
+func (b *BoltStore) GetUint64(key []byte) (uint64, error) {
+	val, err := b.Get(key)
+	if err != nil {
+		return 0, err
+	}
+	return bytesToUint64(val), nil
+}
+
+// Sync performs an fsync on the database file handle. This is not necessary
+// under normal operation unless NoSync is enabled, in which this forces the
+// database file to sync against the disk.
+func (b *BoltStore) Sync() error {
+	return b.conn.Sync()
+}

--- a/internal/raftdb/bolt_store_test.go
+++ b/internal/raftdb/bolt_store_test.go
@@ -1,0 +1,399 @@
+package raftdb
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/raft"
+	raftbench "github.com/hashicorp/raft/bench"
+)
+
+// upstreamEncodeMsgPack is the unmodified upstream raft-boltdb encoding,
+// used to prove wire-format compatibility of this package's codec.
+func upstreamEncodeMsgPack(in interface{}) (*bytes.Buffer, error) {
+	buf := bytes.NewBuffer(nil)
+	hd := codec.MsgpackHandle{}
+	enc := codec.NewEncoder(buf, &hd)
+	err := enc.Encode(in)
+	return buf, err
+}
+
+// upstreamDecodeMsgPack is the unmodified upstream raft-boltdb decoding.
+func upstreamDecodeMsgPack(buf []byte, out interface{}) error {
+	r := bytes.NewBuffer(buf)
+	hd := codec.MsgpackHandle{}
+	dec := codec.NewDecoder(r, &hd)
+	return dec.Decode(out)
+}
+
+func testRaftLog(i uint64) *raft.Log {
+	return &raft.Log{
+		Index:      i,
+		Term:       i + 1,
+		Type:       raft.LogCommand,
+		Data:       []byte("the quick brown fox jumps over the lazy dog"),
+		Extensions: []byte("ext"),
+		AppendedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+}
+
+// TestEncodeDecodeCompatibility verifies that this package's encoding is
+// byte-identical to upstream's, and that each can decode the other's output.
+func TestEncodeDecodeCompatibility(t *testing.T) {
+	log := testRaftLog(42)
+
+	// Encode with this package; decode with upstream.
+	ours, err := encodeMsgPack(log)
+	if err != nil {
+		t.Fatalf("encodeMsgPack failed: %v", err)
+	}
+	var viaUpstream raft.Log
+	if err := upstreamDecodeMsgPack(ours, &viaUpstream); err != nil {
+		t.Fatalf("upstream failed to decode our encoding: %v", err)
+	}
+	if !logsEqual(&viaUpstream, log) {
+		t.Fatalf("roundtrip mismatch via upstream decoder: got %+v want %+v", viaUpstream, *log)
+	}
+
+	// Encode with upstream; decode with this package.
+	theirs, err := upstreamEncodeMsgPack(log)
+	if err != nil {
+		t.Fatalf("upstream encode failed: %v", err)
+	}
+	if !bytes.Equal(ours, theirs.Bytes()) {
+		t.Fatalf("wire format differs from upstream:\n ours: %x\ntheirs: %x", ours, theirs.Bytes())
+	}
+	var viaOurs raft.Log
+	if err := decodeMsgPack(theirs.Bytes(), &viaOurs); err != nil {
+		t.Fatalf("decodeMsgPack failed on upstream encoding: %v", err)
+	}
+	if !logsEqual(&viaOurs, log) {
+		t.Fatalf("roundtrip mismatch via our decoder: got %+v want %+v", viaOurs, *log)
+	}
+}
+
+// TestEncodeDecodeMinimalLog checks a log with nil Data/Extensions, as
+// produced for noop entries.
+func TestEncodeDecodeMinimalLog(t *testing.T) {
+	log := &raft.Log{
+		Index:      7,
+		Term:       2,
+		Type:       raft.LogNoop,
+		AppendedAt: time.Unix(1600000000, 0).UTC(),
+	}
+
+	ours, err := encodeMsgPack(log)
+	if err != nil {
+		t.Fatalf("encodeMsgPack failed: %v", err)
+	}
+	var out raft.Log
+	if err := decodeMsgPack(ours, &out); err != nil {
+		t.Fatalf("decodeMsgPack failed: %v", err)
+	}
+	if !logsEqual(&out, log) {
+		t.Fatalf("roundtrip mismatch: got %+v want %+v", out, *log)
+	}
+
+	// Upstream must also read it.
+	var viaUpstream raft.Log
+	if err := upstreamDecodeMsgPack(ours, &viaUpstream); err != nil {
+		t.Fatalf("upstream failed to decode our minimal encoding: %v", err)
+	}
+	if !logsEqual(&viaUpstream, log) {
+		t.Fatalf("upstream roundtrip mismatch: got %+v want %+v", viaUpstream, *log)
+	}
+}
+
+// TestDecodeLegacyV055TimeFormat is a regression test for reading raft log
+// entries written by the original upstream raft-boltdb using go-msgpack
+// v0.5.5. That version encoded time.Time via encoding.BinaryMarshaler and
+// wrote it as a msgpack string; v0.5.5-encoded data appears in raft.db files
+// created by older rqlite releases. Only go-msgpack v2 decoders understand
+// this format - which is why this package must use go-msgpack/v2.
+//
+// The fixture below was generated with go-msgpack v0.5.5 encoding:
+//
+//	raft.Log{Index: 42, Term: 7, Type: LogCommand,
+//	         Data: "hello world", Extensions: "ext",
+//	         AppendedAt: time.Unix(1700000000, 123456789).UTC()}
+func TestDecodeLegacyV055TimeFormat(t *testing.T) {
+	fixture := []byte{
+		0x86, 0xaa, 0x41, 0x70, 0x70, 0x65, 0x6e, 0x64, 0x65, 0x64, 0x41, 0x74,
+		0xaf, 0x01, 0x00, 0x00, 0x00, 0x0e, 0xdc, 0xe5, 0xe8, 0x00, 0x07, 0x5b,
+		0xcd, 0x15, 0xff, 0xff, 0xa4, 0x44, 0x61, 0x74, 0x61, 0xab, 0x68, 0x65,
+		0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0xaa, 0x45, 0x78,
+		0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x73, 0xa3, 0x65, 0x78, 0x74,
+		0xa5, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x2a, 0xa4, 0x54, 0x65, 0x72, 0x6d,
+		0x07, 0xa4, 0x54, 0x79, 0x70, 0x65, 0x00,
+	}
+
+	var out raft.Log
+	if err := decodeMsgPack(fixture, &out); err != nil {
+		t.Fatalf("failed to decode legacy v0.5.5 encoding: %v", err)
+	}
+	want := time.Unix(1700000000, 123456789).UTC()
+	if !out.AppendedAt.Equal(want) {
+		t.Fatalf("AppendedAt mismatch: got %v want %v", out.AppendedAt, want)
+	}
+	if out.Index != 42 || out.Term != 7 || out.Type != raft.LogCommand {
+		t.Fatalf("field mismatch: got %+v", out)
+	}
+	if !bytes.Equal(out.Data, []byte("hello world")) || !bytes.Equal(out.Extensions, []byte("ext")) {
+		t.Fatalf("data mismatch: got %+v", out)
+	}
+
+	// The new-format encoding of the same log must round-trip identically.
+	newFormat, err := encodeMsgPack(&out)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	var back raft.Log
+	if err := decodeMsgPack(newFormat, &back); err != nil {
+		t.Fatalf("re-decode failed: %v", err)
+	}
+	if !logsEqual(&back, &out) {
+		t.Fatalf("roundtrip mismatch: got %+v want %+v", back, out)
+	}
+}
+
+// TestSharedHandleConcurrentAccess exercises the shared package-level
+// MsgpackHandle from many goroutines to surface any data race (run with -race).
+func TestSharedHandleConcurrentAccess(t *testing.T) {
+	log := testRaftLog(99)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				buf, err := encodeMsgPack(log)
+				if err != nil {
+					t.Errorf("encode failed: %v", err)
+					return
+				}
+				var out raft.Log
+				if err := decodeMsgPack(buf, &out); err != nil {
+					t.Errorf("decode failed: %v", err)
+					return
+				}
+				if !logsEqual(&out, log) {
+					t.Errorf("mismatch: got %+v want %+v", out, *log)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestSharedHandleConcurrentColdCache hammers the shared handle from many
+// goroutines with raft.Log types NOT previously seen by this process, so the
+// codec's handle-level function cache (rtidFns) is still cold. This drives
+// the copy-on-write cache-fill path concurrently - the trickiest part of
+// sharing one handle - and must complete cleanly under -race.
+func TestSharedHandleConcurrentColdCache(t *testing.T) {
+	type coldLog struct {
+		Index      uint64
+		Term       uint64
+		UniqueTag  string // unique per goroutine so each fills a distinct cache entry
+		Data       []byte
+		AppendedAt time.Time
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 32; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			l := &coldLog{
+				Index:      uint64(g),
+				UniqueTag:  fmt.Sprintf("goroutine-%d", g),
+				Data:       []byte("cold cache fill"),
+				AppendedAt: time.Unix(1700000000, int64(g)).UTC(),
+			}
+			for i := 0; i < 50; i++ {
+				var buf []byte
+				if err := codec.NewEncoderBytes(&buf, &msgpackHandle).Encode(l); err != nil {
+					t.Errorf("encode failed: %v", err)
+					return
+				}
+				var out coldLog
+				if err := codec.NewDecoderBytes(buf, &msgpackHandle).Decode(&out); err != nil {
+					t.Errorf("decode failed: %v", err)
+					return
+				}
+				if out.Index != l.Index || out.UniqueTag != l.UniqueTag || !out.AppendedAt.Equal(l.AppendedAt) {
+					t.Errorf("mismatch: got %+v want %+v", out, *l)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestStoreEndToEnd verifies a basic store-retrieve cycle through BoltDB.
+func TestStoreEndToEnd(t *testing.T) {
+	path := mustTempFile(t)
+	store, err := NewBoltStore(path)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+	defer os.Remove(path)
+
+	log := testRaftLog(1)
+	if err := store.StoreLog(log); err != nil {
+		t.Fatalf("failed to store log: %v", err)
+	}
+
+	var out raft.Log
+	if err := store.GetLog(1, &out); err != nil {
+		t.Fatalf("failed to get log: %v", err)
+	}
+	if !logsEqual(&out, log) {
+		t.Fatalf("mismatch: got %+v want %+v", out, *log)
+	}
+
+	fi, err := store.FirstIndex()
+	if err != nil {
+		t.Fatalf("failed to get first index: %v", err)
+	}
+	li, err := store.LastIndex()
+	if err != nil {
+		t.Fatalf("failed to get last index: %v", err)
+	}
+	if fi != 1 || li != 1 {
+		t.Fatalf("got indexes %d, %d; want 1, 1", fi, li)
+	}
+
+	if err := store.DeleteRange(1, 1); err != nil {
+		t.Fatalf("failed to delete range: %v", err)
+	}
+	fi, _ = store.FirstIndex()
+	li, _ = store.LastIndex()
+	if fi != 0 || li != 0 {
+		t.Fatalf("got indexes %d, %d after delete; want 0, 0", fi, li)
+	}
+}
+
+func logsEqual(a, b *raft.Log) bool {
+	return a.Index == b.Index &&
+		a.Term == b.Term &&
+		a.Type == b.Type &&
+		bytes.Equal(a.Data, b.Data) &&
+		bytes.Equal(a.Extensions, b.Extensions) &&
+		a.AppendedAt.Equal(b.AppendedAt)
+}
+
+func mustTempFile(t testing.TB) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "boltdb-test")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+	os.Remove(name)
+	return name
+}
+
+// Benchmark comparisons against the standard hashicorp raft-bench harness.
+func BenchmarkBoltStore_FirstIndex(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.FirstIndex(b, store)
+}
+
+func BenchmarkBoltStore_LastIndex(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.LastIndex(b, store)
+}
+
+func BenchmarkBoltStore_GetLog(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.GetLog(b, store)
+}
+
+func BenchmarkBoltStore_StoreLog(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.StoreLog(b, store)
+}
+
+func BenchmarkBoltStore_StoreLogs(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.StoreLogs(b, store)
+}
+
+func BenchmarkBoltStore_DeleteRange(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.DeleteRange(b, store)
+}
+
+func BenchmarkBoltStore_Set(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.Set(b, store)
+}
+
+func BenchmarkBoltStore_Get(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.Get(b, store)
+}
+
+func BenchmarkBoltStore_SetUint64(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.SetUint64(b, store)
+}
+
+func BenchmarkBoltStore_GetUint64(b *testing.B) {
+	store := testBoltStore(b)
+	defer store.Close()
+	defer os.Remove(store.path)
+
+	raftbench.GetUint64(b, store)
+}
+
+func testBoltStore(b *testing.B) *BoltStore {
+	b.Helper()
+	path := mustTempFile(b)
+	store, err := NewBoltStore(path)
+	if err != nil {
+		b.Fatalf("failed to create store: %v", err)
+	}
+	store.path = path
+	return store
+}

--- a/internal/raftdb/util.go
+++ b/internal/raftdb/util.go
@@ -1,0 +1,68 @@
+package raftdb
+
+import (
+	"encoding/binary"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/raft"
+)
+
+// msgpackHandle is shared by every Encoder and Decoder created in this
+// package.
+//
+// codec.MsgpackHandle's lazily initialized state (format flags, and the
+// reflect-derived codec function cache in rtidFns) is guarded by a mutex /
+// atomic.Value, so one shared handle is safe for concurrent use. Sharing it
+// means the expensive per-type reflection work happens exactly once per
+// process, instead of being rebuilt for every raft log stored or retrieved.
+// Upstream raft-boltdb constructs a fresh handle per call and pays that cost
+// every time.
+//
+// The zero value of MsgpackHandle matches the default configuration used by
+// upstream raft-boltdb.
+//
+// The v2 module is required (not v1): its decoder understands the legacy
+// time.Time encoding emitted by go-msgpack v0.5.5 — the version originally
+// pinned by upstream raft-boltdb, and therefore the format found in existing
+// rqlite raft.db files. The v1 decoder rejects that format. Encoding is
+// byte-identical between v1.1.5 and v2.1.5, so the write path is unchanged.
+var msgpackHandle codec.MsgpackHandle
+
+// Decode reverses the encode operation on a byte slice input.
+//
+// Unlike upstream, which wraps the input in a bytes.Buffer and creates both a
+// new Handle and a new Decoder per call, this uses codec.NewDecoderBytes for
+// zero-copy decoding directly from the input slice and shares a
+// package-level handle.
+//
+// The wire format is unchanged, so existing databases remain fully readable.
+func decodeMsgPack(buf []byte, out *raft.Log) error {
+	return codec.NewDecoderBytes(buf, &msgpackHandle).Decode(out)
+}
+
+// Encode writes an encoded raft.Log to a new byte slice.
+//
+// Unlike upstream, which creates a new Handle and an io.Writer-based encoder
+// over a bytes.Buffer per call, this encodes directly into the destination
+// slice via codec.NewEncoderBytes (no bytes.Buffer allocation, no io
+// indirection) and shares a package-level handle.
+//
+// The wire format is unchanged, so databases remain fully interoperable with
+// upstream raft-boltdb.
+func encodeMsgPack(in *raft.Log) ([]byte, error) {
+	var buf []byte
+	err := codec.NewEncoderBytes(&buf, &msgpackHandle).Encode(in)
+	return buf, err
+}
+
+// Converts bytes to an integer
+func bytesToUint64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+// Converts a uint to a byte slice
+func uint64ToBytes(u uint64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, u)
+	return buf
+}

--- a/store/log/log.go
+++ b/store/log/log.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/raft"
-	"github.com/rqlite/raft-boltdb/v2"
+	"github.com/rqlite/rqlite/v10/internal/raftdb"
 	"go.etcd.io/bbolt"
 )
 
 // Log is an object that can return information about the Raft log.
 type Log struct {
-	*raftboltdb.BoltStore
+	*raftdb.BoltStore
 }
 
 // New returns an instantiated Log object that provides access to the Raft log
@@ -20,7 +20,7 @@ type Log struct {
 // but may increase the risk of data loss in the event of a crash or power loss.
 // Returns an error if the BoltDB store cannot be created.
 func New(path string, noFreelistSync bool) (*Log, error) {
-	bs, err := raftboltdb.New(raftboltdb.Options{
+	bs, err := raftdb.New(raftdb.Options{
 		BoltOptions: &bbolt.Options{
 			NoFreelistSync: noFreelistSync,
 		},

--- a/store/log/log_test.go
+++ b/store/log/log_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/raft"
-	raftboltdb "github.com/rqlite/raft-boltdb/v2"
+	"github.com/rqlite/rqlite/v10/internal/raftdb"
 )
 
 func Test_LogNewEmpty(t *testing.T) {
@@ -56,7 +56,7 @@ func Test_LogNewExistNotEmpty(t *testing.T) {
 	path := mustTempFile(t)
 
 	// Write some entries directory to the BoltDB Raft store.
-	bs, err := raftboltdb.NewBoltStore(path)
+	bs, err := raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to create bolt store: %s", err)
 	}
@@ -113,7 +113,7 @@ func Test_LogNewExistNotEmpty(t *testing.T) {
 	}
 
 	// Delete an entry, recheck index functionality.
-	bs, err = raftboltdb.NewBoltStore(path)
+	bs, err = raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to re-open bolt store: %s", err)
 	}
@@ -165,7 +165,7 @@ func Test_LogNewExistNotEmptyNoFreelistSync(t *testing.T) {
 	path := mustTempFile(t)
 
 	// Write some entries directory to the BoltDB Raft store.
-	bs, err := raftboltdb.NewBoltStore(path)
+	bs, err := raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to create bolt store: %s", err)
 	}
@@ -214,7 +214,7 @@ func Test_LogNewExistNotEmptyNoFreelistSync(t *testing.T) {
 	}
 
 	// Delete an entry, recheck index functionality.
-	bs, err = raftboltdb.NewBoltStore(path)
+	bs, err = raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to re-open bolt store: %s", err)
 	}
@@ -266,7 +266,7 @@ func Test_LogDeleteAll(t *testing.T) {
 	path := mustTempFile(t)
 
 	// Write some entries directory to the BoltDB Raft store.
-	bs, err := raftboltdb.NewBoltStore(path)
+	bs, err := raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to create bolt store: %s", err)
 	}
@@ -344,7 +344,7 @@ func Test_LogLastCommandIndexNotExist(t *testing.T) {
 	path := mustTempFile(t)
 
 	// Write some entries directory to the BoltDB Raft store.
-	bs, err := raftboltdb.NewBoltStore(path)
+	bs, err := raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to create bolt store: %s", err)
 	}
@@ -394,7 +394,7 @@ func Test_LogLastCommandIndexNotExist(t *testing.T) {
 	}
 
 	// Delete first log.
-	bs, err = raftboltdb.NewBoltStore(path)
+	bs, err = raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to re-open bolt store: %s", err)
 	}
@@ -431,7 +431,7 @@ func Test_LogStats(t *testing.T) {
 	path := mustTempFile(t)
 
 	// Write some entries directory to the BoltDB Raft store.
-	bs, err := raftboltdb.NewBoltStore(path)
+	bs, err := raftdb.NewBoltStore(path)
 	if err != nil {
 		t.Fatalf("failed to create bolt store: %s", err)
 	}


### PR DESCRIPTION
Copy github.com/rqlite/raft-boltdb/v2 into internal/raftdb so the MsgPack hot path can be optimized, and switch store/log to use it.

The encode/decode helpers previously built a fresh codec.MsgpackHandle and wrapped the payload in a bytes.Buffer on every call, paying the per-type reflection cost for each raft log stored or retrieved. A single package-level handle is shared instead (safe for concurrent use: the handle's lazily-built codec function cache is copy-on-write behind a mutex, published via atomic.Value), and encoding/decoding goes through codec.NewEncoderBytes/NewDecoderBytes, which work zero-copy directly on the byte slice.

Also remove the go-metrics instrumentation copied from upstream: rqlite never installs a go-metrics sink (observability goes through expvar/OTLP), so every MeasureSince/AddSample call in GetLog/StoreLogs was pure overhead - a []string key allocation plus time.Now per call.

Switch go-msgpack v1 to v2, matching hashicorp/raft v1.7.x. This is required for correctness, not just consistency: v2's decoder understands the legacy time.Time encoding (BinaryMarshaler form) emitted by go-msgpack v0.5.5, which is the format found in raft.db files written by older rqlite releases. The v1 decoder rejects that format. Encoding is byte-identical between v1.1.5 and v2.1.5, so the write path is unchanged.

On-disk format is unchanged and byte-for-byte identical to upstream (cross-encode/decode tests assert this), so existing raft.db files remain fully readable. Upstream github.com/rqlite/raft-boltdb/v2 is no longer a dependency.

Benchmarks (linux/amd64, Hygon C86 7265, benchtime=3s):

| Benchmark     | upstream ns/op | this branch ns/op | speedup          | upstream B/op | branch B/op | B/op delta | upstream allocs | branch allocs | allocs delta |
| ------------- | -------------: | ----------------: | ---------------- | ------------: | -----------: | ---------- | --------------: | ------------: | -----------: |
| encodeMsgPack |           3324 |              1459 | **2.3x (-56%)**  |          1584 |        1296 | **-18%**   |              22 |             5 |   **-77%**   |
| decodeMsgPack |           4512 |              1818 | **2.5x (-60%)**  |          1792 |         744 | **-58%**   |              24 |             6 |   **-75%**   |